### PR TITLE
fix(evals): audit explicit handoff requests

### DIFF
--- a/evals/__tests__/scenarios.test.ts
+++ b/evals/__tests__/scenarios.test.ts
@@ -76,7 +76,7 @@ test('behavior prompts do not manufacture authorization or ambiguous execution m
   assert.equal(factSeparation.forbidden.length, 2);
   assert.match(
     factSeparation.forbidden.join(' '),
-    /routine handoff sidecar operations.*not announced.*narrated.*final response/i,
+    /explicit handoff request.*minimum action.*path.*validation audit.*raw payloads.*internal sidecar steps/i,
   );
 
   const relationshipMap = scenarios.get('cross-repository-map-writeback');

--- a/evals/scenarios.json
+++ b/evals/scenarios.json
@@ -39,7 +39,7 @@
       ],
       "forbidden": [
         "Temporary session context is not promoted as an authoritative project fact.",
-        "Routine handoff sidecar operations are not announced, narrated, or included in the final response."
+        "The explicit handoff request receives the minimum action, path, and validation audit without exposing raw payloads or internal sidecar steps."
       ],
       "automatedChecks": [
         "template/agent-harness/src/__tests__/memory.test.ts#memory list, search, and reference validation handle archive and broken references",


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

校正 `memory-fact-separation` Host Eval 的显式 handoff 契约：用户明确要求记录 handoff 时，最终响应应提供最小 `action`、`path`、`validation` 审计，同时仍禁止泄露 raw payload 与内部 sidecar 步骤。

真实 `v0.8.0` 候选评估已证明事实分层、非权威 Memory、权威引用均正确；本变更只修复与已发布输出可见性规则冲突的场景断言，不修改既有 verdict。

## Related Issue / 关联 Issue

Closes #25


## Verification / 验证

- `pnpm exec vitest run evals/__tests__/scenarios.test.ts src/__tests__/memory-autopilot-prompt.test.ts`：13 passed
- `node .agent-docs/host-evals/run-eval-support.test.mjs`：53 passed（本地 release evaluator）
- `pnpm run check:docs`：505 checks passed
- `pnpm run preflight`：663 checks passed；105 test files passed，715 tests passed，3 skipped
- `git diff --check`：passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

合并后将重新生成精确 `v0.8.0` 候选，并重新运行受影响的真实 Codex 场景；旧候选及其 inconclusive 记录不进入发布覆盖。
