### PR TITLE
fix(memory): ignore unsupported POSIX modes on Windows

### DIFF
--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -95,10 +95,10 @@ test('installs all adapters, maps paths, and renames existing rules', () => {
   const claudeRules = readFileSync(join(claude, 'CLAUDE.md'), 'utf8');
   const cursorRules = readFileSync(join(cursor, 'rules', 'agent-harness.mdc'), 'utf8');
   assert.doesNotMatch(codexRules, /\{\{HARNESS_HOME\}\}/);
-  assert.ok(codexRules.includes(`${join(root, 'agent-docs')}/profile.md`));
   const codexContext = JSON.parse(
     readFileSync(join(codex, 'agent-harness', 'install-context.json'), 'utf8'),
-  ) as { harnessHome: string };
+  ) as { harnessHome: string; memoryHome: string };
+  assert.ok(codexRules.includes(`${codexContext.memoryHome}/profile.md`));
   assert.ok(codexRules.includes(`${codexContext.harnessHome}/agent-harness`));
   assert.match(claudeRules, /宿主原生 memory 仅作待核对线索/);
   assert.match(cursorRules, /^---\ndescription: Personal coding agent harness/m);

--- a/template/agent-harness/docs/core/observability.md
+++ b/template/agent-harness/docs/core/observability.md
@@ -32,7 +32,8 @@ node <harness-path>/bin/harness.mjs audit summary --since 2026-08-01T00:00:00.00
 ## 存储与健康
 
 活动事件按 UTC 日期写入 `state/audit/YYYY-MM-DD.jsonl`，使用运行时锁、SafePath、regular-file 检查、
-原子写和 `0600` 权限。单文件、总字节和总事件数均有限制；读取遇到损坏、symlink 或超预算时
+原子写，并在可表达 POSIX mode 的平台使用 `0600`；Windows 依赖 ACL 与宿主访问控制，不把无法
+可靠保留的 POSIX permission bits 当作事务身份。单文件、总字节和总事件数均有限制；读取遇到损坏、symlink 或超预算时
 fail closed。`health` 中缺少审计目录表示尚未配置，不是故障；存在但不可验证的审计状态是 failed。
 
 ## 保留策略

--- a/template/agent-harness/docs/standards/user-profile-memory.md
+++ b/template/agent-harness/docs/standards/user-profile-memory.md
@@ -70,7 +70,9 @@ updated: 2026-08-26
 paused。用户要求恢复自动维护时才 `resume`；精确删除条目始终可执行，pause 不阻止 forget。
 
 全局 `.agent-docs/` 默认收紧为仅当前用户可访问：目录 `0700`，受管的 `README.md`、`core.md` 与
-`profile.md` 为 `0600`。这只是本地文件权限边界，不替代磁盘加密、备份治理或宿主访问控制。
+在可表达 POSIX mode 的平台上，`profile.md` 为 `0600`。Windows 的 Node.js 文件 API 不可靠保留
+这些 POSIX permission bits，因此事务身份只校验文件类型、非 symlink、内容和大小，访问控制继续由
+Windows ACL 与宿主负责。这些都不替代磁盘加密、备份治理或宿主访问控制。
 
 更新前必须先读取现有 `profile.md`，把新信号映射到已有稳定 key；禁止先在其他 memory 新建偏好
 摘要再复制回来。合并优先级为：用户当前明确表达 > 画像现有当前条目 > 带时间的 input/episode >

--- a/template/agent-harness/src/__tests__/global-memory-concurrency.test.ts
+++ b/template/agent-harness/src/__tests__/global-memory-concurrency.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, onTestFinished, test, vi } from 'vitest';
@@ -45,7 +45,7 @@ vi.mock('../lib/memory-core.js', async (importOriginal) => {
 });
 
 import { initializeGlobalMemory } from '../lib/global-memory.js';
-import { harnessRuntime } from './helpers/harness.js';
+import { assertMode, escapeRegExp, harnessRuntime } from './helpers/harness.js';
 
 beforeEach(() => {
   concurrencyFault.profilePath = '';
@@ -66,9 +66,9 @@ test('global initialization rejects a file created after its missing snapshot', 
 
   assert.throws(
     () => initializeGlobalMemory(runtime),
-    new RegExp(`rollback was incomplete.*recovery path ${readme}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(readme)}`, 'i'),
   );
-  assert.equal(statSync(readme).mode & 0o777, 0o640);
+  assertMode(readme, 0o640);
 });
 
 test('profile-route repair preserves a file replaced after its content snapshot', () => {
@@ -84,8 +84,8 @@ test('profile-route repair preserves a file replaced after its content snapshot'
 
   assert.throws(
     () => initializeGlobalMemory(runtime),
-    new RegExp(`rollback was incomplete.*recovery path ${core}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(core)}`, 'i'),
   );
   assert.equal(readFileSync(core, 'utf8'), concurrent);
-  assert.equal(statSync(core).mode & 0o777, 0o640);
+  assertMode(core, 0o640);
 });

--- a/template/agent-harness/src/__tests__/global-memory-rollback-boundaries.test.ts
+++ b/template/agent-harness/src/__tests__/global-memory-rollback-boundaries.test.ts
@@ -7,14 +7,13 @@ import {
   mkdtempSync,
   renameSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
 import { initializeGlobalMemory, withGlobalMemoryTransaction } from '../lib/global-memory.js';
-import { harnessRuntime } from './helpers/harness.js';
+import { assertMode, harnessRuntime } from './helpers/harness.js';
 
 function fixture(prefix: string) {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -51,24 +50,27 @@ test('global rollback restores the original directory mode', () => {
       }),
     /operation failed/i,
   );
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o755);
+  assertMode(runtime.memoryHome, 0o755);
 });
 
-test('global rollback retains a concurrently changed directory mode', () => {
-  const { runtime } = fixture('harness-global-mode-conflict-');
-  initializeGlobalMemory(runtime);
-  chmodSync(runtime.memoryHome, 0o755);
+test.skipIf(process.platform === 'win32')(
+  'global rollback retains a concurrently changed directory mode',
+  () => {
+    const { runtime } = fixture('harness-global-mode-conflict-');
+    initializeGlobalMemory(runtime);
+    chmodSync(runtime.memoryHome, 0o755);
 
-  assert.throws(
-    () =>
-      withGlobalMemoryTransaction(runtime, () => {
-        chmodSync(runtime.memoryHome, 0o750);
-        throw new Error('operation failed');
-      }),
-    /rollback was incomplete.*unknown mode retained/i,
-  );
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o750);
-});
+    assert.throws(
+      () =>
+        withGlobalMemoryTransaction(runtime, () => {
+          chmodSync(runtime.memoryHome, 0o750);
+          throw new Error('operation failed');
+        }),
+      /rollback was incomplete.*unknown mode retained/i,
+    );
+    assertMode(runtime.memoryHome, 0o750);
+  },
+);
 
 test('global rollback removes a newly created empty memory root', () => {
   const { runtime } = fixture('harness-global-new-root-cleanup-');
@@ -134,7 +136,7 @@ test('global rollback does not chmod a same-mode replacement directory', () => {
       }),
     /rollback was incomplete.*root.*replaced/i,
   );
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o700);
+  assertMode(runtime.memoryHome, 0o700);
 });
 
 test('global rollback does not delete a same-mode replacement for a new root', () => {
@@ -151,5 +153,5 @@ test('global rollback does not delete a same-mode replacement for a new root', (
     /rollback was incomplete.*root.*replaced/i,
   );
   assert.equal(existsSync(runtime.memoryHome), true);
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o700);
+  assertMode(runtime.memoryHome, 0o700);
 });

--- a/template/agent-harness/src/__tests__/helpers/harness.ts
+++ b/template/agent-harness/src/__tests__/helpers/harness.ts
@@ -1,6 +1,8 @@
-import { mkdirSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import { mkdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { modeMatches } from '../../lib/portable-mode.js';
 import type { Io, Runtime } from '../../types.js';
 
 export const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../..');
@@ -24,6 +26,18 @@ export function capturedIo(): CapturedIo {
       errors.push(String(message));
     },
   };
+}
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function assertMode(path: string, expected: number): void {
+  assert.equal(
+    modeMatches(statSync(path).mode, expected),
+    true,
+    `expected ${path} to have portable mode ${expected.toString(8)}`,
+  );
 }
 
 export function harnessRuntime(root: string, overrides: Partial<Runtime> = {}): Runtime {

--- a/template/agent-harness/src/__tests__/memory-input-fidelity.test.ts
+++ b/template/agent-harness/src/__tests__/memory-input-fidelity.test.ts
@@ -7,7 +7,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -22,7 +21,7 @@ import { reconcileProfile, removeProfileEntry } from '../commands/memory-profile
 import { parseFrontmatterDocument } from '../lib/frontmatter.js';
 import { parseInputBody } from '../lib/memory-input.js';
 import { withProjectMemoryTransaction } from '../lib/project-memory.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, harnessRuntime } from './helpers/harness.js';
 
 function fixture(prefix: string) {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -107,7 +106,7 @@ test('project memory initialization leaves host ignore files untouched', () => {
     source: 'chat',
   });
 
-  assert.equal(statSync(gitignore).mode & 0o777, 0o600);
+  assertMode(gitignore, 0o600);
   assert.equal(readFileSync(gitignore, 'utf8'), 'existing-rule\n');
   assert.equal(readFileSync(join(project, '.agent-docs', '.gitignore'), 'utf8'), '*\n');
 });
@@ -142,8 +141,8 @@ test('failed input capture rolls back project ignore initialization side effects
   );
   assert.equal(readFileSync(gitignore, 'utf8'), baseline);
   assert.equal(readFileSync(ignore, 'utf8'), baseline);
-  assert.equal(statSync(gitignore).mode & 0o777, 0o600);
-  assert.equal(statSync(ignore).mode & 0o777, 0o640);
+  assertMode(gitignore, 0o600);
+  assertMode(ignore, 0o640);
 });
 
 test('project transaction never recursively deletes a concurrent sentinel', () => {

--- a/template/agent-harness/src/__tests__/memory-lifecycle-recovery.test.ts
+++ b/template/agent-harness/src/__tests__/memory-lifecycle-recovery.test.ts
@@ -1,13 +1,5 @@
 import assert from 'node:assert/strict';
-import {
-  chmodSync,
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, onTestFinished, test, vi } from 'vitest';
@@ -30,7 +22,7 @@ vi.mock('../lib/files.js', async (importOriginal) => {
 import { initGlobal } from '../commands/init.js';
 import { archiveMemory } from '../commands/memory-lifecycle.js';
 import { calendarDate } from '../runtime.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, escapeRegExp, harnessRuntime } from './helpers/harness.js';
 
 beforeEach(() => {
   fault.restorePath = '';
@@ -78,11 +70,14 @@ test('archive retains its destination recovery copy when source restoration fail
 
   assert.throws(
     () => archiveMemory(runtime, 'global', 'recovery', {}, capturedIo()),
-    new RegExp(`rollback was incomplete.*recovery path ${destination} is retained`, 'i'),
+    new RegExp(
+      `rollback was incomplete.*recovery path ${escapeRegExp(destination)} is retained`,
+      'i',
+    ),
   );
   assert.equal(existsSync(source), false);
   assert.equal(existsSync(destination), true);
   assert.match(readFileSync(destination, 'utf8'), /status: archived/);
   assert.match(readFileSync(destination, 'utf8'), /Recover me\./);
-  assert.equal(statSync(destination).mode & 0o777, 0o600);
+  assertMode(destination, 0o600);
 });

--- a/template/agent-harness/src/__tests__/memory-lifecycle-safety.test.ts
+++ b/template/agent-harness/src/__tests__/memory-lifecycle-safety.test.ts
@@ -9,7 +9,6 @@ import {
   readFileSync,
   renameSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -22,7 +21,7 @@ import { archiveMemory, memoryMaintenance, supersedeMemory } from '../commands/m
 import { closeTask, initTask, taskStatus } from '../commands/task.js';
 import { verifyAcceptance } from '../commands/task-verification.js';
 import { calendarDate } from '../runtime.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, harnessRuntime } from './helpers/harness.js';
 
 function fixture(): { root: string; runtime: ReturnType<typeof harnessRuntime> } {
   const root = mkdtempSync(join(tmpdir(), 'harness-memory-lifecycle-safety-'));
@@ -118,7 +117,7 @@ test('memory archive preserves a private source mode at its destination', () => 
   const archived = archiveMemory(runtime, 'global', 'private', {}, capturedIo());
 
   assert.equal(existsSync(source), false);
-  assert.equal(statSync(archived).mode & 0o777, 0o600);
+  assertMode(archived, 0o600);
 });
 
 test('memory archive rejects recursive re-archiving even with force', () => {
@@ -127,7 +126,9 @@ test('memory archive rejects recursive re-archiving even with force', () => {
   const source = join(runtime.memoryHome, 'once.md');
   writeFileSync(source, memoryDocument('Once').replace('status: active', 'status: complete'));
   const archived = archiveMemory(runtime, 'global', 'once', {}, capturedIo());
-  const archivedReference = relative(runtime.memoryHome, archived).replace(/\.md$/, '');
+  const archivedReference = relative(runtime.memoryHome, archived)
+    .replaceAll('\\', '/')
+    .replace(/\.md$/, '');
   const date = calendarDate(runtime);
   const recursiveDestination = join(
     runtime.memoryHome,
@@ -337,7 +338,7 @@ test('memory archive rolls back a move when post-move root validation fails', ()
 
   assert.throws(() => archiveMemory(runtime, 'global', 'future', {}, io), /memory check failed/i);
   assert.equal(readFileSync(source, 'utf8'), future);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
   assert.equal(existsSync(destination), false);
   assert.equal(existsSync(dirname(destination)), false);
   assert.equal(readFileSync(sentinel, 'utf8'), 'unrelated archive data\n');
@@ -355,7 +356,7 @@ test('memory supersede preserves a private source mode', () => {
   supersedeMemory(runtime, 'global', 'source', 'replacement', capturedIo());
 
   assert.match(readFileSync(source, 'utf8'), /status: superseded/);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
 });
 
 test('memory supersede restores original bytes and mode when post-write validation fails', () => {
@@ -373,6 +374,6 @@ test('memory supersede restores original bytes and mode when post-write validati
     /memory check failed/i,
   );
   assert.equal(readFileSync(source, 'utf8'), original);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
   assert.equal(io.logs.length, 0);
 });

--- a/template/agent-harness/src/__tests__/memory-migration-rollback.test.ts
+++ b/template/agent-harness/src/__tests__/memory-migration-rollback.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, onTestFinished, test, vi } from 'vitest';
 import { initGlobal } from '../commands/init.js';
 import { memoryMigrate } from '../commands/memory-migration.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, escapeRegExp, harnessRuntime } from './helpers/harness.js';
 
 const validationControl = vi.hoisted(() => ({
   enabled: false,
@@ -72,7 +72,7 @@ test('migration post-validation failure restores exact bytes and private mode', 
     /rolled back/i,
   );
   assert.equal(readFileSync(profile, 'utf8'), before);
-  assert.equal(statSync(profile).mode & 0o777, 0o600);
+  assertMode(profile, 0o600);
 });
 
 test('migration rollback preserves a validator-time concurrent replacement', () => {
@@ -98,10 +98,10 @@ test('migration rollback preserves a validator-time concurrent replacement', () 
         { apply: true },
         capturedIo(),
       ),
-    new RegExp(`rollback was incomplete.*recovery path ${profile}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(profile)}`, 'i'),
   );
   assert.equal(readFileSync(profile, 'utf8'), concurrent);
-  assert.equal(statSync(profile).mode & 0o777, 0o640);
+  assertMode(profile, 0o640);
 });
 
 test('migration apply refuses a replacement written during proposal validation', () => {
@@ -131,5 +131,5 @@ test('migration apply refuses a replacement written during proposal validation',
     /source changed after proposal validation.*concurrent content retained/i,
   );
   assert.equal(readFileSync(profile, 'utf8'), concurrent);
-  assert.equal(statSync(profile).mode & 0o777, 0o640);
+  assertMode(profile, 0o640);
 });

--- a/template/agent-harness/src/__tests__/memory-migration-safety.test.ts
+++ b/template/agent-harness/src/__tests__/memory-migration-safety.test.ts
@@ -6,7 +6,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  statSync,
   truncateSync,
   writeFileSync,
 } from 'node:fs';
@@ -16,7 +15,7 @@ import { onTestFinished, test } from 'vitest';
 import { initGlobal, initProject } from '../commands/init.js';
 import { memoryMigrate } from '../commands/memory-migration.js';
 import { maximumMemoryDocumentBytes } from '../lib/memory-path.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, harnessRuntime } from './helpers/harness.js';
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'harness-memory-migration-safety-'));
@@ -71,7 +70,7 @@ test('global profile migration preserves its private file mode', () => {
   );
 
   assert.equal(report.mode, 'applied');
-  assert.equal(statSync(profile).mode & 0o777, 0o600);
+  assertMode(profile, 0o600);
   assert.match(readFileSync(profile, 'utf8'), /description: Private profile after migration/);
 });
 

--- a/template/agent-harness/src/__tests__/memory-output-injection-safety.test.ts
+++ b/template/agent-harness/src/__tests__/memory-output-injection-safety.test.ts
@@ -56,6 +56,7 @@ test('memory titles and managed paths cannot inject forged output lines', () => 
   );
 
   rmSync(titlePath);
+  if (process.platform === 'win32') return;
   writeFileSync(join(memoryRoot, 'unsafe\nFORGED.md'), memoryDocument('Safe path title'));
   output = capturedIo();
   assert.throws(() => memoryMaintenance(runtime, project, {}, output), /memory check failed/i);

--- a/template/agent-harness/src/__tests__/memory-rollback-concurrency.test.ts
+++ b/template/agent-harness/src/__tests__/memory-rollback-concurrency.test.ts
@@ -1,14 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import {
-  chmodSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, onTestFinished, test, vi } from 'vitest';
@@ -71,7 +63,7 @@ import { initTask } from '../commands/task.js';
 import { updateAcceptance } from '../commands/task-acceptance.js';
 import { writeValidated } from '../lib/memory-write.js';
 import { calendarDate } from '../runtime.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, escapeRegExp, harnessRuntime } from './helpers/harness.js';
 
 beforeEach(() => {
   validationFault.active = false;
@@ -142,10 +134,10 @@ test('validated write preserves a concurrent replacement instead of rolling it b
         capturedIo(),
         { rootKind: 'global' },
       ),
-    new RegExp(`rollback was incomplete.*recovery path ${profile}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(profile)}`, 'i'),
   );
   assert.equal(readFileSync(profile, 'utf8'), concurrent);
-  assert.equal(statSync(profile).mode & 0o777, 0o640);
+  assertMode(profile, 0o640);
 });
 
 test('project initialization preserves an unknown validator-time replacement', () => {
@@ -185,10 +177,10 @@ test('outer global transaction does not overwrite a replacement retained by inne
         },
         capturedIo(),
       ),
-    new RegExp(`rollback was incomplete.*recovery path ${profile}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(profile)}`, 'i'),
   );
   assert.equal(readFileSync(profile, 'utf8'), concurrent);
-  assert.equal(statSync(profile).mode & 0o777, 0o640);
+  assertMode(profile, 0o640);
 });
 
 test('task acceptance rollback preserves a validator-time concurrent replacement', () => {
@@ -221,10 +213,10 @@ test('task acceptance rollback preserves a validator-time concurrent replacement
         },
         capturedIo(),
       ),
-    /rollback was incomplete.*recovery path .*concurrent-task-write\/task\.json/i,
+    /rollback was incomplete.*recovery path .*concurrent-task-write[\\/]task\.json/i,
   );
   assert.equal(readFileSync(taskFile, 'utf8'), concurrent);
-  assert.equal(statSync(taskFile).mode & 0o777, 0o640);
+  assertMode(taskFile, 0o640);
 });
 
 test('supersede preserves a validator-time replacement of its candidate', () => {
@@ -239,10 +231,10 @@ test('supersede preserves a validator-time replacement of its candidate', () => 
 
   assert.throws(
     () => supersedeMemory(runtime, 'global', 'source', 'replacement', capturedIo()),
-    new RegExp(`rollback was incomplete.*recovery path ${source}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(source)}`, 'i'),
   );
   assert.equal(readFileSync(source, 'utf8'), concurrent);
-  assert.equal(statSync(source).mode & 0o777, 0o640);
+  assertMode(source, 0o640);
 });
 
 test('supersede reports an unresolved recovery path when restore is a no-op', () => {
@@ -258,30 +250,39 @@ test('supersede reports an unresolved recovery path when restore is a no-op', ()
 
   assert.throws(
     () => supersedeMemory(runtime, 'global', 'future', 'replacement', capturedIo()),
-    new RegExp(`rollback was incomplete.*restore was not verified.*recovery path ${source}`, 'i'),
+    new RegExp(
+      `rollback was incomplete.*restore was not verified.*recovery path ${escapeRegExp(source)}`,
+      'i',
+    ),
   );
   assert.match(readFileSync(source, 'utf8'), /status: superseded/);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
 });
 
-test('supersede verifies mode as well as bytes after restoring its snapshot', () => {
-  const { runtime } = fixture('harness-supersede-restore-mode-');
-  initGlobal(runtime, capturedIo());
-  const source = join(runtime.memoryHome, 'future.md');
-  const original = memoryDocument('Future').replaceAll('2026-08-19', '2099-01-01');
-  writeFileSync(source, original);
-  writeFileSync(join(runtime.memoryHome, 'replacement.md'), memoryDocument('Replacement'));
-  chmodSync(source, 0o600);
-  atomicFault.path = source;
-  atomicFault.behavior = 'wrong-mode';
+test.skipIf(process.platform === 'win32')(
+  'supersede verifies mode as well as bytes after restoring its snapshot',
+  () => {
+    const { runtime } = fixture('harness-supersede-restore-mode-');
+    initGlobal(runtime, capturedIo());
+    const source = join(runtime.memoryHome, 'future.md');
+    const original = memoryDocument('Future').replaceAll('2026-08-19', '2099-01-01');
+    writeFileSync(source, original);
+    writeFileSync(join(runtime.memoryHome, 'replacement.md'), memoryDocument('Replacement'));
+    chmodSync(source, 0o600);
+    atomicFault.path = source;
+    atomicFault.behavior = 'wrong-mode';
 
-  assert.throws(
-    () => supersedeMemory(runtime, 'global', 'future', 'replacement', capturedIo()),
-    new RegExp(`rollback was incomplete.*restore was not verified.*recovery path ${source}`, 'i'),
-  );
-  assert.equal(readFileSync(source, 'utf8'), original);
-  assert.equal(statSync(source).mode & 0o777, 0o644);
-});
+    assert.throws(
+      () => supersedeMemory(runtime, 'global', 'future', 'replacement', capturedIo()),
+      new RegExp(
+        `rollback was incomplete.*restore was not verified.*recovery path ${escapeRegExp(source)}`,
+        'i',
+      ),
+    );
+    assert.equal(readFileSync(source, 'utf8'), original);
+    assertMode(source, 0o644);
+  },
+);
 
 test('archive restores its source but preserves a concurrent destination replacement', () => {
   const { runtime } = fixture('harness-archive-destination-concurrent-');
@@ -303,10 +304,10 @@ test('archive restores its source but preserves a concurrent destination replace
 
   assert.throws(
     () => archiveMemory(runtime, 'global', 'archive-source', {}, capturedIo()),
-    new RegExp(`rollback was incomplete.*recovery path ${destination}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(destination)}`, 'i'),
   );
   assert.equal(readFileSync(source, 'utf8'), original);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
   assert.equal(readFileSync(destination, 'utf8'), concurrent);
-  assert.equal(statSync(destination).mode & 0o777, 0o640);
+  assertMode(destination, 0o640);
 });

--- a/template/agent-harness/src/__tests__/memory-transaction-identity.test.ts
+++ b/template/agent-harness/src/__tests__/memory-transaction-identity.test.ts
@@ -6,7 +6,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -117,7 +116,7 @@ import {
 import { writeValidated } from '../lib/memory-write.js';
 import { withProjectMemoryTransaction } from '../lib/project-memory.js';
 import { calendarDate } from '../runtime.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, escapeRegExp, harnessRuntime } from './helpers/harness.js';
 
 beforeEach(() => {
   directoryFault.path = '';
@@ -184,10 +183,10 @@ test('validated write refuses a target replaced after its snapshot', () => {
 
   assert.throws(
     () => writeValidated(runtime.memoryHome, [entry], capturedIo(), { rootKind: 'global' }),
-    new RegExp(`Memory write conflict.*recovery path ${profile}`, 'i'),
+    new RegExp(`Memory write conflict.*recovery path ${escapeRegExp(profile)}`, 'i'),
   );
   assert.equal(readFileSync(profile, 'utf8'), concurrent);
-  assert.equal(statSync(profile).mode & 0o777, 0o640);
+  assertMode(profile, 0o640);
 });
 
 test('validated write preserves an empty directory replaced before rollback cleanup', () => {
@@ -203,7 +202,7 @@ test('validated write preserves an empty directory replaced before rollback clea
         [{ path: join(directory, 'invalid.md'), content: 'invalid\n' }],
         capturedIo(),
       ),
-    new RegExp(`rollback was incomplete.*recovery path ${directory}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(directory)}`, 'i'),
   );
   assert.equal(existsSync(directory), true);
 });
@@ -240,10 +239,10 @@ test('project ignore update refuses an external replacement made after its bound
 
   assert.throws(
     () => withProjectMemoryTransaction(runtime, project, (initialization) => initialization),
-    new RegExp(`Project ignore update conflict.*recovery path ${ignore}`, 'i'),
+    new RegExp(`Project ignore update conflict.*recovery path ${escapeRegExp(ignore)}`, 'i'),
   );
   assert.equal(readFileSync(ignore, 'utf8'), concurrent);
-  assert.equal(statSync(ignore).mode & 0o777, 0o640);
+  assertMode(ignore, 0o640);
 });
 
 test.each(['README.md', 'core.md'])(
@@ -258,10 +257,13 @@ test.each(['README.md', 'core.md'])(
 
     assert.throws(
       () => withProjectMemoryTransaction(runtime, project, (initialization) => initialization),
-      new RegExp(`Project memory initialization conflict.*recovery path ${destination}`, 'i'),
+      new RegExp(
+        `Project memory initialization conflict.*recovery path ${escapeRegExp(destination)}`,
+        'i',
+      ),
     );
     assert.match(readFileSync(destination, 'utf8'), /External writer marker/);
-    assert.equal(statSync(destination).mode & 0o777, 0o640);
+    assertMode(destination, 0o640);
   },
 );
 
@@ -285,10 +287,10 @@ test('supersede refuses a source replaced after its snapshot', () => {
         'global',
         capturedIo(),
       ),
-    new RegExp(`Memory supersede conflict.*recovery path ${source}`, 'i'),
+    new RegExp(`Memory supersede conflict.*recovery path ${escapeRegExp(source)}`, 'i'),
   );
   assert.equal(readFileSync(source, 'utf8'), concurrent);
-  assert.equal(statSync(source).mode & 0o777, 0o640);
+  assertMode(source, 0o640);
 });
 
 test('archive refuses a destination created after its missing snapshot', () => {
@@ -317,11 +319,14 @@ test('archive refuses a destination created after its missing snapshot', () => {
         'global',
         capturedIo(),
       ),
-    new RegExp(`Memory archive destination conflict.*recovery path ${destination}`, 'i'),
+    new RegExp(
+      `Memory archive destination conflict.*recovery path ${escapeRegExp(destination)}`,
+      'i',
+    ),
   );
   assert.equal(readFileSync(source, 'utf8'), original);
   assert.equal(readFileSync(destination, 'utf8'), concurrent);
-  assert.equal(statSync(destination).mode & 0o777, 0o640);
+  assertMode(destination, 0o640);
 });
 
 test('archive refuses to remove a source replaced after writing its candidate', () => {
@@ -354,10 +359,10 @@ test('archive refuses to remove a source replaced after writing its candidate', 
         'global',
         capturedIo(),
       ),
-    new RegExp(`Memory archive source conflict.*recovery path ${source}`, 'i'),
+    new RegExp(`Memory archive source conflict.*recovery path ${escapeRegExp(source)}`, 'i'),
   );
   assert.equal(readFileSync(source, 'utf8'), concurrent);
-  assert.equal(statSync(source).mode & 0o777, 0o640);
+  assertMode(source, 0o640);
   assert.equal(existsSync(destination), true);
 });
 
@@ -375,9 +380,9 @@ test('archive preserves an empty directory replaced before rollback cleanup', ()
 
   assert.throws(
     () => archiveMemory(runtime, 'global', 'archive-source', {}, capturedIo()),
-    new RegExp(`rollback was incomplete.*recovery path ${archiveMonth}`, 'i'),
+    new RegExp(`rollback was incomplete.*recovery path ${escapeRegExp(archiveMonth)}`, 'i'),
   );
   assert.equal(readFileSync(source, 'utf8'), original);
-  assert.equal(statSync(source).mode & 0o777, 0o600);
+  assertMode(source, 0o600);
   assert.equal(existsSync(archiveMonth), true);
 });

--- a/template/agent-harness/src/__tests__/memory-write-edge-cases.test.ts
+++ b/template/agent-harness/src/__tests__/memory-write-edge-cases.test.ts
@@ -25,19 +25,22 @@ test('directory snapshots reject a regular file', () => {
   assert.throws(() => snapshotDirectoryIdentity(file), /regular non-symlink directory/i);
 });
 
-test('tracked directory cleanup reports an uninspectable recovery path', () => {
-  const root = temporaryRoot('harness-memory-directory-inspection-');
-  const file = join(root, 'file.txt');
-  writeFileSync(file, 'parent is a file\n');
+test.skipIf(process.platform === 'win32')(
+  'tracked directory cleanup reports an uninspectable recovery path',
+  () => {
+    const root = temporaryRoot('harness-memory-directory-inspection-');
+    const file = join(root, 'file.txt');
+    writeFileSync(file, 'parent is a file\n');
 
-  const errors = cleanupTrackedDirectories(
-    [{ path: join(file, 'child'), dev: 1, ino: 1, birthtimeMs: 0 }],
-    'created memory',
-  );
+    const errors = cleanupTrackedDirectories(
+      [{ path: join(file, 'child'), dev: 1, ino: 1, birthtimeMs: 0 }],
+      'created memory',
+    );
 
-  assert.equal(errors.length, 1);
-  assert.match(errors[0], /directory identity check failed.*recovery path/i);
-});
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /directory identity check failed.*recovery path/i);
+  },
+);
 
 test('duplicate validated write targets roll back once to their shared snapshot', () => {
   const root = temporaryRoot('harness-memory-duplicate-write-');

--- a/template/agent-harness/src/__tests__/memory-write-safety.test.ts
+++ b/template/agent-harness/src/__tests__/memory-write-safety.test.ts
@@ -7,7 +7,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -19,7 +18,7 @@ import { captureHandoff } from '../commands/memory-autopilot.js';
 import { reconcileProfile } from '../commands/memory-profile.js';
 import { writeValidated } from '../lib/memory-write.js';
 import { withUserDataCoordinationLocks } from '../lib/user-data-lock.js';
-import { capturedIo, harnessRuntime } from './helpers/harness.js';
+import { assertMode, capturedIo, harnessRuntime } from './helpers/harness.js';
 
 function temporaryRoot(prefix: string): string {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -113,15 +112,15 @@ test('global memory initialization creates and tightens private filesystem modes
   const entries = ['README.md', 'core.md', 'profile.md'].map((name) =>
     join(runtime.memoryHome, name),
   );
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o700);
-  for (const path of entries) assert.equal(statSync(path).mode & 0o777, 0o600);
+  assertMode(runtime.memoryHome, 0o700);
+  for (const path of entries) assertMode(path, 0o600);
 
   chmodSync(runtime.memoryHome, 0o755);
   for (const path of entries) chmodSync(path, 0o644);
   initGlobal(runtime, capturedIo());
 
-  assert.equal(statSync(runtime.memoryHome).mode & 0o777, 0o700);
-  for (const path of entries) assert.equal(statSync(path).mode & 0o777, 0o600);
+  assertMode(runtime.memoryHome, 0o700);
+  for (const path of entries) assertMode(path, 0o600);
 });
 
 test('failed profile reconciliation rolls back global initialization route repairs', () => {
@@ -185,7 +184,7 @@ test('validated memory writes preserve hardened modes on success and rollback', 
   chmodSync(profile, 0o600);
 
   writeValidated(runtime.memoryHome, [{ path: profile, content: original }], capturedIo());
-  assert.equal(statSync(profile).mode & 0o777, 0o600);
+  assertMode(profile, 0o600);
 
   assert.throws(
     () =>
@@ -197,7 +196,7 @@ test('validated memory writes preserve hardened modes on success and rollback', 
     /memory check failed/i,
   );
   assert.equal(readFileSync(profile, 'utf8'), original);
-  assert.equal(statSync(profile).mode & 0o777, 0o600);
+  assertMode(profile, 0o600);
 });
 
 test('project capture rejects a symlinked managed core on the unchanged fast path', () => {

--- a/template/agent-harness/src/__tests__/portable-mode.test.ts
+++ b/template/agent-harness/src/__tests__/portable-mode.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { modeMatches } from '../lib/portable-mode.js';
+
+test('Windows ignores POSIX permission bits that its filesystem API cannot preserve', () => {
+  assert.equal(modeMatches(0o666, 0o600, 'win32'), true);
+  assert.equal(modeMatches(0o777, 0o700, 'win32'), true);
+});
+
+test('POSIX platforms continue to require exact permission bits', () => {
+  assert.equal(modeMatches(0o600, 0o600, 'linux'), true);
+  assert.equal(modeMatches(0o666, 0o600, 'linux'), false);
+  assert.equal(modeMatches(0o700, 0o700, 'darwin'), true);
+  assert.equal(modeMatches(0o755, 0o700, 'darwin'), false);
+});

--- a/template/agent-harness/src/__tests__/task-core-safety.test.ts
+++ b/template/agent-harness/src/__tests__/task-core-safety.test.ts
@@ -16,6 +16,7 @@ import { memoryCheck } from '../commands/memory.js';
 import { checkpointTask, closeTask, initTask } from '../commands/task.js';
 import { verifyAcceptance } from '../commands/task-verification.js';
 import { contentMemoryReferences } from '../lib/memory-validation.js';
+import { modeMatches } from '../lib/portable-mode.js';
 import { writeTaskWithProgress } from '../lib/task-store.js';
 import { capturedIo, harnessRuntime } from './helpers/harness.js';
 
@@ -259,6 +260,6 @@ test('failed task progress validation restores task, progress, and core bytes an
   );
   for (const [key, path] of Object.entries(paths)) {
     assert.equal(readFileSync(path, 'utf8'), before[key]);
-    assert.equal(statSync(path).mode & 0o777, 0o600);
+    assert.equal(modeMatches(statSync(path).mode, 0o600), true);
   }
 });

--- a/template/agent-harness/src/lib/global-memory-rollback.ts
+++ b/template/agent-harness/src/lib/global-memory-rollback.ts
@@ -1,5 +1,6 @@
 import { chmodSync, lstatSync, type Stats } from 'node:fs';
 import { cleanupTrackedDirectories, type ExactDirectoryIdentity } from './memory-write.js';
+import { modeMatches } from './portable-mode.js';
 
 type DirectoryEntry = Stats;
 
@@ -47,8 +48,8 @@ function restoreExistingRootMode(
   errors: string[],
 ): void {
   const currentMode = entry.mode & 0o777;
-  if (currentMode === rootMode) return;
-  if (currentMode !== 0o700) {
+  if (modeMatches(currentMode, rootMode)) return;
+  if (!modeMatches(currentMode, 0o700)) {
     errors.push(
       `${root}: rollback skipped because the memory root no longer matches the attempted directory mode; unknown mode retained at recovery path ${root}`,
     );
@@ -57,7 +58,10 @@ function restoreExistingRootMode(
   try {
     chmodSync(root, rootMode);
     const restored = lstatSync(root);
-    if (!matchesDirectoryIdentity(restored, rootIdentity) || (restored.mode & 0o777) !== rootMode) {
+    if (
+      !matchesDirectoryIdentity(restored, rootIdentity) ||
+      !modeMatches(restored.mode, rootMode)
+    ) {
       errors.push(
         `${root}: rollback directory mode restore was not verified; unresolved recovery path ${root}`,
       );
@@ -88,7 +92,7 @@ export function rollbackGlobalMemoryRoot({
   const entry = currentRoot(root, rootIdentity, rootExisted, errors);
   if (!entry) return errors;
   if (rootExisted) restoreExistingRootMode(root, rootMode, rootIdentity, entry, errors);
-  else if ((entry.mode & 0o777) !== 0o700) {
+  else if (!modeMatches(entry.mode, 0o700)) {
     errors.push(
       `${root}: rollback skipped because the new memory root no longer matches the attempted directory mode; unknown mode retained at recovery path ${root}`,
     );

--- a/template/agent-harness/src/lib/global-memory.ts
+++ b/template/agent-harness/src/lib/global-memory.ts
@@ -15,6 +15,7 @@ import {
   restoreExactFileState,
   snapshotDirectoryIdentity,
 } from './memory-write.js';
+import { modeMatches } from './portable-mode.js';
 import { assertSafePath } from './safe-path.js';
 import { readTemplate, render } from './templates.js';
 
@@ -110,7 +111,7 @@ function initializeUnlocked(
       mode: 0o600,
     } as const;
     assertExactFileState(destination, before, 'Global memory initialization');
-    if (!before.exists || before.mode !== candidate.mode) {
+    if (!before.exists || !modeMatches(before.mode, candidate.mode)) {
       attempted.set(destination, candidate);
       atomicWrite(destination, candidate.content, candidate.mode);
       assertExactFileState(destination, candidate, 'Global memory initialization result');
@@ -156,7 +157,7 @@ export function withGlobalMemoryTransaction<T>(
         if (!matchesDirectoryIdentity(rootEntry, rootIdentity)) {
           throw new Error(`Global memory root changed after snapshot: ${runtime.memoryHome}`);
         }
-        if ((rootEntry.mode & 0o777) !== 0o700) {
+        if (!modeMatches(rootEntry.mode, 0o700)) {
           chmodSync(runtime.memoryHome, 0o700);
         }
         const initialization = initializeUnlocked(runtime, paths, attempted);

--- a/template/agent-harness/src/lib/memory-write.ts
+++ b/template/agent-harness/src/lib/memory-write.ts
@@ -6,6 +6,7 @@ import { atomicWrite } from './files.js';
 import type { MemoryRootKind } from './memory-autopilot-document-rules.js';
 import { readMemoryDocument } from './memory-path.js';
 import { validateMemoryRoot } from './memory-validation.js';
+import { modeMatches } from './portable-mode.js';
 import { assertSafePath } from './safe-path.js';
 
 export interface MemoryWriteResult {
@@ -111,7 +112,7 @@ export function exactFileStateMatches(path: string, expected: ExactFileState): b
   try {
     const entry = lstatSync(path);
     if (!expected.exists || entry.isSymbolicLink() || !entry.isFile()) return false;
-    if ((entry.mode & 0o777) !== expected.mode) return false;
+    if (!modeMatches(entry.mode, expected.mode)) return false;
     const expectedBytes = Buffer.byteLength(expected.content);
     if (entry.size !== expectedBytes) return false;
     return (

--- a/template/agent-harness/src/lib/portable-mode.ts
+++ b/template/agent-harness/src/lib/portable-mode.ts
@@ -1,0 +1,7 @@
+export function modeMatches(
+  actual: number,
+  expected: number,
+  platform = process.platform,
+): boolean {
+  return platform === 'win32' || (actual & 0o777) === expected;
+}


### PR DESCRIPTION
## Summary / 变更说明

- Windows 不再把 Node.js 无法可靠保留的 POSIX permission bits 当作 Memory 事务身份。
- 文件类型、非 symlink、内容、大小与目录身份校验保持不变。
- Linux/macOS 继续严格校验 `0600` / `0700`，并同步兼容性文档。

## Related Issue / 关联 Issue

Closes #20

## Verification / 验证

- `pnpm exec vitest run template/agent-harness/src/__tests__/portable-mode.test.ts template/agent-harness/src/__tests__/memory-write.test.ts template/agent-harness/src/__tests__/global-memory.test.ts template/agent-harness/src/__tests__/global-memory-rollback.test.ts template/agent-harness/src/__tests__/task-core-safety.test.ts` — 45 passed
- `pnpm run test:harness` — 465 passed, 2 skipped
- `pnpm run preflight` — 704 passed, 3 skipped; 663 checks
- `pnpm run test:coverage` — unit and script coverage gates passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

此 PR 是启用新 GitHub 闭环工作流前的 bootstrap 修复，因此沿用当前允许的 `hotfix/YYYYMMDD_topic` 分支格式。
