### PR TITLE
fix: complete autopilot routing contract

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -13,12 +13,20 @@ const architecture = readFileSync(
   join(root, 'template', 'agent-harness', 'docs', 'core', 'harness-cli-architecture.md'),
   'utf8',
 );
+const longRunning = readFileSync(
+  join(root, 'template', 'agent-harness', 'docs', 'core', 'long-running-tasks.md'),
+  'utf8',
+);
 const operatingModel = readFileSync(
   join(root, 'template', 'agent-harness', 'docs', 'core', 'operating-model.md'),
   'utf8',
 );
 const docsIndex = readFileSync(
   join(root, 'template', 'agent-harness', 'docs', 'README.md'),
+  'utf8',
+);
+const userProfile = readFileSync(
+  join(root, 'template', 'agent-harness', 'docs', 'standards', 'user-profile-memory.md'),
   'utf8',
 );
 
@@ -45,7 +53,16 @@ test('top-level prompt is a compact bootstrap instead of a Memory CLI manual', (
 test('top-level routing uses one primary playbook plus supporting topics without category exceptions', () => {
   assert.match(agents, /primaryPlaybook/);
   assert.match(agents, /topics/);
+  assert.match(agents, /加载.*primaryPlaybook.*全部.*返回.*topics/s);
   assert.match(agents, /歧义.*停止|停止.*歧义/s);
+  assert.match(
+    agents,
+    /路由查询.*用户当前原文.*不得.*改写.*遗漏.*验收.*未来默认.*仍有后续.*host-signal/s,
+  );
+  assert.match(
+    agents,
+    /本地 Harness.*Memory.*画像控制.*不是.*宿主产品.*不加载.*产品文档.*skill.*web/s,
+  );
   assert.match(docsIndex, /primaryPlaybook/);
   assert.match(docsIndex, /topics/);
 });
@@ -130,6 +147,10 @@ test('background sidecars stay quiet while explicit Memory requests remain audit
   assert.match(projectMemory, /普通任务.*final.*不得.*持久保留.*已保存.*归档.*Memory.*校验/s);
   assert.match(projectMemory, /final.*独立句.*直接陈述.*不.*结论/s);
   assert.match(projectMemory, /final.*事实本身.*主语.*当前架构边界为.*不.*正式文档确认/s);
+  assert.match(
+    agents,
+    /纯 host-signal\/replay.*允许空响应.*不得.*agent_message.*强制响应.*上一用户任务.*验证结果.*不提.*sidecar/s,
+  );
 });
 
 test('documentation states the real host-hook and source-of-truth boundaries', () => {
@@ -153,6 +174,13 @@ test('input capture policy distinguishes durable decisions from one-shot actions
   assert.match(projectMemory, /长度.*不是|不能.*字数/s);
   assert.match(projectMemory, /workstream.*durable/s);
   assert.match(projectMemory, /verbatim.*逐字|逐字.*verbatim/s);
+  assert.match(projectMemory, /capture-input.*JSON payload.*sourceRefs.*复数.*不得.*sourceRef/s);
+  assert.match(projectMemory, /source.*只接受.*chat.*file.*meeting.*link.*other/s);
+  assert.match(userProfile, /evidence.*只接受.*explicit.*observed.*不得.*解释文本/s);
+  assert.match(
+    longRunning,
+    /JSON payload.*旧.*open.*全部.*resolved.*只接受.*clearOpen.*true.*不得.*clear.*open.*占位/s,
+  );
   assert.match(operatingModel, /一次性.*授权.*不.*捕获/s);
   assert.match(architecture, /mode.*verbatim.*summary/s);
   assert.match(architecture, /close-input.*core\.md/s);

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -16,12 +16,14 @@
 1. 新宿主 task/thread 的首个动作是静默读取一次 canonical 用户画像
    `{{HARNESS_MEMORY_HOME}}/profile.md`；缺失则继续。
 2. 读取 `{{HARNESS_PERSONAL_HOME}}/AGENTS.md`，再确认 cwd、Git 根、工作树状态和就近项目规则。
-3. 用目录检查确认项目根是否已有 `.agent-docs/`；发现 `.agent-docs/` 后的首个 Memory 命令必须只读
+3. 用目录检查确认项目根是否已有 `.agent-docs/`；发现 `.agent-docs/` 后，首个 Memory 命令必须先读取且只读取
    “输出可见性”，固定使用 `rg -n -C 12 '输出可见性' '{{HARNESS_HOME}}/agent-harness/docs/standards/project-agent-docs.md'`，不得合并其它读取。
    只读取索引命中正文，随后核对代码、配置、测试、manifest、lockfile 和脚本等事实源。
 4. 对修改、诊断、评审、设计、发布、工具、安全、Git、长任务或 CLI 请求，先读取
-   `{{HARNESS_HOME}}/agent-harness/docs/README.md` 并运行文档路由。加载至多一个 `primaryPlaybook` 和完成
-   任务所需的 `topics`；若最高优先级 playbook 存在歧义，停止选择并向用户澄清。
+   `{{HARNESS_HOME}}/agent-harness/docs/README.md` 并运行文档路由。加载至多一个 `primaryPlaybook` 和全部返回的
+   `topics`；若最高优先级 playbook 存在歧义，停止选择并向用户澄清。
+   路由查询保留用户当前原文，不得概括改写而遗漏验收、未来默认、仍有后续或 host-signal 等高损失信号。
+   本地 Harness Memory/画像控制不是宿主产品设置；只用 Harness 文档与 CLI，不加载产品文档、skill 或 web。
 5. 不递归读取整个 `docs/`、`.agent-docs/`、archive、历史会话或全部规则；只有缺失信息会改变权限、范围或结果时才询问用户。
 
 ## 工作与交付
@@ -40,6 +42,7 @@
   可追溯提炼。宿主原生 memory 仅作待核对线索。
 - 项目 Memory 的资格、发现、写入、Task/Handoff、画像和 CLI 细节以路由命中的专题文档为准，入口层不复制其协议。
 - 自动后台 sidecar 保持静默；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final，只报告用户任务结果。
+- 纯 host-signal/replay turn：宿主允许空响应时不得发送 `agent_message`；强制响应时只陈述上一用户任务的验证结果，不提 sidecar 动作。
 - 普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；只有用户明确请求 Memory 审计时例外。
 - 用户明确请求 Memory 操作、交接、状态或审计时，返回最小可核验结果：`action`、`path`、`validation`；proposed 或 blocked 时说明原因。
 

--- a/template/agent-harness/docs/core/long-running-tasks.md
+++ b/template/agent-harness/docs/core/long-running-tasks.md
@@ -81,6 +81,8 @@ signal turn 内、下一条用户消息前，以 `reason: compaction` 单独执�
 已运行适用 verifier 时，`verification` 必须写入当前命令与结果；旧 `open` 全部 resolved 时必须用
 `clearOpen: true`，仅部分 resolved 时必须用 replacement `open` 明列剩余项；省略都会保留旧值，close 不能代替。结束信号必须
 来自当前 user/host turn；`open` 空、sentinel、变更或验收全完成都不能据此提前 close。
+handoff JSON payload 中旧 `open` 全部 resolved 时只接受布尔字段 `clearOpen: true`，不得使用 `clear` 数组、
+空字符串或“No known remaining”等 `open` 占位；首次 mutation 前按此精确字段生成，禁止试错后重试。
 
 自动命令必须单独执行且不得通过 shell 插值传递自由文本。自动 sidecar 与用户明确请求的 Memory 操作
 采用不同的可见性策略，统一遵循 [project Memory standard](../standards/project-agent-docs.md)；

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -23,7 +23,7 @@ entries:
   harness-cli-architecture:
     kind: topic
     path: core/harness-cli-architecture.md
-    triggers: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, doctor, health, route, explain, memory-migrate, 安装, 初始化, 记忆命令, 自动记忆, 健康检查, 路由, 记忆迁移]
+    triggers: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, explain, memory-migrate, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移]
   observability:
     kind: topic
     path: core/observability.md
@@ -36,7 +36,7 @@ entries:
     kind: playbook
     priority: 40
     path: playbooks/change.md
-    triggers: [implement, modify, refactor, build, 实现, 修改, 重构, 构建]
+    triggers: [change, implement, modify, refactor, build, 变更, 实现, 修改, 重构, 构建]
   diagnose:
     kind: playbook
     priority: 50
@@ -68,8 +68,8 @@ entries:
   project-agent-docs:
     kind: standard
     path: standards/project-agent-docs.md
-    triggers: [.agent-docs, session, evidence, handoff, multi-stage, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, secret-hygiene, host-evals, 项目记忆, 会话, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 凭据卫生]
+    triggers: [.agent-docs, session, evidence, handoff, acceptance, future-tasks, multi-stage, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, secret-hygiene, host-evals, 项目记忆, 会话, 验收, 未来所有任务, 以后所有任务, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 凭据卫生]
   user-profile-memory:
     kind: standard
     path: standards/user-profile-memory.md
-    triggers: [user-profile, reconcile-profile, forget-profile, profile-autopilot, preference, identity, coding-style, research-interest, 用户画像, 画像合并, 画像暂停, 画像遗忘, 偏好, 身份, 编码风格, 研究兴趣]
+    triggers: [user-profile, reconcile-profile, forget-profile, profile-autopilot, future-tasks, local-harness, harness-profile, profile-autopilot-control, preference, identity, coding-style, research-interest, 用户画像, 画像合并, 画像暂停, 画像遗忘, 未来所有任务, 以后所有任务, 本地-harness, harness-画像, 画像控制, 偏好, 身份, 编码风格, 研究兴趣]

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -145,6 +145,10 @@ schema-version: 1
 
 输入模式必须显式选择。`verbatim` 正文只允许用户原始字节，不能加入 Agent 解释；任何补全、概括或上下文
 拼接都必须使用 `summary`，并显示为“可靠摘要”。标题可以概括，但不能用标题或摘要伪造用户原话。
+`capture-input` 的 JSON payload 字段必须严格使用 `title`、`content` 或 `contentFile`、`source`、`mode`、
+`purpose`、`retention`，以及可选的 `workstream`、`scope`、`sourceRefs`；数组字段 `sourceRefs` 必须使用复数，
+不得把 CLI 选项 `--source-ref` 写成 payload 字段 `sourceRef`，也不得试错后重试 mutation。`source` 只接受
+`chat`、`file`、`meeting`、`link`、`other`；当前用户消息固定使用 `chat`，不能写 `user` 或带前缀的变体。
 
 不应写：一次性动作授权、框架常识、容易重新搜索的事实、逐行代码摘要、正式文档的完整副本、无来源猜测，以及密码、
 Token、Cookie、验证码、私钥或未脱敏生产数据。

--- a/template/agent-harness/docs/standards/user-profile-memory.md
+++ b/template/agent-harness/docs/standards/user-profile-memory.md
@@ -112,6 +112,8 @@ node {{HARNESS_HOME}}/agent-harness/bin/harness.mjs memory profile-autopilot res
 没有新信息时不改写。自动产生的 conclusion 等自由文本必须由非 shell 文件能力写入 JSON payload，并用
 `--payload-file` 传递；禁止把不可信文本做 shell 插值。reconcile payload 只接受 `key`、`conclusion`、
 `evidence`、`confidence` 与可选 `userDirected`，日期由 CLI 维护，不得自行加入 `date` 或其他字段。自动
+reconcile 的 `evidence` 只接受 `explicit` 或 `observed`，不得写用户原话、来源说明或其他解释文本；用户
+明确表达的偏好固定使用 `explicit` 与 `high`，不得先试错再重试 mutation。
 `reconcile-profile` 必须单独执行并带 `--payload-file` 与 `--json`，不得与验证命令拼接。
 `forget-profile` 与 `profile-autopilot` 也必须单独执行并带 `--json`。
 `profile-autopilot: paused` 会机械拒绝自动 reconcile；

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -94,6 +94,28 @@ test('debugging a long-running handoff chooses diagnose and loads only supportin
   );
 });
 
+test('an exact multi-turn acceptance prompt routes every required autopilot owner', () => {
+  const report = routeDocumentation(docsRoot, [
+    'Change docs/status.txt from pending to ready. Acceptance: node verify-autopilot.mjs docs/status.txt exits 0 and no other tracked file changes. For all future tasks, keep status summaries to one sentence.',
+  ]);
+
+  assert.equal(report.primaryPlaybook?.name, 'change');
+  assert.deepEqual(
+    report.topics.map(({ name }) => name),
+    ['harness-cli-architecture', 'long-running-tasks', 'project-agent-docs', 'user-profile-memory'],
+  );
+});
+
+test('local Harness profile controls route locally instead of to product documentation', () => {
+  const report = routeDocumentation(docsRoot, ['Pause this local Harness profile autopilot.']);
+
+  assert.deepEqual(
+    report.topics.map(({ name }) => name),
+    ['harness-cli-architecture', 'user-profile-memory'],
+  );
+  assert.ok(!report.routes.some(({ name }) => name === 'tool-routing'));
+});
+
 test('runtime audit, policy decision, and token cost queries route to observability guidance', () => {
   const report = routeDocumentation(docsRoot, ['查看运行审计、policy decision 和 token 成本']);
   assert.deepEqual(


### PR DESCRIPTION
## Summary / 变更说明

- route exact multi-turn memory prompts through every returned topic owner
- make local Harness/profile controls bypass product-doc and skill routing
- document exact `capture-input`, profile evidence, and handoff-closing contracts
- keep eligible host-signal and replay turns silent
- add regression coverage for the complete Autopilot routing contract

## Related Issue / 关联 Issue

Closes #34

## Verification / 验证

- `pnpm run preflight` — 665 checks; 107 test files, 733 passed, 3 skipped
- `pnpm run test:coverage` — passed both unit and script coverage gates
- `git diff --check`
- real Codex Host Eval `codex-memory-autopilot-unprompted-20260828200146-f8df73e2` — 18/18 passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The formal release candidate and its complete Host Eval suite will be rebuilt from the merged `main` commit before publishing.
