### PR TITLE
fix: respect negated routing intent

### DIFF
--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -23,7 +23,7 @@ entries:
   harness-cli-architecture:
     kind: topic
     path: core/harness-cli-architecture.md
-    triggers: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, explain, memory-migrate, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移]
+    triggers: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, memory-migrate, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移]
   observability:
     kind: topic
     path: core/observability.md
@@ -41,7 +41,7 @@ entries:
     kind: playbook
     priority: 50
     path: playbooks/diagnose.md
-    triggers: [debug, bug, incident, ci-failure, 排障, 调试, 缺陷, 事故, ci失败]
+    triggers: [diagnose, debug, bug, incident, ci-failure, 诊断, 排障, 调试, 缺陷, 事故, ci失败]
   review:
     kind: playbook
     priority: 50

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -94,6 +94,24 @@ test('debugging a long-running handoff chooses diagnose and loads only supportin
   );
 });
 
+test('diagnostic routing ignores negated change intent and generic explanation wording', () => {
+  const report = routeDocumentation(docsRoot, [
+    'Diagnose a failing focused test and explain the likely cause. Do not implement a fix.',
+  ]);
+
+  assert.equal(report.primaryPlaybook?.name, 'diagnose');
+  assert.deepEqual(report.topics, []);
+  assert.ok(!report.routes.some(({ name }) => name === 'change'));
+  assert.ok(!report.routes.some(({ name }) => name === 'harness-cli-architecture'));
+});
+
+test('diagnostic routing ignores negated Chinese change intent', () => {
+  const report = routeDocumentation(docsRoot, ['诊断失败测试，不要修改代码']);
+
+  assert.equal(report.primaryPlaybook?.name, 'diagnose');
+  assert.ok(!report.routes.some(({ name }) => name === 'change'));
+});
+
 test('an exact multi-turn acceptance prompt routes every required autopilot owner', () => {
   const report = routeDocumentation(docsRoot, [
     'Change docs/status.txt from pending to ready. Acceptance: node verify-autopilot.mjs docs/status.txt exits 0 and no other tracked file changes. For all future tasks, keep status summaries to one sentence.',

--- a/template/agent-harness/src/lib/docs-routing.ts
+++ b/template/agent-harness/src/lib/docs-routing.ts
@@ -50,15 +50,44 @@ function escapeRegularExpression(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function routingMatchPositions(candidate: string, term: string): number[] {
+  if (/\p{Script=Han}/u.test(candidate)) {
+    const positions: number[] = [];
+    let offset = 0;
+    while (offset <= term.length - candidate.length) {
+      const position = term.indexOf(candidate, offset);
+      if (position === -1) break;
+      positions.push(position);
+      offset = position + candidate.length;
+    }
+    return positions;
+  }
+  const pattern = new RegExp(
+    `(?:^|[^\\p{L}\\p{N}])(${escapeRegularExpression(candidate)})(?=$|[^\\p{L}\\p{N}])`,
+    'gu',
+  );
+  return [...term.matchAll(pattern)].map(
+    (match) => (match.index ?? 0) + match[0].length - (match[1]?.length ?? 0),
+  );
+}
+
+function routingMatchIsNegated(term: string, position: number): boolean {
+  const clause =
+    term
+      .slice(0, position)
+      .split(/[,.!?;，。！？；]/u)
+      .at(-1) ?? '';
+  return /(?:\b(?:do\s+not|don't|not|never|without|no)\s+(?:\p{L}+\s+){0,2}|(?:不要|无需|不必|别|禁止|避免|不)\s*)$/u.test(
+    clause,
+  );
+}
+
 function matchesRoutingTerm(trigger: string, term: string): boolean {
   const candidate = normalizeRoutingText(trigger);
   if (!candidate) return false;
-  if (candidate === term) return true;
-  if (/\p{Script=Han}/u.test(candidate)) return term.includes(candidate);
-  return new RegExp(
-    `(?:^|[^\\p{L}\\p{N}])${escapeRegularExpression(candidate)}(?:$|[^\\p{L}\\p{N}])`,
-    'u',
-  ).test(term);
+  return routingMatchPositions(candidate, term).some(
+    (position) => !routingMatchIsNegated(term, position),
+  );
 }
 
 function manifestEntries(value: unknown): Record<string, ManifestEntry> {


### PR DESCRIPTION
## Summary / 变更说明

- ignore explicitly negated route triggers such as `do not implement` and `不要修改`
- add `diagnose` and `诊断` as direct diagnostic playbook triggers
- remove generic `explain` from the Harness CLI architecture topic
- add exact English Host Eval regression coverage and Chinese negation coverage

## Related Issue / 关联 Issue

Closes #36

## Verification / 验证

- `pnpm run preflight` — 665 checks; 107 test files, 735 passed, 3 skipped
- `pnpm run test:coverage` — passed unit and script coverage gates
- `pnpm exec vitest run template/agent-harness/src/__tests__/docs-routing.test.ts` — 18 passed
- `git diff --check`

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The failed formal `progressive-disclosure` Host Eval will be rerun from a fresh candidate built from the merged `main` commit before release.
