### PR TITLE
fix(memory): retain high-loss handoff guards

### DIFF
--- a/src/__tests__/memory-autopilot-lifecycle-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-lifecycle-prompt.test.ts
@@ -19,8 +19,9 @@ function owners(pattern: RegExp): string[] {
   return [...documents].flatMap(([name, content]) => (pattern.test(content) ? [name] : []));
 }
 
-test('handoff lifecycle has one normative owner', () => {
-  assert.deepEqual(owners(/clearOpen/), ['long-running-tasks']);
+test('handoff lifecycle has one normative owner plus the high-loss bootstrap guard', () => {
+  assert.deepEqual(owners(/clearOpen/), ['agents', 'long-running-tasks']);
+  assert.deepEqual(owners(/仅部分 resolved.*replacement `open`/), ['long-running-tasks']);
   assert.deepEqual(owners(/Task ledger[^\n]*唯一[^\n]*事实源/), ['long-running-tasks']);
   assert.deepEqual(owners(/phase[^\n]*compaction[^\n]*multi-task[^\n]*manual/), [
     'long-running-tasks',

--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -45,9 +45,16 @@ test('top-level prompt is a compact bootstrap instead of a Memory CLI manual', (
   assert.ok(Math.max(...lines.map((line) => line.length)) <= 160);
   assert.doesNotMatch(
     agents,
-    /capture-input|capture-experience|close-handoff|reconcile-profile|clearOpen|sourceRefs|--payload-file/,
+    /capture-input|capture-experience|close-handoff|reconcile-profile|sourceRefs|--payload-file/,
   );
   assert.doesNotMatch(agents, /core\/git-conventions\.md/);
+});
+
+test('top-level rules preserve high-loss handoff payload contracts', () => {
+  assert.match(agents, /每次.*handoff.*attempt.*全新.*payload.*路径.*执行后.*冻结.*失败.*新路径/s);
+  assert.match(agents, /verification.*精确命令.*exit 0.*completed.*不能.*代替/s);
+  assert.match(agents, /旧.*open.*全部.*解决.*首次.*clearOpen.*true.*不得.*clear.*open/s);
+  assert.match(agents, /第二个.*独立.*已验证.*任务.*reason.*multi-task/s);
 });
 
 test('top-level routing uses one primary playbook plus supporting topics without category exceptions', () => {

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -43,6 +43,10 @@
 - `docs/`、ADR、代码、测试、schema、lint 和 CI 是事实源；Memory 只保存非权威输入、状态、证据和
   可追溯提炼。宿主原生 memory 仅作待核对线索。
 - 项目 Memory 的资格、发现、写入、Task/Handoff、画像和 CLI 细节以路由命中的专题文档为准，入口层不复制其协议。
+- 每次 handoff mutation attempt 使用全新 payload 路径；命令执行后路径与内容冻结，失败重试也用新路径；
+  只有宿主要求的跨 turn identical replay 原样复用成功 payload。
+- Handoff 的 `verification` 写当前 verifier 精确命令与 `exit 0`，`completed` 不能代替；旧 `open` 全部解决时首次即用
+  `clearOpen: true`，不得用 `clear: ["open"]` 试探；同一 session 的第二个独立已验证任务用 `reason: multi-task`。
 - 自动后台 sidecar 保持静默；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final，只报告用户任务结果。
 - 纯 host-signal/replay turn：宿主允许空响应时不得发送 `agent_message`；强制响应时只陈述上一用户任务的验证结果，不提 sidecar 动作。
 - 普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；只有用户明确请求 Memory 审计时例外。


### PR DESCRIPTION
## Summary / 变更说明

- retain the handoff payload immutability contract in the compact bootstrap
- require current verifier evidence, one-shot `clearOpen`, and `multi-task` routing at the high-loss entry boundary
- keep the detailed lifecycle protocol owned by `long-running-tasks.md`

## Related Issue / 关联 Issue

Closes #34

## Verification / 验证

- `pnpm run preflight` — 665 preflight checks and 737 tests passed, 3 skipped
- `pnpm run test:coverage` — coverage gates passed
- `git diff --check` — passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The formal Host Eval remains unchanged and will be rerun from a new post-merge release candidate.
