### PR TITLE
fix(memory): enforce quiet ordered discovery

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -55,6 +55,8 @@ test('startup rules retain progressive project discovery without copying its com
   const personal = agents.indexOf('AGENTS.md', profile + 1);
   const project = agents.indexOf('project-agent-docs.md');
   assert.ok(profile >= 0 && personal > profile && project > personal);
+  assert.match(agents, /发现.*\.agent-docs.*首个.*Memory.*命令.*只读.*输出可见性/s);
+  assert.match(agents, /不得.*合并.*其它.*读取/s);
   assert.doesNotMatch(agents, /memory list|task status|memory maintain/);
   assert.match(agents, /命中正文.*事实源/s);
 });
@@ -66,6 +68,11 @@ test('background sidecars stay quiet while explicit Memory requests remain audit
   assert.match(projectMemory, /用户明确请求.*action.*path.*validation/s);
   assert.match(projectMemory, /字段名.*原样.*action.*path.*validation/s);
   assert.match(projectMemory, /正式结论.*handoff.*不能替代.*path/s);
+  assert.match(agents, /普通任务.*Memory.*恢复.*检索.*修复.*归档.*校验.*不得.*commentary\/final/s);
+  assert.match(
+    projectMemory,
+    /普通任务.*Memory.*恢复.*检索.*修复.*归档.*校验.*不得.*commentary\/final/s,
+  );
 });
 
 test('documentation states the real host-hook and source-of-truth boundaries', () => {

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -16,8 +16,8 @@
 1. 新宿主 task/thread 的首个动作是静默读取一次 canonical 用户画像
    `{{HARNESS_MEMORY_HOME}}/profile.md`；缺失则继续。
 2. 读取 `{{HARNESS_PERSONAL_HOME}}/AGENTS.md`，再确认 cwd、Git 根、工作树状态和就近项目规则。
-3. 用目录检查确认项目根是否已有 `.agent-docs/`；存在时，先读取
-   `{{HARNESS_HOME}}/agent-harness/docs/standards/project-agent-docs.md`，再执行其中的有界发现流程。
+3. 用目录检查确认项目根是否已有 `.agent-docs/`；发现 `.agent-docs/` 后的首个 Memory 命令必须只读
+   `{{HARNESS_HOME}}/agent-harness/docs/standards/project-agent-docs.md` 的“输出可见性”段，不得合并其它读取；再执行其中的有界发现流程。
    只读取索引命中正文，随后核对代码、配置、测试、manifest、lockfile 和脚本等事实源。
 4. 对修改、诊断、评审、设计、发布、工具、安全、Git、长任务或 CLI 请求，先读取
    `{{HARNESS_HOME}}/agent-harness/docs/README.md` 并运行文档路由。加载至多一个 `primaryPlaybook` 和完成
@@ -39,7 +39,7 @@
 - `docs/`、ADR、代码、测试、schema、lint 和 CI 是事实源；Memory 只保存非权威输入、状态、证据和
   可追溯提炼。宿主原生 memory 仅作待核对线索。
 - 项目 Memory 的资格、发现、写入、Task/Handoff、画像和 CLI 细节以路由命中的专题文档为准，入口层不复制其协议。
-- 自动后台 sidecar 操作保持静默，不进入普通 commentary/final。
+- 自动后台 sidecar 保持静默；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final，只报告用户任务结果。
 - 用户明确请求 Memory 操作、交接、状态或审计时，返回最小可核验结果：`action`、`path`、`validation`；proposed 或 blocked 时说明原因。
 
 ## 安全

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -62,7 +62,9 @@ Agent 不应因为进入一个项目就创建 `.agent-docs/`：
 
 ## 启动发现闭环
 
-已有 `.agent-docs/` 时，任何 commentary 前先单独读取本文件的“输出可见性”段，再按独立阶段执行：
+已有 `.agent-docs/` 时，任何 commentary 前先单独读取本文件的“输出可见性”段。发现 `.agent-docs/` 后的
+首个 Memory 命令必须且只能读取该段，不得与画像、个人规则、其它 Harness 文档、项目索引或正文合并；
+随后再按独立阶段执行：
 
 1. 用直接文件系统检查确认绝对项目根下的 `.agent-docs/`；不能因 Git、`rg` 或普通索引未命中而判不存在。
 2. 获取不含正文的名称、type、status、updated 列表；无效 JSON 只重试一次，之后标为 `inconclusive`。
@@ -134,6 +136,9 @@ Token、Cookie、验证码、私钥或未脱敏生产数据。
 
 自动后台 sidecar 的恢复、检索、写入、校验和维护状态保持静默，不预告、不混入普通 commentary/final，
 也不把“已保留”“已归档”“已校验”改写成用户任务结果。
+
+普通任务中的 Memory 恢复、检索、修复、归档和校验均属后台 sidecar，不得出现在 commentary/final；
+即使 Memory 支撑了结论，也只报告经事实源核对后的用户任务结果。
 
 用户明确请求 Memory 操作、交接、状态、审计或变更清单时，不套用后台静默规则；返回最小可核验结果：
 `action`、`path`、`validation`。字段名必须原样输出为 `action`、`path`、`validation`；即使存在多个正式


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

- 将发现 `.agent-docs/` 后的首个 Memory 命令限定为只读取项目 Memory 标准的“输出可见性”段，禁止混合其它读取。
- 明确普通任务中的 Memory 恢复、检索、修复、归档与校验属于后台 sidecar，不得进入 commentary/final。
- 在入口规则和项目 Memory 标准中同步边界，并新增 prompt 契约测试。
- 未修改或降低 Host Eval verifier。

## Related Issue / 关联 Issue

Closes #30


## Verification / 验证

- `pnpm exec vitest run src/__tests__/memory-autopilot-prompt.test.ts`：7 passed
- `pnpm run preflight`：665 checks；107 files / 729 tests passed，3 skipped
- `pnpm run test:coverage`：通过；statements 84.82%，branches 78.68%，functions 92.39%，lines 87.02%；scripts coverage 通过
- `pnpm run test:harness`：63 files / 465 tests passed，2 skipped
- `git diff --check`：通过

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

该缺陷由 0.8.0 发布候选的真实 Host Eval `project-memory-recall-writeback` 连续两次复现。合并后将重建候选并重新执行该场景及其余发布门禁。
