### PR TITLE
fix(memory): require exact audit field labels

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -64,6 +64,8 @@ test('background sidecars stay quiet while explicit Memory requests remain audit
   assert.match(agents, /明确.*Memory.*action.*path.*validation/s);
   assert.match(projectMemory, /自动后台.*静默/s);
   assert.match(projectMemory, /用户明确请求.*action.*path.*validation/s);
+  assert.match(projectMemory, /字段名.*原样.*action.*path.*validation/s);
+  assert.match(projectMemory, /正式结论.*handoff.*不能替代.*path/s);
 });
 
 test('documentation states the real host-hook and source-of-truth boundaries', () => {

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -136,8 +136,9 @@ Token、Cookie、验证码、私钥或未脱敏生产数据。
 也不把“已保留”“已归档”“已校验”改写成用户任务结果。
 
 用户明确请求 Memory 操作、交接、状态、审计或变更清单时，不套用后台静默规则；返回最小可核验结果：
-`action`、`path`、`validation`。结果为 proposed 或 blocked 时同时说明原因和所需决策。普通任务仍只报告
-源码、正式文档、测试或运行结果。
+`action`、`path`、`validation`。字段名必须原样输出为 `action`、`path`、`validation`；即使存在多个正式
+文档或 Memory 路径，也统一列在 `path` 下，“正式结论”、`handoff` 等近义标签不能替代 `path`。结果为
+proposed 或 blocked 时同时说明原因和所需决策。普通任务仍只报告源码、正式文档、测试或运行结果。
 
 纯 host-signal/replay 的输出和执行语义由 long-running task protocol 统一定义，本节不重复其状态机。
 


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

- 明确要求显式 Memory 审计结果原样输出 `action`、`path`、`validation`。
- 多个正式文档或 Memory 路径统一归入 `path`，禁止以“正式结论”或 `handoff` 等近义标签替代。
- 新增 prompt 契约测试，锁定该行为；未修改 Host Eval verifier。

## Related Issue / 关联 Issue

Closes #28


## Verification / 验证

- `pnpm exec vitest run src/__tests__/memory-autopilot-prompt.test.ts`：7 passed
- `pnpm run preflight`：665 checks；107 files / 729 tests passed，3 skipped
- `pnpm run test:coverage`：通过；statements 84.82%，branches 78.68%，functions 92.39%，lines 87.02%；scripts coverage 通过
- `pnpm run test:harness`：63 files / 465 tests passed，2 skipped
- `git diff --check`：通过

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

该缺陷由 0.8.0 发布候选的真实 Host Eval `memory-fact-separation` 连续两次稳定复现。PR 合并后将重建候选并重新执行真实 Host Eval。
