### PR TITLE
ci(github): upgrade actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         node: [24]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -29,9 +29,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/pr-contract.yml
+++ b/.github/workflows/pr-contract.yml
@@ -12,11 +12,11 @@ jobs:
     name: PR Contract
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

将 CI 与 PR Contract 使用的 `actions/checkout`、`actions/setup-node` 从 v4 升级到 v6，移除 GitHub runner 的 Node.js 20 runtime 弃用警告。Node 24、pnpm cache、权限和任务语义保持不变。

## Related Issue / 关联 Issue

Closes #23


## Verification / 验证

- `pnpm exec vitest run src/__tests__/github-templates.test.ts`：11 passed
- `pnpm run check:docs`：505 checks passed
- `pnpm run preflight`：663 checks passed；105 test files passed，715 tests passed，3 skipped
- `git diff --check`：passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

该 PR 不改变发布包内容、产品运行时行为、npm Trusted Publishing 或 Host Eval 门禁。
