### PR TITLE
fix(memory): preserve auditable handoff payloads

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -194,6 +194,11 @@ test('input capture policy distinguishes durable decisions from one-shot actions
     longRunning,
     /JSON payload.*旧.*open.*全部.*resolved.*只接受.*clearOpen.*true.*不得.*clear.*open.*占位/s,
   );
+  assert.match(
+    longRunning,
+    /每次.*mutation attempt.*全新.*payload.*命令.*执行.*冻结.*失败.*不得.*覆盖.*复用.*重试.*新.*路径.*跨 turn.*replay.*例外/s,
+  );
+  assert.match(longRunning, /verification.*精确命令.*exit 0.*completed.*不能.*代替/s);
   assert.match(operatingModel, /一次性.*授权.*不.*捕获/s);
   assert.match(architecture, /mode.*verbatim.*summary/s);
   assert.match(architecture, /close-input.*core\.md/s);

--- a/template/agent-harness/docs/core/long-running-tasks.md
+++ b/template/agent-harness/docs/core/long-running-tasks.md
@@ -2,7 +2,7 @@
 title: Long-running Task Protocol
 type: harness-core
 status: active
-updated: 2026-08-28
+updated: 2026-08-29
 ---
 
 # Long-running Task Protocol
@@ -78,11 +78,15 @@ active task、plan/backlog 与 handoff `open`/`next` 后确认无仍有效事项
 signal turn 内、下一条用户消息前，以 `reason: compaction` 单独执行并校验一次 checkpoint；已有、相同
 或刚更新快照均不豁免。该 signal turn 必须静默执行。仅预判压缩而尚未收到明确信号时，
 才按“旧快照不足恢复且有实质变化”去重。
-已运行适用 verifier 时，`verification` 必须写入当前命令与结果；旧 `open` 全部 resolved 时必须用
+已运行适用 verifier 时，`verification` 必须写入当前 verifier 的精确命令与 `exit 0`；只在 `completed`
+中声称验证通过不能代替 `verification`。旧 `open` 全部 resolved 时必须用
 `clearOpen: true`，仅部分 resolved 时必须用 replacement `open` 明列剩余项；省略都会保留旧值，close 不能代替。结束信号必须
 来自当前 user/host turn；`open` 空、sentinel、变更或验收全完成都不能据此提前 close。
 handoff JSON payload 中旧 `open` 全部 resolved 时只接受布尔字段 `clearOpen: true`，不得使用 `clear` 数组、
 空字符串或“No known remaining”等 `open` 占位；首次 mutation 前按此精确字段生成，禁止试错后重试。
+每次 handoff mutation attempt 必须先写入全新 payload 路径；命令开始执行后，该路径与内容即冻结，即使失败也
+不得覆盖或复用，重试必须创建新路径。只有宿主明确要求的跨 turn identical replay 例外：原样复用上一回合
+已成功 checkpoint 的相同路径和内容，且不得重写文件。
 
 自动命令必须单独执行且不得通过 shell 插值传递自由文本。自动 sidecar 与用户明确请求的 Memory 操作
 采用不同的可见性策略，统一遵循 [project Memory standard](../standards/project-agent-docs.md)；


### PR DESCRIPTION
## Summary / 变更说明

- 将 handoff mutation payload 明确为 one-shot、immutable：每次 attempt 使用全新路径，命令开始后不得覆盖或复用。
- 明确失败重试也必须创建新 payload；仅宿主明确要求的跨 turn identical replay 可原样复用已成功 checkpoint 的路径和内容。
- 要求 `verification` 保存当前 verifier 的精确命令与 `exit 0`，禁止用 `completed` 中的自然语言声明替代。
- 保留现有 `clearOpen: true` 严格字段和 Host Eval verifier，不放宽 schema 或断言。

## Related Issue / 关联 Issue

Closes #34


## Verification / 验证

- `pnpm exec vitest run src/__tests__/memory-autopilot-prompt.test.ts` — 10 passed
- `pnpm run preflight` — 665 checks; 107 test files passed; 736 passed, 3 skipped
- `pnpm run test:coverage` — passed; unit and script coverage gates satisfied
- cleanroom packaged CLI reproduction: `memory profile-autopilot pause --json` returned machine-readable JSON and persisted `profile-autopilot: paused`
- pre-push `pnpm run preflight` — passed
- `git diff --check` — passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

0.8.0 发布保持阻断。PR 合并且默认分支检查通过后，将构建全新候选并从 `memory-autopilot-unprompted` 开始重跑真实 Host Eval；场景不全绿则不发布。
