### PR TITLE
fix(memory): make discovery contract executable

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -57,8 +57,52 @@ test('startup rules retain progressive project discovery without copying its com
   assert.ok(profile >= 0 && personal > profile && project > personal);
   assert.match(agents, /发现.*\.agent-docs.*首个.*Memory.*命令.*只读.*输出可见性/s);
   assert.match(agents, /不得.*合并.*其它.*读取/s);
+  assert.match(agents, /rg -n -C 12.*输出可见性.*project-agent-docs\.md/s);
+  assert.match(
+    projectMemory,
+    /metadata.*core\.md.*active\/blocked task.*维护候选.*命中正文.*事实源/s,
+  );
+  assert.match(projectMemory, /每个阶段.*单独命令.*不得.*合并/s);
+  assert.match(
+    projectMemory,
+    /memory list.*--json.*core\.md.*task status.*--project.*--json.*memory maintain.*--json/s,
+  );
+  assert.match(projectMemory, /事实源.*单独命令.*sed.*docs\/architecture/s);
+  assert.match(
+    projectMemory,
+    /contradicted.*supersede.*archive.*expired.*无独有.*archive.*indexed/s,
+  );
   assert.doesNotMatch(agents, /memory list|task status|memory maintain/);
   assert.match(agents, /命中正文.*事实源/s);
+});
+
+test('the bounded first project-memory read contains the complete executable startup contract', () => {
+  const lines = projectMemory.split('\n');
+  const anchor = lines.findIndex(
+    (line) => line.includes('已有 `.agent-docs/`') && line.includes('输出可见性'),
+  );
+  assert.ok(anchor >= 0);
+  const boundedRead = lines.slice(Math.max(0, anchor - 12), anchor + 13).join('\n');
+
+  assert.match(
+    boundedRead,
+    /memory list.*--json.*core\.md.*task status.*--project.*--json.*memory maintain.*--json/s,
+  );
+  assert.match(boundedRead, /完成.*事实源.*前.*禁止.*agent_message.*commentary/s);
+  assert.match(boundedRead, /事实源.*单独命令.*sed.*docs\/architecture/s);
+  assert.match(boundedRead, /memory list.*空输出.*原样重试一次/s);
+  assert.match(boundedRead, /maintain.*全部.*unindexed.*expired.*active\/blocked/s);
+  assert.match(boundedRead, /命中正文.*命令.*完成.*事实源.*新.*单独命令.*不得.*合并/s);
+});
+
+test('the bounded output-visibility read retains the ordinary-sidecar classifier', () => {
+  const lines = projectMemory.split('\n');
+  const anchor = lines.findIndex((line) => line.trim() === '## 输出可见性');
+  assert.ok(anchor >= 0);
+  const boundedRead = lines.slice(Math.max(0, anchor - 12), anchor + 13).join('\n');
+
+  assert.match(boundedRead, /即使触发自动 sidecar.*不等于索要操作/s);
+  assert.match(boundedRead, /prior memory.*preserve expensive finding.*后台 sidecar/s);
 });
 
 test('background sidecars stay quiet while explicit Memory requests remain auditable', () => {
@@ -73,6 +117,13 @@ test('background sidecars stay quiet while explicit Memory requests remain audit
     projectMemory,
     /普通任务.*Memory.*恢复.*检索.*修复.*归档.*校验.*不得.*commentary\/final/s,
   );
+  assert.match(agents, /普通任务.*不得.*action.*path.*validation.*\.agent-docs/s);
+  assert.match(projectMemory, /普通任务.*不得.*action.*path.*validation.*\.agent-docs/s);
+  assert.match(projectMemory, /即使触发自动 sidecar.*不等于索要操作/s);
+  assert.match(projectMemory, /prior memory.*preserve expensive finding.*后台 sidecar/s);
+  assert.match(projectMemory, /普通任务.*final.*不得.*持久保留.*已保存.*归档.*Memory.*校验/s);
+  assert.match(projectMemory, /final.*独立句.*直接陈述.*不.*结论/s);
+  assert.match(projectMemory, /final.*事实本身.*主语.*当前架构边界为.*不.*正式文档确认/s);
 });
 
 test('documentation states the real host-hook and source-of-truth boundaries', () => {

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -17,7 +17,7 @@
    `{{HARNESS_MEMORY_HOME}}/profile.md`；缺失则继续。
 2. 读取 `{{HARNESS_PERSONAL_HOME}}/AGENTS.md`，再确认 cwd、Git 根、工作树状态和就近项目规则。
 3. 用目录检查确认项目根是否已有 `.agent-docs/`；发现 `.agent-docs/` 后的首个 Memory 命令必须只读
-   `{{HARNESS_HOME}}/agent-harness/docs/standards/project-agent-docs.md` 的“输出可见性”段，不得合并其它读取；再执行其中的有界发现流程。
+   “输出可见性”，固定使用 `rg -n -C 12 '输出可见性' '{{HARNESS_HOME}}/agent-harness/docs/standards/project-agent-docs.md'`，不得合并其它读取。
    只读取索引命中正文，随后核对代码、配置、测试、manifest、lockfile 和脚本等事实源。
 4. 对修改、诊断、评审、设计、发布、工具、安全、Git、长任务或 CLI 请求，先读取
    `{{HARNESS_HOME}}/agent-harness/docs/README.md` 并运行文档路由。加载至多一个 `primaryPlaybook` 和完成
@@ -40,6 +40,7 @@
   可追溯提炼。宿主原生 memory 仅作待核对线索。
 - 项目 Memory 的资格、发现、写入、Task/Handoff、画像和 CLI 细节以路由命中的专题文档为准，入口层不复制其协议。
 - 自动后台 sidecar 保持静默；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final，只报告用户任务结果。
+- 普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；只有用户明确请求 Memory 审计时例外。
 - 用户明确请求 Memory 操作、交接、状态或审计时，返回最小可核验结果：`action`、`path`、`validation`；proposed 或 blocked 时说明原因。
 
 ## 安全

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -64,7 +64,18 @@ Agent 不应因为进入一个项目就创建 `.agent-docs/`：
 
 已有 `.agent-docs/` 时，任何 commentary 前先单独读取本文件的“输出可见性”段。发现 `.agent-docs/` 后的
 首个 Memory 命令必须且只能读取该段，不得与画像、个人规则、其它 Harness 文档、项目索引或正文合并；
-随后再按独立阶段执行：
+随后严格用已解析的 `<harness>` CLI 前缀和项目根 `.` 执行以下独立命令：
+
+`<harness> memory list . --json`
+`sed -n '1,260p' .agent-docs/core.md`
+`<harness> task status --project . --json`
+`<harness> memory maintain . --json`
+`memory list` 遇到空输出或非 JSON 时原样重试一次；不得猜测 `report`、`project` 或插入 `--help`。
+`maintain` 后读取其全部 unindexed、expired 及相关 active/blocked 正文；命中正文命令完成后，事实源必须由
+新的单独命令读取，且只读 `sed -n '1,260p' docs/architecture.md`，不得合并。
+完成命中正文与事实源核对前，禁止发送任何 agent_message/commentary。
+
+完整阶段如下：
 
 1. 用直接文件系统检查确认绝对项目根下的 `.agent-docs/`；不能因 Git、`rg` 或普通索引未命中而判不存在。
 2. 获取不含正文的名称、type、status、updated 列表；无效 JSON 只重试一次，之后标为 `inconclusive`。
@@ -72,8 +83,20 @@ Agent 不应因为进入一个项目就创建 `.agent-docs/`：
 4. 读取与当前目标、路径或关键词命中的 active/blocked 正文；仅同阶段多篇正文可用只读 `&&`，禁用 `;`。
 5. 用当前代码、测试、契约或正式文档复核结论；失败不越级，不递归读取 archive 或全部历史。
 
+上述顺序固定为 metadata → `core.md` → active/blocked task → 维护候选 → 命中正文 → 事实源。每个阶段
+使用单独命令，不得合并，也不得在这些阶段之间插入 `--help` 或再次路由；前一阶段未完成时不进入下一阶段。
+前四阶段不得用 `find`、`rg` 或手工 frontmatter 扫描替代 Harness 报告。
+
+维护候选中的 unindexed、expired 与 active/blocked 条目只要和当前任务相关，就都属于命中正文；全部读取后
+才能核对事实源和发送首条 commentary。
+
+事实源阶段读取正式事实后再进行其它源码检索，不得把正式事实源读取与 `rg`、文件枚举或其它检查合并在
+同一命令中。
+
 未索引或过期不等于无效。仍有恢复价值的条目先修复索引；只有已核验为 contradicted、expired 且无独有
 恢复价值的普通记忆，才可进入可恢复归档候选。
+对已核验为 contradicted 的 active/blocked 条目，必须先 `supersede` 再 `archive`；对 expired 且无独有
+恢复价值的条目执行 `archive`。修复完成后运行 `memory check <project> --indexed --json` 验证索引闭环。
 
 ## 元信息
 
@@ -134,11 +157,21 @@ Token、Cookie、验证码、私钥或未脱敏生产数据。
 
 ## 输出可见性
 
+即使触发自动 sidecar，也不等于索要操作、状态或审计。用户要求使用 `prior memory` 或
+`preserve expensive finding` 只触发后台 sidecar，不构成显式 Memory 审计请求。
+
 自动后台 sidecar 的恢复、检索、写入、校验和维护状态保持静默，不预告、不混入普通 commentary/final，
 也不把“已保留”“已归档”“已校验”改写成用户任务结果。
 
 普通任务中的 Memory 恢复、检索、修复、归档和校验均属后台 sidecar，不得出现在 commentary/final；
 即使 Memory 支撑了结论，也只报告经事实源核对后的用户任务结果。
+普通任务的 final 不得提及“持久保留”“已保存”“归档”、Memory 写入或 Memory 校验，也不得用近义表述披露
+后台 sidecar 的维护结果。
+普通任务的 final 应以独立句直接陈述经事实源核对的结论，不把“结论：”等标签和事实断言写在同一句中。
+final 应以事实本身作主语，例如“当前架构边界为 `<verified relation>`”；不要写成“正式文档确认边界为…”，
+来源另列为证据。
+普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；仅当用户明确请求 Memory
+操作、交接、状态、审计或变更清单时才输出这些审计字段。
 
 用户明确请求 Memory 操作、交接、状态、审计或变更清单时，不套用后台静默规则；返回最小可核验结果：
 `action`、`path`、`validation`。字段名必须原样输出为 `action`、`path`、`validation`；即使存在多个正式


### PR DESCRIPTION
## Summary / 变更说明

- Make the bounded project-memory bootstrap expose an executable ordered discovery sequence.
- Require all matched active, unindexed, and expired memory to be read before a standalone authoritative-source check.
- Keep automatic Memory maintenance quiet for ordinary tasks and make verified facts machine-observable in final delivery.
- Add regression coverage for both bounded `rg -C 12` windows and the repair/visibility contract.

## Related Issue / 关联 Issue

Closes #30


## Verification / 验证

- `pnpm exec vitest run src/__tests__/memory-autopilot-prompt.test.ts` — 9 passed.
- Real Codex Host Eval `project-memory-recall-writeback` — 8/8 passed (`codex-project-memory-recall-writeback-20260828163553-2c3af0fe`).
- `pnpm run preflight` — 665 preflight checks; 107 files and 731 tests passed, 3 skipped.
- `pnpm run test:coverage` — coverage gates passed; script coverage 90.1% statements, 76.72% branches, 98.96% functions, 90.1% lines.
- `pnpm run test:harness` — 63 files and 465 tests passed, 2 skipped.
- `git diff --check` — passed.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The passing Host Eval is a pre-merge behavior check against the locally packed 0.7.1 candidate. Release evidence will be regenerated from clean `main` after this PR merges.
