### PR TITLE
feat(adapter): support DeepSeek Harness host

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
       description: Provide what you know; use “unknown” when unavailable. / 请填写已知信息，不清楚的项目可写“未知”。
       placeholder: |
         Harnesssmith version / 版本：
-        Host: Codex / Cursor / Claude Code / OpenCode / installer only
+        Host: Codex / Cursor / Claude Code / OpenCode / DeepSeek Harness / installer only
         Scope / 范围：global / project
         OS：
         Node.js / pnpm：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Harnessmith Contributor Guide
 
-Harnessmith 是跨 Codex、Cursor、Claude Code、OpenCode 分发个人 Agent Harness 的 npm initializer。详细贡献
+Harnessmith 是跨 Codex、Cursor、Claude Code、OpenCode、DeepSeek Harness 分发个人 Agent Harness 的 npm initializer。详细贡献
 规范见 `CONTRIBUTING.md`；内置 Harness 架构见
 `template/agent-harness/docs/core/harness-cli-architecture.md`。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The embedded Harness schema has its own explicitly recorded version.
 
 ## Unreleased
 
+### Added
+
+- Add a DeepSeek Harness (`dsh`) host Adapter that installs the shared Personal Harness into
+  `$DSH_HOME/AGENTS.md` (default `~/.dsh/AGENTS.md`), following the official
+  `@deepseek-ai/dsh-agent-instructions` user-global baseline contract.
+
 ## 0.7.1 - 2026-08-28
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -84,6 +84,11 @@ After installation, Harnessmith initializes:
 | DeepSeek Harness | `$DSH_HOME/AGENTS.md`; otherwise `~/.dsh/AGENTS.md` when unset or blank | `$DSH_HOME/agent-harness` | Global |
 | Cursor | `<project>/.cursor/rules/agent-harness.mdc` | `<project>/.cursor/agent-harness` | Project |
 
+The DeepSeek Adapter (official `dsh` / `@deepseek-ai/dsh`) installs **only** the user-global
+`$DSH_HOME/AGENTS.md`. Project-root and nested instruction candidates, plus permissions / sandbox /
+approval, stay host-owned. A successful install does not mean the full DSH instruction chain or a real
+Host Eval is verified. See the [architecture note](./docs/architecture.md#deepseek-harness-契约来源与验证边界).
+
 Cursor file-based rules are project-scoped. Pass `--project` for the intended repository. Harnessmith adds
 only its managed files to the repository-local Git exclude file and `.cursor/.ignore`; it never hides or
 overwrites the team's entire `.cursor/` directory.

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 Harnessmith is a local-first, cross-host Personal Harness distribution and work-state control plane. It safely
 installs the same working rules, progressive documentation, memory protocol, and task-state tools across Codex,
-Cursor, Claude Code, and OpenCode.
+Cursor, Claude Code, OpenCode, and DeepSeek Harness.
 
 ```bash
 npx harnessmith
@@ -81,6 +81,7 @@ After installation, Harnessmith initializes:
 | Codex | `$CODEX_HOME/AGENTS.md` | `$CODEX_HOME/agent-harness` | Global |
 | Claude Code | `$CLAUDE_CONFIG_DIR/CLAUDE.md`, with `AGENTS.md` retained | `$CLAUDE_CONFIG_DIR/agent-harness` | Global |
 | OpenCode | `$OPENCODE_CONFIG_DIR/AGENTS.md`; otherwise `${XDG_CONFIG_HOME:-~/.config}/opencode/AGENTS.md` | `agent-harness` under that config root | Global |
+| DeepSeek Harness | `$DSH_HOME/AGENTS.md`; otherwise `~/.dsh/AGENTS.md` when unset or blank | `$DSH_HOME/agent-harness` | Global |
 | Cursor | `<project>/.cursor/rules/agent-harness.mdc` | `<project>/.cursor/agent-harness` | Project |
 
 Cursor file-based rules are project-scoped. Pass `--project` for the intended repository. Harnessmith adds
@@ -92,7 +93,7 @@ overwrites the team's entire `.cursor/` directory.
 ```bash
 # Install one or several agents
 npx harnessmith install --agent codex
-npx harnessmith --agent codex,cursor,claude,opencode --project /absolute/path/to/repository
+npx harnessmith --agent codex,cursor,claude,opencode,deepseek --project /absolute/path/to/repository
 
 # Emit stable JSON Lines for automation
 npx harnessmith --agent all --project . --dry-run --json
@@ -260,7 +261,8 @@ the complete boundaries.
 <details>
 <summary><strong>Automation options and exit codes</strong></summary>
 
-`--agent` is repeatable and accepts `codex`, `cursor`, `claude`, `claude-code`, `opencode`, and `all`. Non-interactive
+`--agent` is repeatable and accepts `codex`, `cursor`, `claude`, `claude-code`, `opencode`, `deepseek`
+(aliases `dsh`, `deepseek-harness`), and `all`. Non-interactive
 calls should select agents explicitly and use `--json` when a stable machine protocol is required.
 
 `capabilities` is a read-only command that neither resolves installation paths nor writes files. Dry-run,
@@ -288,6 +290,7 @@ JSON failures are emitted as one stderr object containing `version`, `error.code
 | `CODEX_HOME` | Codex installation target | `~/.codex` |
 | `CLAUDE_CONFIG_DIR` | Claude Code installation target | `~/.claude` |
 | `OPENCODE_CONFIG_DIR` | OpenCode config and installation target | `${XDG_CONFIG_HOME:-~/.config}/opencode` |
+| `DSH_HOME` | DeepSeek Harness installation target | `~/.dsh` |
 | `HARNESS_MEMORY_HOME` | Cross-project personal memory | `~/.agent-docs` |
 | `HARNESS_PERSONAL_HOME` | User-owned rules and repository map | `~/.agent-harness` |
 | `HARNESS_REPOSITORY_ROOT` | Repository collection root | `~/git-repo` |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [English](./README.en.md) · **简体中文**
 
 Harnessmith 是一个本地优先、跨 Host 的 Personal Harness 分发与工作状态控制层。它把同一套个人
-工作规则、渐进式文档、记忆协议和任务状态工具，安全地安装到 Codex、Cursor、Claude Code 与 OpenCode。
+工作规则、渐进式文档、记忆协议和任务状态工具，安全地安装到 Codex、Cursor、Claude Code、OpenCode
+与 DeepSeek Harness。
 
 ```bash
 npx harnessmith
@@ -77,6 +78,7 @@ npx harnessmith --agent all --project /absolute/path/to/repository --dry-run
 | Codex | `$CODEX_HOME/AGENTS.md` | `$CODEX_HOME/agent-harness` | 全局 |
 | Claude Code | `$CLAUDE_CONFIG_DIR/CLAUDE.md`，并保留 `AGENTS.md` | `$CLAUDE_CONFIG_DIR/agent-harness` | 全局 |
 | OpenCode | `$OPENCODE_CONFIG_DIR/AGENTS.md`；未设置时 `${XDG_CONFIG_HOME:-~/.config}/opencode/AGENTS.md` | 对应配置根下 `agent-harness` | 全局 |
+| DeepSeek Harness | `$DSH_HOME/AGENTS.md`；未设置或为空时 `~/.dsh/AGENTS.md` | `$DSH_HOME/agent-harness` | 全局 |
 | Cursor | `<project>/.cursor/rules/agent-harness.mdc` | `<project>/.cursor/agent-harness` | 项目 |
 
 Cursor 的文件化规则按项目安装。使用 `--project` 指定仓库；Harnessmith 只把自己管理的文件写入
@@ -87,7 +89,7 @@ repository-local Git exclude 和 `.cursor/.ignore`，不会隐藏或覆盖团队
 ```bash
 # 安装单个或多个 Agent
 npx harnessmith install --agent codex
-npx harnessmith --agent codex,cursor,claude,opencode --project /absolute/path/to/repository
+npx harnessmith --agent codex,cursor,claude,opencode,deepseek --project /absolute/path/to/repository
 
 # 为自动化输出稳定的 JSON Lines
 npx harnessmith --agent all --project . --dry-run --json
@@ -234,8 +236,8 @@ acceptance gate 进入 `complete`，并发更新使用任务锁。`task verify` 
 <details>
 <summary><strong>自动化参数与退出码</strong></summary>
 
-可重复传入 `--agent`；支持 `codex`、`cursor`、`claude`、`claude-code`、`opencode` 和 `all`。非交互调用应显式
-指定 Agent，并在需要稳定协议时使用 `--json`。
+可重复传入 `--agent`；支持 `codex`、`cursor`、`claude`、`claude-code`、`opencode`、`deepseek`（别名
+`dsh`、`deepseek-harness`）和 `all`。非交互调用应显式指定 Agent，并在需要稳定协议时使用 `--json`。
 
 `capabilities` 是不解析安装路径、不写文件的只读命令。dry-run、install result 和 status JSON 也
 包含同一 Adapter `capabilities`，用于区分作用域、激活方式、文件所有权和权限 owner。
@@ -261,6 +263,7 @@ JSON 失败输出为单条 stderr 对象，包含 `version`、`error.code`、`me
 | `CODEX_HOME` | Codex 安装目标 | `~/.codex` |
 | `CLAUDE_CONFIG_DIR` | Claude Code 安装目标 | `~/.claude` |
 | `OPENCODE_CONFIG_DIR` | OpenCode 配置与安装目标 | `${XDG_CONFIG_HOME:-~/.config}/opencode` |
+| `DSH_HOME` | DeepSeek Harness 安装目标 | `~/.dsh` |
 | `HARNESS_MEMORY_HOME` | 跨项目个人记忆 | `~/.agent-docs` |
 | `HARNESS_PERSONAL_HOME` | 用户维护的规则与仓库关系 | `~/.agent-harness` |
 | `HARNESS_REPOSITORY_ROOT` | 仓库集合根目录 | `~/git-repo` |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ npx harnessmith --agent all --project /absolute/path/to/repository --dry-run
 | DeepSeek Harness | `$DSH_HOME/AGENTS.md`；未设置或为空时 `~/.dsh/AGENTS.md` | `$DSH_HOME/agent-harness` | 全局 |
 | Cursor | `<project>/.cursor/rules/agent-harness.mdc` | `<project>/.cursor/agent-harness` | 项目 |
 
+DeepSeek（官方 `dsh` / `@deepseek-ai/dsh`）Adapter **只**安装用户全局 `$DSH_HOME/AGENTS.md`。项目根与
+嵌套指令、权限/sandbox/审批仍由宿主按会话加载与强制；安装成功不等于完整 DSH 作用域链或 Host Eval
+已验证。边界见[架构说明](./docs/architecture.md#deepseek-harness-契约来源与验证边界)。
+
 Cursor 的文件化规则按项目安装。使用 `--project` 指定仓库；Harnessmith 只把自己管理的文件写入
 repository-local Git exclude 和 `.cursor/.ignore`，不会隐藏或覆盖团队已有的整个 `.cursor/` 目录。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Harnessmith Architecture and Enforcement Model
 
 Harnessmith 是一个本地优先、跨 Host 的 Personal Harness 分发与工作状态控制层，覆盖 Codex、Cursor、
-Claude Code 和 OpenCode。它安全地安装和升级规则与内嵌 Harness CLI，并提供渐进式文档、项目上下文、
+Claude Code、OpenCode 和 DeepSeek Harness。它安全地安装和升级规则与内嵌 Harness CLI，并提供渐进式文档、项目上下文、
 非权威记忆和带验收门禁的长任务状态。
 
 | 能力状态 | 边界 |
@@ -27,7 +27,7 @@ Markdown 规则属于 advisory guidance；安全强制来自安装器、schema�
 Host Eval gate 会校验维护者提交记录的 package version、候选 tarball SHA-256、完整 scenario contract、
 behavior fingerprint、freshness、脱敏 artifact digest、工具行为、文件差异、逐项 pass 断言、禁止行为
 断言和 verdict，并要求当前 release policy 中的必需宿主覆盖完整场景矩阵。当前必需宿主为 Codex；
-Cursor、Claude Code 与 OpenCode 保留为受支持的可选证据。
+Cursor、Claude Code、OpenCode 与 DeepSeek Harness 保留为受支持的可选证据。
 The gate does not launch or authenticate to any third-party host. 真实宿主执行、脱敏和证据采集仍由明确
 授权的维护者或 CI runner 完成。因此 gate
 通过只表示“maintainer-attested structure 内部一致且绑定当前候选包”；本地记录和摘要可由仓库写入者
@@ -44,10 +44,32 @@ result 与 status JSON 中。
 | Codex | global | Markdown | host-default | advisory | host-owned |
 | Claude Code | global | Markdown | host-default | advisory | host-owned |
 | OpenCode | global | Markdown | host-default | advisory | host-owned |
+| DeepSeek Harness | global | Markdown | host-default | advisory | host-owned |
 | Cursor | project | MDC | always | advisory | host-owned |
 
 Cursor 的 `always` 只用于当前高损失 personal baseline，不表示 Harnessmith 已建模所有宿主原生规则
 类型。若未来需要不同激活策略，应先增加真实宿主 Eval，再扩展 capability descriptor。
+
+### DeepSeek Harness 契约来源与验证边界
+
+产品身份：官方 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（CLI `dsh` /
+`@deepseek-ai/dsh`）。配置根为 `$DSH_HOME`（默认 `~/.dsh`）；空或仅空白的 `DSH_HOME` 按上游
+`resolveDshHome` 视为未设置。
+
+官方规则加载契约来自 `@deepseek-ai/dsh-agent-instructions`：用户全局基线固定为
+`$DSH_HOME/AGENTS.md`（无 local overlay）。因此 DeepSeek Adapter 复用 global Markdown Adapter，
+只管理该 `AGENTS.md` 与同根下的 `agent-harness/`、`.harnessmith/`。Harnessmith **不**写入
+`cordis.patch.yml`、`settings.yaml`、`.credentials.yaml`，也 **不**挂载 Cordis 插件。
+
+| 状态 | DeepSeek 边界 |
+| --- | --- |
+| 已实现（Implemented） | Adapter 路径解析、`install --dry-run` / `install` / `status` / `restore` / `uninstall`、SafePath、锁、备份与回滚 |
+| 已在真实宿主验证（Verified on Host） | 尚未提交 maintainer-attested DeepSeek Host Eval 记录；发布门禁仍只要求 Codex |
+| 由宿主负责（Delegated to the Host） | `dsh` 模型循环、工具/权限、profile/bundle 组合、会话存储与凭证 |
+
+真实 Host Eval 计划（可选证据，不阻断当前 release policy）：在隔离 `$DSH_HOME` 下安装候选包，启动
+`dsh`/`npx @deepseek-ai/dsh`，按 `evals/scenarios.json` 跑通场景并写入脱敏 `run.json`；验证宿主确实把
+`$DSH_HOME/AGENTS.md` 注入会话 baseline，且 Harness CLI 健康检查通过。
 
 ## 运行审计边界
 
@@ -94,5 +116,5 @@ Node.js 无法提供跨平台 `openat(O_NOFOLLOW)` 等同语义，因此 TOCTOU 
 
 源码与测试达到 Alpha 质量不等于已发布。首次公开发布至少需要：P0 安全回归、`preflight`、覆盖率、
 tarball dry-run、依赖审计、真实 CI 记录、当前 release policy 要求的真实宿主 Eval 证据，
-以及正式 Git commit/tag baseline。当前必需宿主为 Codex；Cursor、Claude Code 与 OpenCode 是受支持但非发布
+以及正式 Git commit/tag baseline。当前必需宿主为 Codex；Cursor、Claude Code、OpenCode 与 DeepSeek Harness 是受支持但非发布
 阻断的可选证据。仓库没有真实运行记录时只能报告“已配置”或“本地通过”，不能报告“跨平台已验证”。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,24 +52,34 @@ Cursor 的 `always` 只用于当前高损失 personal baseline，不表示 Harne
 
 ### DeepSeek Harness 契约来源与验证边界
 
-产品身份：官方 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（CLI `dsh` /
-`@deepseek-ai/dsh`）。配置根为 `$DSH_HOME`（默认 `~/.dsh`）；空或仅空白的 `DSH_HOME` 按上游
-`resolveDshHome` 视为未设置。
+产品身份（官方坐标）：仓库 [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)，
+npm 包 `@deepseek-ai/dsh`，可执行文件 `dsh`。配置根为 `$DSH_HOME`（默认 `~/.dsh`）；空或仅空白的
+`DSH_HOME` 按上游 `resolveDshHome` 视为未设置。契约以官方包文档与
+`@deepseek-ai/dsh-agent-instructions` 为准；社区 handbook 仅作参考，不是 DeepSeek AI 官方项目。
+
+**不要把 Adapter 契约等同于「写一个全局 Markdown 文件」。** 产品身份与指令加载是两件事：DSH 会话
+baseline 是一条作用域链，而 Harnessmith 只托管其中固定的用户全局一层。
+
+| 范围 | 谁负责 | 说明 |
+| --- | --- | --- |
+| 用户全局 `$DSH_HOME/AGENTS.md` | Harnessmith Adapter | 唯一安装的指令入口；同根下还有 `agent-harness/`、`.harnessmith/` |
+| 项目根 / 嵌套 `AGENTS.md`、`CLAUDE.md` 与 `.local` overlay | 宿主 / 工作区 | 按 Session `cwd`、根标记与候选列表加载；**不在**安装范围内 |
+| 权限、sandbox、工具白名单、审批 | 宿主 Runtime | 指令文件仅为 advisory，安装成功不等于强制执行 |
+| Cordis patch、`settings.yaml`、凭证 | 宿主 / 用户 | Harnessmith **不**写入、不挂载插件 |
 
 官方规则加载契约来自 `@deepseek-ai/dsh-agent-instructions`：用户全局基线固定为
-`$DSH_HOME/AGENTS.md`（无 local overlay）。因此 DeepSeek Adapter 复用 global Markdown Adapter，
-只管理该 `AGENTS.md` 与同根下的 `agent-harness/`、`.harnessmith/`。Harnessmith **不**写入
-`cordis.patch.yml`、`settings.yaml`、`.credentials.yaml`，也 **不**挂载 Cordis 插件。
+`$DSH_HOME/AGENTS.md`（该作用域无 local overlay）。因此 DeepSeek Adapter 复用 global Markdown
+Adapter，只管理上表「Harnessmith Adapter」行。
 
 | 状态 | DeepSeek 边界 |
 | --- | --- |
-| 已实现（Implemented） | Adapter 路径解析、`install --dry-run` / `install` / `status` / `restore` / `uninstall`、SafePath、锁、备份与回滚 |
-| 已在真实宿主验证（Verified on Host） | 尚未提交 maintainer-attested DeepSeek Host Eval 记录；发布门禁仍只要求 Codex |
-| 由宿主负责（Delegated to the Host） | `dsh` 模型循环、工具/权限、profile/bundle 组合、会话存储与凭证 |
+| 已实现（Implemented） | 用户全局路径解析、`install --dry-run` / `install` / `status` / `restore` / `uninstall`、SafePath、锁、备份、所有权标记与回滚；**不**声称托管完整作用域链 |
+| 已在真实宿主验证（Verified on Host） | 尚未提交 maintainer-attested DeepSeek Host Eval；文件存在 ≠ 已验证 Session baseline 注入；发布门禁仍只要求 Codex |
+| 由宿主负责（Delegated to the Host） | 项目/嵌套指令发现、模型循环、工具/权限/sandbox/审批、profile/bundle、会话存储与凭证 |
 
 真实 Host Eval 计划（可选证据，不阻断当前 release policy）：在隔离 `$DSH_HOME` 下安装候选包，启动
-`dsh`/`npx @deepseek-ai/dsh`，按 `evals/scenarios.json` 跑通场景并写入脱敏 `run.json`；验证宿主确实把
-`$DSH_HOME/AGENTS.md` 注入会话 baseline，且 Harness CLI 健康检查通过。
+真实 `dsh` Session，按 `evals/scenarios.json` 跑通场景并写入脱敏 `run.json`；验证宿主确实把
+`$DSH_HOME/AGENTS.md` 注入 baseline（而非仅检查文件落盘），且 Harness CLI 健康检查通过。
 
 ## 运行审计边界
 

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -8,13 +8,15 @@ claims:
   - id: cross-host-distribution
     status: implemented
     owner: outer installer adapters
-    claim: Distribute one Personal Harness across Codex, Cursor, Claude Code, and OpenCode.
+    claim: Distribute one Personal Harness across Codex, Cursor, Claude Code, OpenCode, and DeepSeek Harness.
     implementation:
       - src/adapters.ts
       - src/install.ts
     verification:
       - src/__tests__/install.test.ts
       - src/__tests__/adapters-opencode.test.ts
+      - src/__tests__/adapters-deepseek.test.ts
+      - src/__tests__/install-deepseek.test.ts
 
   - id: safe-install-lifecycle
     status: implemented

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,8 +1,8 @@
 # Harness behavior evaluations
 
 Unit tests prove deterministic file and CLI behavior. This directory defines a separate contract for
-recording a maintainer-observed Codex, Cursor, Claude Code, or OpenCode run against the installed Harness. The
-current release policy requires Codex; Cursor, Claude Code, and OpenCode records remain supported optional evidence. A schema
+recording a maintainer-observed Codex, Cursor, Claude Code, OpenCode, or DeepSeek Harness run against the installed Harness. The
+current release policy requires Codex; Cursor, Claude Code, OpenCode, and DeepSeek Harness records remain supported optional evidence. A schema
 fixture, scenario catalog, mocked transcript, or passing unit test is never real host evidence.
 
 ## Evidence contract
@@ -112,7 +112,7 @@ may remain in the evidence directory, but they are not eligible for current cove
 
 The gate intentionally fails when records are absent, stale, inconclusive, failed, tied to another behavior
 contract, or missing any scenario cell for a host required by the checked-in release policy. The
-current required host is Codex; Cursor, Claude Code, and OpenCode can still be validated and retained as optional evidence.
+current required host is Codex; Cursor, Claude Code, OpenCode, and DeepSeek Harness can still be validated and retained as optional evidence.
 The gate never launches, authenticates to,
 or spends money on a third-party host. External host execution and evidence capture remain explicit
 maintainer/CI responsibilities.

--- a/evals/__tests__/run-fixture.ts
+++ b/evals/__tests__/run-fixture.ts
@@ -62,7 +62,7 @@ export function writeRun(
     outcome = 'passed',
     runId = `${adapter}-${scenarioId}`,
   }: {
-    adapter?: 'codex' | 'cursor' | 'claude' | 'opencode';
+    adapter?: 'codex' | 'cursor' | 'claude' | 'opencode' | 'deepseek';
     scenarioId?: string;
     finishedAt?: string;
     evaluatedAt?: string;

--- a/evals/__tests__/run-selection-security.test.ts
+++ b/evals/__tests__/run-selection-security.test.ts
@@ -6,7 +6,7 @@ import { currentFingerprint, root, run, temporaryDirectory, writeRun } from './r
 
 function writePassingMatrix(runsDirectory: string, evaluatedAt: string): void {
   const scenarioIds = Object.keys(currentFingerprint().scenarios);
-  for (const adapter of ['codex', 'cursor', 'claude', 'opencode'] as const) {
+  for (const adapter of ['codex', 'cursor', 'claude', 'opencode', 'deepseek'] as const) {
     for (const scenarioId of scenarioIds) {
       writeRun(runsDirectory, {
         adapter,

--- a/evals/run.schema.json
+++ b/evals/run.schema.json
@@ -30,7 +30,7 @@
       "type": "object",
       "required": ["adapter", "product", "version", "model", "modelVersion"],
       "properties": {
-        "adapter": { "enum": ["codex", "cursor", "claude", "opencode"] },
+        "adapter": { "enum": ["codex", "cursor", "claude", "opencode", "deepseek"] },
         "product": { "type": "string", "minLength": 1 },
         "version": { "type": "string", "minLength": 1 },
         "model": { "type": "string", "minLength": 1 },

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # Harnessmith
 
 > Harnessmith is a cross-host Personal Harness distribution and work-state control plane for Codex, Cursor,
-> Claude Code, and OpenCode.
+> Claude Code, OpenCode, and DeepSeek Harness.
 > This file is an operational guide for an LLM helping a user install or initialize it.
 
 Project: https://www.npmjs.com/package/harnessmith
@@ -42,12 +42,20 @@ use the published `npx --yes harnessmith` commands below.
   - Instructions: `$OPENCODE_CONFIG_DIR/AGENTS.md` when set
   - Default instructions: `${XDG_CONFIG_HOME:-~/.config}/opencode/AGENTS.md`
   - Harness: `agent-harness` under the same effective OpenCode config directory
+- `deepseek` (aliases: `dsh`, `deepseek-harness`)
+  - Product: DeepSeek Harness CLI (`dsh` / `@deepseek-ai/dsh`)
+  - Instructions: `$DSH_HOME/AGENTS.md` when set to a non-empty value
+  - Default instructions: `~/.dsh/AGENTS.md`
+  - Harness: `agent-harness` under the same effective DeepSeek Harness home
+  - Contract source: `@deepseek-ai/dsh-agent-instructions` loads the user-global `$DSH_HOME/AGENTS.md`
+    baseline; Harnessmith does not mount Cordis plugins or edit `settings.yaml` / credentials
 
 ## LLM installation protocol
 
 1. Verify the runtime with `node --version`. Stop and explain the requirement if Node.js is older than 24.12.
 2. Determine the exact agent selection from the user's request. Accepted values are `codex`, `cursor`,
-   `claude`, `claude-code`, `opencode`, and `all`. Never infer `all` from an ambiguous request.
+   `claude`, `claude-code`, `opencode`, `deepseek`, `dsh`, `deepseek-harness`, and `all`. Never infer `all`
+   from an ambiguous request.
 3. If Cursor is selected, determine the intended project path. Ask the user if more than one repository is
    plausible. Prefer an absolute path.
 4. Preview resolved destinations before writing:

--- a/llms.txt
+++ b/llms.txt
@@ -43,12 +43,15 @@ use the published `npx --yes harnessmith` commands below.
   - Default instructions: `${XDG_CONFIG_HOME:-~/.config}/opencode/AGENTS.md`
   - Harness: `agent-harness` under the same effective OpenCode config directory
 - `deepseek` (aliases: `dsh`, `deepseek-harness`)
-  - Product: DeepSeek Harness CLI (`dsh` / `@deepseek-ai/dsh`)
+  - Official coordinates: `deepseek-ai/deepseek-harness`, package `@deepseek-ai/dsh`, executable `dsh`
   - Instructions: `$DSH_HOME/AGENTS.md` when set to a non-empty value
   - Default instructions: `~/.dsh/AGENTS.md`
   - Harness: `agent-harness` under the same effective DeepSeek Harness home
-  - Contract source: `@deepseek-ai/dsh-agent-instructions` loads the user-global `$DSH_HOME/AGENTS.md`
-    baseline; Harnessmith does not mount Cordis plugins or edit `settings.yaml` / credentials
+  - Contract source: `@deepseek-ai/dsh-agent-instructions` user-global baseline only
+  - Out of scope: project-root / nested `AGENTS.md`/`CLAUDE.md` candidates and local overlays; Cordis
+    patches; `settings.yaml`; credentials; permissions, sandbox, tool allowlists, and approval
+  - Do not tell the user that installing the file enforces DSH security controls or verifies a real
+    Session baseline; file presence is not Host Eval evidence
 
 ## LLM installation protocol
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "cursor",
     "claude-code",
     "opencode",
+    "deepseek",
     "agents-md",
     "harness",
     "harnessmith"

--- a/scripts/preflight-docs.ts
+++ b/scripts/preflight-docs.ts
@@ -163,7 +163,7 @@ function checkPortableTemplate(root: string, check: Check): void {
       );
     }
     check(
-      !/\b(?:codex|cursor|claude|opencode)\b|CODEX_HOME|CLAUDE_CONFIG_DIR|OPENCODE_CONFIG_DIR/i.test(
+      !/\b(?:codex|cursor|claude|opencode|deepseek)\b|CODEX_HOME|CLAUDE_CONFIG_DIR|OPENCODE_CONFIG_DIR|DSH_HOME/i.test(
         content,
       ),
       `host-specific identity leaked into portable template: ${relative(root, path)}`,

--- a/src/__tests__/adapters-deepseek.test.ts
+++ b/src/__tests__/adapters-deepseek.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter } from '../adapters.js';
+
+test('DeepSeek adapter installs its global rule under DSH_HOME when set', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-deepseek-config-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const configured = join(root, 'custom-dsh');
+  const canonicalRoot = realpathSync.native(root);
+
+  const adapter = createAdapter('deepseek', {
+    env: {
+      HOME: root,
+      DSH_HOME: configured,
+    },
+  });
+
+  assert.equal(adapter.label, 'DeepSeek Harness');
+  assert.equal(adapter.home, join(canonicalRoot, 'custom-dsh'));
+  assert.equal(adapter.instructions.length, 1);
+  assert.equal(adapter.instructions[0].path, join(canonicalRoot, 'custom-dsh', 'AGENTS.md'));
+  assert.equal(adapter.harness, join(canonicalRoot, 'custom-dsh', 'agent-harness'));
+  assert.equal(adapter.record, join(canonicalRoot, 'custom-dsh', '.harnessmith', 'install.json'));
+  assert.equal(adapter.capabilities.scope, 'global');
+  assert.equal(adapter.capabilities.instructionFormat, 'markdown');
+  assert.equal(adapter.capabilities.nativeRuleActivation, 'host-default');
+});
+
+test('DeepSeek adapter treats empty DSH_HOME as unset', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-deepseek-empty-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const canonicalRoot = realpathSync.native(root);
+
+  const adapter = createAdapter('deepseek', {
+    env: { HOME: root, DSH_HOME: '   ' },
+  });
+
+  assert.equal(adapter.home, join(canonicalRoot, '.dsh'));
+  assert.equal(adapter.instructions[0].path, join(canonicalRoot, '.dsh', 'AGENTS.md'));
+});
+
+test('DeepSeek adapter defaults to the documented harness home', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-deepseek-home-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const canonicalRoot = realpathSync.native(root);
+
+  const adapter = createAdapter('deepseek', { env: { HOME: root } });
+
+  assert.equal(adapter.home, join(canonicalRoot, '.dsh'));
+});

--- a/src/__tests__/args.test.ts
+++ b/src/__tests__/args.test.ts
@@ -16,7 +16,7 @@ test('Commander supports repeatable and comma-separated agent values', async () 
       '--agent',
       'codex,cursor',
       '-a',
-      'claude-code,opencode',
+      'claude-code,opencode,deepseek',
       '--project',
       '/tmp/project',
       '--dry-run',
@@ -24,13 +24,20 @@ test('Commander supports repeatable and comma-separated agent values', async () 
     { from: 'user' },
   );
   assert.ok(result);
-  assert.deepEqual(normalizeAgents(result.agent), ['codex', 'cursor', 'claude', 'opencode']);
+  assert.deepEqual(normalizeAgents(result.agent), [
+    'codex',
+    'cursor',
+    'claude',
+    'opencode',
+    'deepseek',
+  ]);
   assert.equal(result.project, '/tmp/project');
   assert.equal(result.dryRun, true);
 });
 
 test('normalizeAgents expands all and rejects unknown agents', () => {
-  assert.deepEqual(normalizeAgents(['all']), ['codex', 'cursor', 'claude', 'opencode']);
+  assert.deepEqual(normalizeAgents(['all']), ['codex', 'cursor', 'claude', 'opencode', 'deepseek']);
+  assert.deepEqual(normalizeAgents(['dsh', 'deepseek-harness']), ['deepseek']);
   assert.throws(() => normalizeAgents(['windsurf']), /Unsupported agent/);
 });
 
@@ -76,7 +83,7 @@ test('capabilities reports every adapter without resolving installation paths', 
   assert.equal(report.version, 1);
   assert.deepEqual(
     report.adapters.map(({ agent }: { agent: string }) => agent),
-    ['codex', 'cursor', 'claude', 'opencode'],
+    ['codex', 'cursor', 'claude', 'opencode', 'deepseek'],
   );
   assert.equal(report.adapters[0].capabilities.enforcement.permissions, 'host-owned');
 });

--- a/src/__tests__/github-templates.test.ts
+++ b/src/__tests__/github-templates.test.ts
@@ -90,6 +90,7 @@ test('bug reports collect one compact environment block and forbid public securi
   assert.match(serialized, /Cursor/);
   assert.match(serialized, /Claude Code/);
   assert.match(serialized, /OpenCode/);
+  assert.match(serialized, /DeepSeek Harness/);
   assert.match(serialized, /Node\.js/);
   const checks = byId.get('checks')?.attributes?.options as Array<{ required?: unknown }>;
   assert.equal(checks.filter(({ required }) => required === true).length, 1);

--- a/src/__tests__/install-deepseek.test.ts
+++ b/src/__tests__/install-deepseek.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { onTestFinished, test } from 'vitest';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const cli = join(packageRoot, 'bin', 'harnessmith.mjs');
+
+function execute(root: string, args: string[]) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: root,
+      DSH_HOME: join(root, 'dsh-home'),
+      HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+      HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+      HARNESS_REPOSITORY_ROOT: join(root, 'repos'),
+      HARNESS_OWNER: 'deepseek-test',
+    },
+  });
+}
+
+test('DeepSeek install, status, restore, and uninstall use the effective DSH home', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harnessmith-deepseek-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const agentHome = join(root, 'dsh-home');
+  const rules = join(agentHome, 'AGENTS.md');
+  mkdirSync(agentHome, { recursive: true });
+  writeFileSync(rules, 'existing deepseek rules');
+
+  const dryRun = execute(root, ['install', '--agent', 'deepseek', '--dry-run', '--json']);
+  assert.equal(dryRun.status, 0, dryRun.stderr);
+  const dryPlan = JSON.parse(dryRun.stdout.trim().split('\n')[0]);
+  assert.equal(dryPlan.adapter, 'deepseek');
+  assert.equal(dryPlan.home, join(realpathSync.native(root), 'dsh-home'));
+  assert.equal(existsSync(join(agentHome, 'agent-harness')), false);
+  assert.equal(readFileSync(rules, 'utf8'), 'existing deepseek rules');
+
+  const installed = execute(root, [
+    'install',
+    '--agent',
+    'deepseek',
+    '--force',
+    '--no-init-global',
+    '--json',
+  ]);
+  assert.equal(installed.status, 0, installed.stderr);
+  const installResult = JSON.parse(installed.stdout);
+  assert.equal(installResult.results[0].adapter, 'deepseek');
+  assert.equal(installResult.results[0].home, join(realpathSync.native(root), 'dsh-home'));
+  assert.match(readFileSync(rules, 'utf8'), /managed-by: harnessmith/);
+  const backup = readdirSync(agentHome).find((name) => name.startsWith('AGENTS.md.backup-'));
+  assert.ok(backup);
+  assert.equal(readFileSync(join(agentHome, backup), 'utf8'), 'existing deepseek rules');
+
+  const status = execute(root, ['status', '--agent', 'deepseek', '--json']);
+  assert.equal(status.status, 0, status.stderr);
+  assert.equal(JSON.parse(status.stdout).outputs[0].status, 'managed');
+
+  const restored = execute(root, ['restore', '--agent', 'deepseek', '--json']);
+  assert.equal(restored.status, 0, restored.stderr);
+  assert.equal(readFileSync(rules, 'utf8'), 'existing deepseek rules');
+  assert.equal(existsSync(join(agentHome, 'agent-harness')), false);
+  assert.equal(existsSync(join(agentHome, '.harnessmith', 'install.json')), false);
+
+  const reinstalled = execute(root, [
+    'install',
+    '--agent',
+    'deepseek',
+    '--force',
+    '--no-init-global',
+    '--json',
+  ]);
+  assert.equal(reinstalled.status, 0, reinstalled.stderr);
+
+  const uninstalled = execute(root, ['uninstall', '--agent', 'deepseek', '--json']);
+  assert.equal(uninstalled.status, 0, uninstalled.stderr);
+  assert.equal(readFileSync(rules, 'utf8'), 'existing deepseek rules');
+  assert.equal(existsSync(join(agentHome, 'agent-harness')), false);
+  assert.equal(existsSync(join(agentHome, '.harnessmith', 'install.json')), false);
+});
+
+test('DeepSeek aliases resolve to the deepseek adapter', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harnessmith-deepseek-alias-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+
+  for (const agent of ['dsh', 'deepseek-harness', '5']) {
+    const dryRun = execute(root, ['install', '--agent', agent, '--dry-run', '--json']);
+    assert.equal(dryRun.status, 0, `${agent}\n${dryRun.stderr}`);
+    assert.equal(JSON.parse(dryRun.stdout.trim().split('\n')[0]).adapter, 'deepseek');
+  }
+});

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -19,21 +19,27 @@ import { onTestFinished, test } from 'vitest';
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const cli = join(packageRoot, 'bin', 'harnessmith.mjs');
 
+function testEnv(root: string, overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, 'codex-home'),
+    CLAUDE_CONFIG_DIR: join(root, 'claude-home'),
+    OPENCODE_CONFIG_DIR: join(root, 'opencode-home'),
+    DSH_HOME: join(root, 'dsh-home'),
+    HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+    HARNESS_REPOSITORY_ROOT: join(root, 'repos'),
+    HARNESS_OWNER: 'package-test',
+    ...overrides,
+  };
+}
+
 function execute(root: string, args: string[]): string {
   const result = spawnSync(process.execPath, [cli, ...args], {
     cwd: root,
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      HOME: root,
-      CODEX_HOME: join(root, 'codex-home'),
-      CLAUDE_CONFIG_DIR: join(root, 'claude-home'),
-      OPENCODE_CONFIG_DIR: join(root, 'opencode-home'),
-      HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
-      HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
-      HARNESS_REPOSITORY_ROOT: join(root, 'repos'),
-      HARNESS_OWNER: 'package-test',
-    },
+    env: testEnv(root),
   });
   assert.equal(result.status, 0, `${args.join(' ')}\n${result.stdout}\n${result.stderr}`);
   return result.stdout;
@@ -43,18 +49,7 @@ function executeResult(root: string, args: string[], envOverrides: NodeJS.Proces
   return spawnSync(process.execPath, [cli, ...args], {
     cwd: root,
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      HOME: root,
-      CODEX_HOME: join(root, 'codex-home'),
-      CLAUDE_CONFIG_DIR: join(root, 'claude-home'),
-      OPENCODE_CONFIG_DIR: join(root, 'opencode-home'),
-      HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
-      HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
-      HARNESS_REPOSITORY_ROOT: join(root, 'repos'),
-      HARNESS_OWNER: 'package-test',
-      ...envOverrides,
-    },
+    env: testEnv(root, envOverrides),
   });
 }
 
@@ -254,10 +249,12 @@ test('dry-run reports destinations without creating agent homes', () => {
   assert.match(output, /"adapter":"cursor"/);
   assert.match(output, /"adapter":"claude"/);
   assert.match(output, /"adapter":"opencode"/);
+  assert.match(output, /"adapter":"deepseek"/);
   assert.match(output, /"action":"create"/);
   assert.equal(existsSync(join(root, 'codex-home')), false);
   assert.equal(existsSync(join(root, 'claude-home')), false);
   assert.equal(existsSync(join(root, 'opencode-home')), false);
+  assert.equal(existsSync(join(root, 'dsh-home')), false);
   assert.equal(existsSync(join(root, 'project', '.cursor')), false);
 });
 
@@ -280,7 +277,7 @@ test('json mode emits parseable automation output without terminal decoration', 
     .map((line) => JSON.parse(line));
   assert.deepEqual(
     plans.map(({ adapter }) => adapter),
-    ['codex', 'cursor', 'claude', 'opencode'],
+    ['codex', 'cursor', 'claude', 'opencode', 'deepseek'],
   );
   assert.equal(plans[0].capabilities.scope, 'global');
   assert.equal(plans[1].capabilities.scope, 'project');

--- a/src/__tests__/llms.test.ts
+++ b/src/__tests__/llms.test.ts
@@ -18,7 +18,9 @@ test('llms.txt exposes a complete non-interactive install protocol', () => {
     'Cursor',
     'Claude Code',
     'OpenCode',
+    'DeepSeek Harness',
     'OPENCODE_CONFIG_DIR',
+    'DSH_HOME',
     '.backup-<timestamp>',
     '--force',
     'conflict',
@@ -271,10 +273,10 @@ test('distributed Harness template contains no host product identity', () => {
       if (entry.isDirectory()) pending.push(path);
       else if (entry.isFile()) {
         const content = readFileSync(path, 'utf8');
-        assert.doesNotMatch(content, /\b(codex|cursor|claude)\b/i, path);
+        assert.doesNotMatch(content, /\b(codex|cursor|claude|opencode|deepseek)\b/i, path);
         assert.doesNotMatch(
           content,
-          /CODEX_HOME|CLAUDE_CONFIG_DIR|DP_REPO_ROOT|dp-repository/i,
+          /CODEX_HOME|CLAUDE_CONFIG_DIR|OPENCODE_CONFIG_DIR|DSH_HOME|DP_REPO_ROOT|dp-repository/i,
           path,
         );
       }

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -122,6 +122,16 @@ export function createAdapter(
     const agentHome = canonicalPath(env.OPENCODE_CONFIG_DIR || join(configRoot, 'opencode'));
     return globalMarkdownAdapter(name, 'OpenCode', agentHome);
   }
+  if (name === 'deepseek') {
+    // Official DeepSeek Harness (dsh) home: $DSH_HOME, default ~/.dsh.
+    // Empty/whitespace DSH_HOME is treated as unset (upstream resolveDshHome).
+    // User-global instructions: $DSH_HOME/AGENTS.md via @deepseek-ai/dsh-agent-instructions.
+    const configured = env.DSH_HOME;
+    const agentHome = canonicalPath(
+      configured !== undefined && configured.trim().length > 0 ? configured : join(home, '.dsh'),
+    );
+    return globalMarkdownAdapter(name, 'DeepSeek Harness', agentHome);
+  }
   if (name === 'cursor') {
     const root = projectRoot(project);
     const agentHome = join(root, '.cursor');

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -6,6 +6,7 @@ export const supportedAgentNames = [
   'cursor',
   'claude',
   'opencode',
+  'deepseek',
 ] as const satisfies readonly AgentName[];
 
 export const supportedAgents = [
@@ -13,6 +14,7 @@ export const supportedAgents = [
   { value: 'cursor', label: 'Cursor', hint: 'current project' },
   { value: 'claude', label: 'Claude Code', hint: 'global configuration' },
   { value: 'opencode', label: 'OpenCode', hint: 'global configuration' },
+  { value: 'deepseek', label: 'DeepSeek Harness', hint: 'global configuration' },
 ];
 
 export function isAgentName(value: unknown): value is AgentName {
@@ -38,7 +40,10 @@ export function normalizeAgents(values: string[]): AgentName[] {
     ['2', 'cursor'],
     ['3', 'claude'],
     ['4', 'opencode'],
+    ['5', 'deepseek'],
     ['claude-code', 'claude'],
+    ['dsh', 'deepseek'],
+    ['deepseek-harness', 'deepseek'],
   ]);
   const expanded = values.flatMap((value) =>
     value.toLowerCase() === 'all'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Readable, Writable } from 'node:stream';
 
-export type AgentName = 'codex' | 'cursor' | 'claude' | 'opencode';
+export type AgentName = 'codex' | 'cursor' | 'claude' | 'opencode' | 'deepseek';
 export type OutputAction = 'create' | 'replace-managed' | 'conflict';
 export type ManagedStatus = 'managed' | 'modified' | 'missing';
 


### PR DESCRIPTION
## Summary
- Add a DeepSeek Harness (`dsh`) host Adapter that installs the shared Personal Harness into `$DSH_HOME/AGENTS.md` (default `~/.dsh/AGENTS.md`), following the official `@deepseek-ai/dsh-agent-instructions` user-global baseline contract.
- Wire CLI aliases (`deepseek`, `dsh`, `deepseek-harness`), capabilities, docs, Host Eval optional evidence, and lifecycle tests without guessing Cordis/settings/credential paths.
- Document implemented vs not-yet-host-verified vs host-owned boundaries for DeepSeek.

Closes #2

## Test plan
- [ ] `pnpm exec vitest run src/__tests__/adapters-deepseek.test.ts src/__tests__/install-deepseek.test.ts`
- [ ] `pnpm exec vitest run src/__tests__/args.test.ts`
- [ ] `node bin/harnessmith.mjs install --agent deepseek --dry-run --json` with isolated `DSH_HOME`
- [ ] `install` / `status` / `restore` / `uninstall` against the isolated home
- [ ] Optional: boot real `dsh` and confirm `$DSH_HOME/AGENTS.md` appears in session baseline
- [ ] `pnpm run preflight` on a Linux/CI environment (Windows may hit known symlink/mode issues)
