### PR TITLE
feat(release): verify published registry artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,18 +48,23 @@ jobs:
         env:
           HARNESS_RELEASE_WORKFLOW: '1'
         run: npm publish .release-ci/harnessmith-*.tgz --access public --registry=https://registry.npmjs.org/
-      - name: Verify npm publication
-        run: |
-          expected="${GITHUB_REF_NAME#v}"
-          for attempt in 1 2 3 4 5 6; do
-            actual=$(npm view "harnessmith@${expected}" version --registry=https://registry.npmjs.org/ 2>/dev/null || true)
-            if [ "${actual}" = "${expected}" ]; then
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "harnessmith@${expected} is not visible in npm" >&2
-          exit 1
+      - name: Verify npm registry package
+        run: >-
+          node --import tsx scripts/registry-verify.ts
+          --package harnessmith
+          --version "${GITHUB_REF_NAME#v}"
+          --expected-artifact .release-ci/harnessmith-*.tgz
+          --evidence-file .release-ci/registry-verification.json
+          --require-provenance
+          --json
+      - name: Upload registry verification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: registry-verification-${{ github.ref_name }}
+          path: .release-ci/registry-verification.json
+          if-no-files-found: warn
+          retention-days: 30
 
   release:
     name: Create GitHub Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,9 @@ host-neutrality test passing.
    should not appear in generated release notes. Move the PR out of Draft after focused and full verification.
 5. Squash-merge only after `PR Contract`, `CI Required`, review conversations, and acceptance criteria pass.
    The linked Issue closes through the PR keyword. Tagged publication verifies npm first, then creates the
-   GitHub Release; `CHANGELOG.md` remains a fixed pointer rather than accumulating release history.
+   GitHub Release. The publish job uploads a registry clean-room report that binds official metadata,
+   integrity, provenance, downloaded bytes, and isolated smoke results to the exact tag; `CHANGELOG.md`
+   remains a fixed pointer rather than accumulating release history.
 
 Commitlint enforces Conventional Commits through the Husky `commit-msg` hook. The `pre-commit` hook checks
 staged code and documentation; `pre-push` runs the full `pnpm run preflight`. Preflight accepts long-lived

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -101,6 +101,19 @@ claims:
       - evals/__tests__/run-gate.test.ts
       - evals/__tests__/fingerprint-tarball.test.ts
 
+  - id: post-publish-registry-verification
+    status: implemented
+    owner: release verification scripts and publish workflow
+    claim: Verify official npm registry metadata, provenance, exact package bytes, and isolated installed behavior after publication.
+    implementation:
+      - scripts/registry-verification.ts
+      - scripts/registry-verification-registry.ts
+      - scripts/registry-verification-smoke.ts
+      - .github/workflows/publish.yml
+    verification:
+      - evals/__tests__/registry-verification.test.ts
+      - src/__tests__/github-templates.test.ts
+
   - id: model-loop-tools-and-permissions
     status: delegated
     owner: host Agent Runtime

--- a/docs/concepts/evidence-and-evaluation.md
+++ b/docs/concepts/evidence-and-evaluation.md
@@ -43,6 +43,17 @@ verdict 的内部一致性。release gate 还会检查当前 policy 要求的宿
 它们不能证明记录一定来自真实 Host，也不能证明脱敏前证据完整、维护者结论正确或第三方服务没有异常。仓库写入者可以
 伪造一份结构正确的本地记录；更强信任需要外部 CI、签名 attestation 和人工证据复核。
 
+## 发布后的 Registry Clean-room
+
+发布前的 tarball 与 Host Eval 不能证明 npm registry 最终向用户提供了相同字节。tag publish workflow 因此在
+`npm publish` 成功后运行 `release:verify-registry`：等待精确版本可见，核对官方 registry metadata、SHA-1、SHA-512
+integrity、SHA-256 和 provenance，再对实际下载的 tarball 执行隔离安装，HOME 与 npm cache 均位于受管临时目录。smoke 依次覆盖外层 CLI
+version、capabilities、无写 dry-run、最小 install，以及内嵌 Harness 的 doctor 和 health。
+
+验证输出把传播延迟、metadata 不匹配、integrity 不匹配和运行失败分成稳定错误码，并写入
+`registry-verification.json` 供对应 GitHub Actions run 上传。已经成功发布但 clean-room 失败时只保留诊断证据并停止创建
+GitHub Release，不尝试覆盖或删除 npm 中不可变的已发布版本。
+
 ## 为什么不只检查最终文本
 
 最终文本可能说“测试通过”，但文件没有修改；也可能没有出现预期关键词，却已经完成了正确工具调用。Harnesssmith 的
@@ -54,5 +65,6 @@ predicate，但不应独自决定总体 verdict。
 首先区分产品行为失败与评测基础设施失败。无法访问宿主、认证过期或 runner 超时只能得到 `inconclusive` 或基础设施
 故障，不能直接证明 Harnessmith 不支持该宿主。同样，本地 `eval:validate` 通过也不能升级成“真实 Host 已验证”。
 
-具体命令见项目 `package.json` 中的 `eval:check`、`eval:validate`、`eval:gate` 和 `release:check`；当前公开能力与证据路径
+具体命令见项目 `package.json` 中的 `eval:check`、`eval:validate`、`eval:gate`、`release:check` 和
+`release:verify-registry`；当前公开能力与证据路径
 以[能力声明—证据矩阵](../capability-evidence.yaml)为准。

--- a/evals/__tests__/registry-verification.test.ts
+++ b/evals/__tests__/registry-verification.test.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { readNpmPackageTarball } from '../../scripts/npm-tarball.js';
+import { candidateArtifact } from './run-fixture.js';
+
+const root = join(import.meta.dirname, '..', '..');
+
+function fixture(): string {
+  const path = mkdtempSync(join(tmpdir(), 'harnessmith-registry-verification-'));
+  onTestFinished(() => rmSync(path, { recursive: true, force: true }));
+  return path;
+}
+
+function digest(algorithm: 'sha1' | 'sha256' | 'sha512', content: Buffer): string {
+  return createHash(algorithm)
+    .update(content)
+    .digest(algorithm === 'sha512' ? 'base64' : 'hex');
+}
+
+function fakeNpm(directory: string, version: string): string {
+  const bin = join(directory, 'bin');
+  mkdirSync(bin, { recursive: true });
+  const implementation = join(bin, 'fake-npm.mjs');
+  writeFileSync(
+    implementation,
+    `#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const artifact = process.env.HARNESS_TEST_REGISTRY_ARTIFACT;
+const log = process.env.HARNESS_TEST_REGISTRY_LOG;
+const mode = process.env.HARNESS_TEST_REGISTRY_MODE;
+const version = process.env.HARNESS_TEST_REGISTRY_VERSION;
+writeFileSync(log, JSON.stringify(args) + '\\n', { flag: 'a' });
+
+if (args[0] === 'view') {
+  if (mode === 'unavailable') {
+    console.error('E404 package version not found');
+    process.exit(1);
+  }
+  const content = readFileSync(artifact);
+  console.log(JSON.stringify({
+    version: mode === 'bad-metadata' ? '9.9.9' : version,
+    dist: {
+      tarball: 'https://registry.npmjs.org/harnessmith/-/harnessmith-' + version + '.tgz',
+      shasum: mode === 'bad-integrity' ? '0'.repeat(40) : createHash('sha1').update(content).digest('hex'),
+      integrity: 'sha512-' + createHash('sha512').update(content).digest('base64'),
+      attestations: {
+        url: 'https://registry.npmjs.org/-/npm/v1/attestations/harnessmith@' + version,
+        provenance: { predicateType: 'https://slsa.dev/provenance/v1' },
+      },
+    },
+  }));
+  process.exit(0);
+}
+
+if (args[0] === 'pack') {
+  const destination = args[args.indexOf('--pack-destination') + 1];
+  const filename = 'harnessmith-' + version + '.tgz';
+  copyFileSync(artifact, join(destination, filename));
+  console.log(JSON.stringify([{ filename }]));
+  process.exit(0);
+}
+
+if (args[0] === 'install') {
+  if (mode === 'runtime-failure') {
+    console.error('isolated install failed');
+    process.exit(1);
+  }
+  const prefix = args[args.indexOf('--prefix') + 1];
+  const packageRoot = join(prefix, 'node_modules', 'harnessmith');
+  mkdirSync(join(packageRoot, 'bin'), { recursive: true });
+  writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({ name: 'harnessmith', version }));
+  writeFileSync(
+    join(packageRoot, 'bin', 'harnessmith.mjs'),
+    \`#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+const args = process.argv.slice(2);
+if (args[0] === '--version') console.log('${version}');
+else if (args[0] === 'capabilities') console.log(JSON.stringify({ version: 1, agents: ['codex'] }));
+else if (args[0] === 'install' && args.includes('--dry-run')) console.log(JSON.stringify({ command: 'install', dryRun: true }));
+else if (args[0] === 'install') {
+  mkdirSync(join(process.env.CODEX_HOME, 'agent-harness', 'bin'), { recursive: true });
+  mkdirSync(process.env.HARNESS_MEMORY_HOME, { recursive: true });
+  mkdirSync(process.env.HARNESS_PERSONAL_HOME, { recursive: true });
+  writeFileSync(join(process.env.CODEX_HOME, 'AGENTS.md'), 'managed');
+  writeFileSync(join(process.env.HARNESS_MEMORY_HOME, 'README.md'), 'memory');
+  writeFileSync(join(process.env.HARNESS_MEMORY_HOME, 'core.md'), 'core');
+  writeFileSync(join(process.env.HARNESS_MEMORY_HOME, 'profile.md'), 'profile');
+  writeFileSync(join(process.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), 'personal');
+  writeFileSync(join(process.env.CODEX_HOME, 'agent-harness', 'bin', 'harness.mjs'), \\\`#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'doctor') console.log('Doctor passed');
+else if (args[0] === 'health' && args.includes('--json')) console.log(JSON.stringify({ version: 1, healthy: true, checks: [] }));
+else process.exitCode = 2;
+\\\`);
+  console.log(JSON.stringify({ command: 'install', adapter: 'codex' }));
+} else process.exitCode = 2;
+\`,
+  );
+  process.exit(0);
+}
+
+console.error('unsupported fake npm command: ' + args.join(' '));
+process.exit(2);
+`,
+  );
+  chmodSync(implementation, 0o755);
+  const npm = join(bin, 'npm');
+  writeFileSync(npm, `#!/bin/sh\nexec "${process.execPath}" "${implementation}" "$@"\n`);
+  chmodSync(npm, 0o755);
+  writeFileSync(join(bin, 'npm.cmd'), `@"${process.execPath}" "${implementation}" %*\r\n`);
+  return bin;
+}
+
+test('registry verification validates metadata, downloaded bytes, and isolated smoke commands', () => {
+  const directory = fixture();
+  const tarball = readNpmPackageTarball(candidateArtifact);
+  const manifest = JSON.parse(tarball.files.get('package.json')?.toString('utf8') ?? '{}') as {
+    version: string;
+  };
+  const evidence = join(directory, 'registry-verification.json');
+  const commandLog = join(directory, 'npm-commands.jsonl');
+  const bin = fakeNpm(directory, manifest.version);
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      'scripts/registry-verify.ts',
+      '--package',
+      'harnessmith',
+      '--version',
+      manifest.version,
+      '--expected-artifact',
+      candidateArtifact,
+      '--evidence-file',
+      evidence,
+      '--max-attempts',
+      '3',
+      '--retry-delay-ms',
+      '1',
+      '--require-provenance',
+      '--json',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        HARNESS_TEST_REGISTRY_ARTIFACT: candidateArtifact,
+        HARNESS_TEST_REGISTRY_LOG: commandLog,
+        HARNESS_TEST_REGISTRY_VERSION: manifest.version,
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const report = JSON.parse(result.stdout) as {
+    valid: boolean;
+    artifact: { sha1: string; sha256: string; integrity: string };
+    smoke: Record<string, boolean>;
+  };
+  const content = readFileSync(candidateArtifact);
+  assert.equal(report.valid, true);
+  assert.deepEqual(report.artifact, {
+    sha1: digest('sha1', content),
+    sha256: digest('sha256', content),
+    integrity: `sha512-${digest('sha512', content)}`,
+  });
+  assert.deepEqual(report.smoke, {
+    version: true,
+    capabilities: true,
+    dryRunNoWrite: true,
+    install: true,
+    doctor: true,
+    health: true,
+  });
+  assert.deepEqual(JSON.parse(readFileSync(evidence, 'utf8')), report);
+  const commands = readFileSync(commandLog, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as string[]);
+  assert.equal(commands[0]?.[0], 'view');
+  assert.equal(commands[1]?.[0], 'pack');
+  assert.equal(commands[2]?.[0], 'install');
+});
+
+test('registry verification reports bounded propagation failure with a stable code', () => {
+  const directory = fixture();
+  const tarball = readNpmPackageTarball(candidateArtifact);
+  const manifest = JSON.parse(tarball.files.get('package.json')?.toString('utf8') ?? '{}') as {
+    version: string;
+  };
+  const evidence = join(directory, 'registry-verification.json');
+  const commandLog = join(directory, 'npm-commands.jsonl');
+  const bin = fakeNpm(directory, manifest.version);
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      'scripts/registry-verify.ts',
+      '--package',
+      'harnessmith',
+      '--version',
+      manifest.version,
+      '--expected-artifact',
+      candidateArtifact,
+      '--evidence-file',
+      evidence,
+      '--max-attempts',
+      '2',
+      '--retry-delay-ms',
+      '1',
+      '--require-provenance',
+      '--json',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        HARNESS_TEST_REGISTRY_ARTIFACT: candidateArtifact,
+        HARNESS_TEST_REGISTRY_LOG: commandLog,
+        HARNESS_TEST_REGISTRY_MODE: 'unavailable',
+        HARNESS_TEST_REGISTRY_VERSION: manifest.version,
+      },
+    },
+  );
+
+  assert.equal(result.status, 1);
+  const report = JSON.parse(readFileSync(evidence, 'utf8')) as {
+    valid: boolean;
+    error: { code: string };
+    registry: { attempts: number };
+    recoveryPath: string;
+  };
+  assert.equal(report.valid, false);
+  assert.equal(report.error.code, 'REGISTRY_PROPAGATION_TIMEOUT');
+  assert.equal(report.registry.attempts, 2);
+  assert.match(result.stderr, /REGISTRY_PROPAGATION_TIMEOUT/);
+  rmSync(report.recoveryPath, { recursive: true, force: true });
+});
+
+for (const [mode, expectedCode] of [
+  ['bad-metadata', 'REGISTRY_METADATA_MISMATCH'],
+  ['bad-integrity', 'REGISTRY_INTEGRITY_MISMATCH'],
+  ['runtime-failure', 'REGISTRY_RUNTIME_FAILURE'],
+] as const) {
+  test(`registry verification classifies ${mode} without exposing command output`, () => {
+    const directory = fixture();
+    const tarball = readNpmPackageTarball(candidateArtifact);
+    const manifest = JSON.parse(tarball.files.get('package.json')?.toString('utf8') ?? '{}') as {
+      version: string;
+    };
+    const evidence = join(directory, 'registry-verification.json');
+    const commandLog = join(directory, 'npm-commands.jsonl');
+    const bin = fakeNpm(directory, manifest.version);
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        'scripts/registry-verify.ts',
+        '--package',
+        'harnessmith',
+        '--version',
+        manifest.version,
+        '--expected-artifact',
+        candidateArtifact,
+        '--evidence-file',
+        evidence,
+        '--max-attempts',
+        '1',
+        '--retry-delay-ms',
+        '0',
+        '--require-provenance',
+        '--json',
+      ],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+          HARNESS_TEST_REGISTRY_ARTIFACT: candidateArtifact,
+          HARNESS_TEST_REGISTRY_LOG: commandLog,
+          HARNESS_TEST_REGISTRY_MODE: mode,
+          HARNESS_TEST_REGISTRY_VERSION: manifest.version,
+        },
+      },
+    );
+
+    assert.equal(result.status, 1);
+    const report = JSON.parse(readFileSync(evidence, 'utf8')) as {
+      error: { code: string; message: string };
+      registry: { attempts: number };
+      recoveryPath: string;
+    };
+    assert.equal(report.error.code, expectedCode);
+    assert.equal(report.registry.attempts, 1);
+    assert.doesNotMatch(JSON.stringify(report), /isolated install failed/);
+    rmSync(report.recoveryPath, { recursive: true, force: true });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "quality:secrets": "secretlint --no-color \"src/**/*\" \"scripts/**/*\" \"template/**/*\" \"evals/**/*\" \"docs/**/*\" \".github/**/*\" \".husky/**/*\" \"*.md\" \"*.txt\" \"*.json\" \"*.yaml\" \"*.yml\" \"*.ts\" \"*.mjs\"",
     "release:quality": "pnpm run check && pnpm run build:emit && pnpm run test:coverage:unit && pnpm run test:scripts-coverage",
     "release:check": "pnpm run release:quality && pnpm run eval:gate",
+    "release:verify-registry": "node --import tsx scripts/registry-verify.ts",
     "release": "node --import tsx scripts/release-version.ts",
     "release:prepare": "node --import tsx scripts/release-publish.ts --prepare-only",
     "release:publish": "node --import tsx scripts/release-publish.ts",

--- a/scripts/registry-verification-registry.ts
+++ b/scripts/registry-verification-registry.ts
@@ -1,0 +1,224 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { execaSync } from 'execa';
+import { readNpmPackageTarball } from './npm-tarball.js';
+import {
+  officialRegistry,
+  type RegistryMetadata,
+  RegistryVerificationError,
+  type RegistryVerificationOptions,
+  type RegistryVerificationRunner,
+  type RunOptions,
+} from './registry-verification-types.js';
+
+export const defaultRegistryRunner: RegistryVerificationRunner = (executable, args, options) => {
+  const result = execaSync(executable, args, {
+    cwd: options.cwd,
+    env: options.env,
+    reject: false,
+  });
+  return {
+    status: result.exitCode ?? null,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+};
+
+export function checkedRegistryRun(
+  label: string,
+  executable: string,
+  args: string[],
+  options: RunOptions,
+  runner: RegistryVerificationRunner,
+): string {
+  const result = runner(executable, args, options);
+  if (result.status !== 0) {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      `${label} failed with exit ${String(result.status)}`,
+    );
+  }
+  return result.stdout;
+}
+
+export function registryEnvironment(workspace: string): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(?:NODE_AUTH_TOKEN|NPM_TOKEN)$/i.test(key) || /^npm_config_.*auth/i.test(key))
+      delete env[key];
+  }
+  return {
+    ...env,
+    HOME: join(workspace, 'home'),
+    npm_config_cache: join(workspace, 'npm-cache'),
+    npm_config_registry: officialRegistry,
+    npm_config_userconfig: join(workspace, 'empty-npmrc'),
+  };
+}
+
+function metadataError(message: string): never {
+  throw new RegistryVerificationError('REGISTRY_METADATA_MISMATCH', message);
+}
+
+function parseMetadata(content: string, packageName: string, version: string): RegistryMetadata {
+  let metadata: RegistryMetadata;
+  try {
+    metadata = JSON.parse(content) as RegistryMetadata;
+  } catch {
+    return metadataError(`Registry metadata for ${packageName}@${version} is not valid JSON`);
+  }
+  if (metadata.version !== version) {
+    return metadataError(`Registry metadata version does not match ${packageName}@${version}`);
+  }
+  const expectedTarball = `${officialRegistry}${packageName}/-/${packageName}-${version}.tgz`;
+  if (metadata.dist?.tarball !== expectedTarball) {
+    return metadataError(`Registry tarball URL does not match ${packageName}@${version}`);
+  }
+  if (!/^[a-f0-9]{40}$/.test(metadata.dist.shasum ?? '')) {
+    return metadataError(`Registry shasum is invalid for ${packageName}@${version}`);
+  }
+  if (!/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(metadata.dist.integrity ?? '')) {
+    return metadataError(`Registry integrity is invalid for ${packageName}@${version}`);
+  }
+  return metadata;
+}
+
+export async function fetchRegistryMetadata(
+  options: RegistryVerificationOptions,
+  workspace: string,
+  env: NodeJS.ProcessEnv,
+  runner: RegistryVerificationRunner,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<{ attempts: number; metadata: RegistryMetadata }> {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    const result = runner(
+      npm,
+      [
+        'view',
+        `${options.packageName}@${options.version}`,
+        'version',
+        'dist',
+        '--json',
+        `--registry=${officialRegistry}`,
+      ],
+      { cwd: workspace, env },
+    );
+    if (result.status === 0) {
+      try {
+        return {
+          attempts: attempt,
+          metadata: parseMetadata(result.stdout, options.packageName, options.version),
+        };
+      } catch (error) {
+        if (error instanceof RegistryVerificationError && error.attempts === 0) {
+          throw new RegistryVerificationError(error.code, error.message, attempt);
+        }
+        throw error;
+      }
+    }
+    if (attempt < options.maxAttempts) await sleep(options.retryDelayMs);
+  }
+  throw new RegistryVerificationError(
+    'REGISTRY_PROPAGATION_TIMEOUT',
+    `${options.packageName}@${options.version} did not become visible in the official npm registry after ${options.maxAttempts} attempts`,
+    options.maxAttempts,
+  );
+}
+
+function packFilename(content: string): string {
+  let records: Array<{ filename?: string }>;
+  try {
+    records = JSON.parse(content) as Array<{ filename?: string }>;
+  } catch {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      'npm pack did not return valid JSON',
+    );
+  }
+  const filename = records.length === 1 ? records[0]?.filename : undefined;
+  if (!filename || filename !== basename(filename) || !filename.endsWith('.tgz')) {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      'npm pack did not return one safe tarball filename',
+    );
+  }
+  return filename;
+}
+
+export function downloadRegistryArtifact(
+  options: RegistryVerificationOptions,
+  metadata: RegistryMetadata,
+  attempts: number,
+  expectedSha256: string,
+  workspace: string,
+  downloads: string,
+  env: NodeJS.ProcessEnv,
+  runner: RegistryVerificationRunner,
+): { path: string; artifact: { sha1: string; sha256: string; integrity: string } } {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const packed = checkedRegistryRun(
+    'Registry package download',
+    npm,
+    [
+      'pack',
+      `${options.packageName}@${options.version}`,
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination',
+      downloads,
+      `--registry=${officialRegistry}`,
+    ],
+    { cwd: workspace, env },
+    runner,
+  );
+  const path = join(downloads, packFilename(packed));
+  const content = readFileSync(path);
+  const artifact = {
+    sha1: createHash('sha1').update(content).digest('hex'),
+    sha256: readNpmPackageTarball(path).sha256,
+    integrity: `sha512-${createHash('sha512').update(content).digest('base64')}`,
+  };
+  if (
+    artifact.sha1 !== metadata.dist?.shasum ||
+    artifact.integrity !== metadata.dist?.integrity ||
+    artifact.sha256 !== expectedSha256
+  ) {
+    throw new RegistryVerificationError(
+      'REGISTRY_INTEGRITY_MISMATCH',
+      `Registry package integrity does not match ${options.packageName}@${options.version}`,
+      attempts,
+    );
+  }
+  return { path, artifact };
+}
+
+export function installRegistryArtifact(
+  artifact: string,
+  installRoot: string,
+  workspace: string,
+  env: NodeJS.ProcessEnv,
+  runner: RegistryVerificationRunner,
+): void {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  checkedRegistryRun(
+    'Registry package installation',
+    npm,
+    [
+      'install',
+      artifact,
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--package-lock=false',
+      '--prefix',
+      installRoot,
+      '--cache',
+      join(workspace, 'npm-cache'),
+      `--registry=${officialRegistry}`,
+    ],
+    { cwd: workspace, env },
+    runner,
+  );
+}

--- a/scripts/registry-verification-smoke.ts
+++ b/scripts/registry-verification-smoke.ts
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { checkedRegistryRun } from './registry-verification-registry.js';
+import {
+  RegistryVerificationError,
+  type RegistryVerificationOptions,
+  type RegistryVerificationReport,
+  type RegistryVerificationRunner,
+} from './registry-verification-types.js';
+
+export interface RegistrySmokePaths {
+  codexHome: string;
+  home: string;
+  installRoot: string;
+  workspace: string;
+}
+
+function directorySnapshot(root: string): string {
+  const records: string[] = [];
+  const visit = (directory: string): void => {
+    const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      const relative = path.slice(root.length + 1);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Dry-run target contains a symbolic link: ${path}`);
+      }
+      if (stat.isDirectory()) {
+        records.push(`d:${relative}`);
+        visit(path);
+      } else if (stat.isFile()) {
+        const digest = createHash('sha256').update(readFileSync(path)).digest('hex');
+        records.push(`f:${relative}:${stat.mode}:${digest}`);
+      } else throw new Error(`Dry-run target contains an unsupported entry: ${path}`);
+      if (records.length > 10_000) throw new Error('Dry-run target snapshot entry limit exceeded');
+    }
+  };
+  visit(root);
+  return createHash('sha256').update(records.join('\n')).digest('hex');
+}
+
+function parseJson(label: string, content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      `${label} did not return valid JSON`,
+    );
+  }
+}
+
+export function runRegistrySmoke(
+  options: RegistryVerificationOptions,
+  paths: RegistrySmokePaths,
+  env: NodeJS.ProcessEnv,
+  runner: RegistryVerificationRunner,
+): RegistryVerificationReport['smoke'] {
+  const cli = join(
+    paths.installRoot,
+    'node_modules',
+    options.packageName,
+    'bin',
+    'harnessmith.mjs',
+  );
+  const runCli = (label: string, args: string[]): string =>
+    checkedRegistryRun(
+      label,
+      process.execPath,
+      [cli, ...args],
+      { cwd: paths.workspace, env },
+      runner,
+    );
+  if (runCli('CLI version smoke', ['--version']).trim() !== options.version) {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      `Installed CLI version does not match ${options.version}`,
+    );
+  }
+  parseJson('CLI capabilities smoke', runCli('CLI capabilities smoke', ['capabilities', '--json']));
+  const beforeDryRun = directorySnapshot(paths.home);
+  parseJson(
+    'CLI dry-run smoke',
+    runCli('CLI dry-run smoke', ['install', '--agent', 'codex', '--dry-run', '--json', '--yes']),
+  );
+  if (directorySnapshot(paths.home) !== beforeDryRun) {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      'CLI dry-run modified the isolated user home',
+    );
+  }
+  parseJson(
+    'CLI install smoke',
+    runCli('CLI install smoke', ['install', '--agent', 'codex', '--json', '--yes']),
+  );
+  const harnessCli = join(paths.codexHome, 'agent-harness', 'bin', 'harness.mjs');
+  checkedRegistryRun(
+    'Harness doctor smoke',
+    process.execPath,
+    [harnessCli, 'doctor'],
+    { cwd: paths.workspace, env },
+    runner,
+  );
+  const health = checkedRegistryRun(
+    'Harness health smoke',
+    process.execPath,
+    [harnessCli, 'health', '--json'],
+    { cwd: paths.workspace, env },
+    runner,
+  );
+  if ((parseJson('Harness health smoke', health) as { healthy?: boolean }).healthy !== true) {
+    throw new RegistryVerificationError(
+      'REGISTRY_RUNTIME_FAILURE',
+      'Harness health smoke reported an unhealthy installation',
+    );
+  }
+  return {
+    version: true,
+    capabilities: true,
+    dryRunNoWrite: true,
+    install: true,
+    doctor: true,
+    health: true,
+  };
+}

--- a/scripts/registry-verification-types.ts
+++ b/scripts/registry-verification-types.ts
@@ -1,0 +1,104 @@
+export const officialRegistry = 'https://registry.npmjs.org/';
+
+interface CommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
+export type RegistryVerificationRunner = (
+  executable: string,
+  args: string[],
+  options: RunOptions,
+) => CommandResult;
+
+export interface RegistryMetadata {
+  version?: string;
+  dist?: {
+    tarball?: string;
+    shasum?: string;
+    integrity?: string;
+    attestations?: {
+      url?: string;
+      provenance?: { predicateType?: string };
+    };
+  };
+}
+
+export interface RegistryVerificationOptions {
+  evidenceFile: string;
+  expectedArtifact: string;
+  maxAttempts: number;
+  packageName: string;
+  requireProvenance: boolean;
+  retryDelayMs: number;
+  version: string;
+}
+
+export interface RegistryVerificationReport {
+  version: 1;
+  valid: true;
+  package: { name: string; version: string };
+  registry: {
+    url: string;
+    tarball: string;
+    provenance: boolean;
+    attempts: number;
+  };
+  artifact: { sha1: string; sha256: string; integrity: string };
+  smoke: {
+    version: true;
+    capabilities: true;
+    dryRunNoWrite: true;
+    install: true;
+    doctor: true;
+    health: true;
+  };
+  verifiedAt: string;
+}
+
+export type RegistryVerificationErrorCode =
+  | 'REGISTRY_PROPAGATION_TIMEOUT'
+  | 'REGISTRY_METADATA_MISMATCH'
+  | 'REGISTRY_INTEGRITY_MISMATCH'
+  | 'REGISTRY_RUNTIME_FAILURE';
+
+export interface RegistryVerificationFailureReport {
+  version: 1;
+  valid: false;
+  package: { name: string; version: string };
+  registry: { url: string; attempts: number };
+  error: { code: RegistryVerificationErrorCode; message: string };
+  recoveryPath: string;
+  verifiedAt: string;
+}
+
+export class RegistryVerificationError extends Error {
+  readonly code: RegistryVerificationErrorCode;
+  readonly attempts: number;
+
+  constructor(code: RegistryVerificationErrorCode, message: string, attempts = 0) {
+    super(message);
+    this.name = 'RegistryVerificationError';
+    this.code = code;
+    this.attempts = attempts;
+  }
+}
+
+export class RegistryVerificationFailure extends Error {
+  readonly report: RegistryVerificationFailureReport;
+
+  constructor(report: RegistryVerificationFailureReport, cause: unknown) {
+    super(
+      `${report.error.code}: ${report.error.message}; recovery data retained at: ${report.recoveryPath}`,
+      { cause: cause instanceof Error ? cause : undefined },
+    );
+    this.name = 'RegistryVerificationFailure';
+    this.report = report;
+  }
+}

--- a/scripts/registry-verification.ts
+++ b/scripts/registry-verification.ts
@@ -1,0 +1,204 @@
+import { existsSync, lstatSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import writeFileAtomic from 'write-file-atomic';
+import { createTemporaryWorkspace, disposeTemporaryWorkspace } from '../src/temporary-resource.js';
+import { readNpmPackageTarball } from './npm-tarball.js';
+import {
+  defaultRegistryRunner,
+  downloadRegistryArtifact,
+  fetchRegistryMetadata,
+  installRegistryArtifact,
+  registryEnvironment,
+} from './registry-verification-registry.js';
+import { type RegistrySmokePaths, runRegistrySmoke } from './registry-verification-smoke.js';
+import {
+  officialRegistry,
+  RegistryVerificationError,
+  RegistryVerificationFailure,
+  type RegistryVerificationFailureReport,
+  type RegistryVerificationOptions,
+  type RegistryVerificationReport,
+  type RegistryVerificationRunner,
+} from './registry-verification-types.js';
+
+export type {
+  RegistryVerificationOptions,
+  RegistryVerificationReport,
+  RegistryVerificationRunner,
+} from './registry-verification-types.js';
+
+function evidenceTarget(path: string): string {
+  const target = resolve(path);
+  const parent = dirname(target);
+  if (!existsSync(parent) || !lstatSync(parent).isDirectory()) {
+    throw new Error(`Evidence directory does not exist: ${parent}`);
+  }
+  if (existsSync(target)) {
+    const entry = lstatSync(target);
+    if (!entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error(`Evidence target must be a regular file: ${target}`);
+    }
+  }
+  return target;
+}
+
+function writeReport(
+  path: string,
+  report: RegistryVerificationReport | RegistryVerificationFailureReport,
+): void {
+  writeFileAtomic.sync(path, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+}
+
+function validateOptions(options: RegistryVerificationOptions): void {
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(options.packageName)) {
+    throw new Error(`Unsupported npm package name: ${options.packageName}`);
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(options.version)) {
+    throw new Error(`Expected an exact npm package version, received: ${options.version}`);
+  }
+}
+
+function workspacePaths(workspace: string): RegistrySmokePaths & { downloads: string } {
+  const home = join(workspace, 'home');
+  const paths = {
+    workspace,
+    downloads: join(workspace, 'downloads'),
+    installRoot: join(workspace, 'install'),
+    home,
+    codexHome: join(home, '.codex'),
+  };
+  for (const directory of [
+    paths.downloads,
+    paths.installRoot,
+    paths.home,
+    paths.codexHome,
+    join(home, '.agent-docs'),
+    join(home, '.agent-harness'),
+  ]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+  return paths;
+}
+
+function workspaceEnvironment(paths: RegistrySmokePaths): NodeJS.ProcessEnv {
+  return {
+    ...registryEnvironment(paths.workspace),
+    CODEX_HOME: paths.codexHome,
+    HARNESS_MEMORY_HOME: join(paths.home, '.agent-docs'),
+    HARNESS_PERSONAL_HOME: join(paths.home, '.agent-harness'),
+    HARNESS_REPOSITORY_ROOT: join(paths.home, 'git-repo'),
+    HARNESS_OWNER: 'registry-verification',
+  };
+}
+
+function hasProvenance(metadata: Awaited<ReturnType<typeof fetchRegistryMetadata>>['metadata']) {
+  return (
+    metadata.dist?.attestations?.provenance?.predicateType === 'https://slsa.dev/provenance/v1' &&
+    typeof metadata.dist.attestations.url === 'string'
+  );
+}
+
+async function executeVerification(
+  options: RegistryVerificationOptions,
+  workspace: string,
+  runner: RegistryVerificationRunner,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<{ report: RegistryVerificationReport; attempts: number }> {
+  const expectedSha256 = readNpmPackageTarball(options.expectedArtifact).sha256;
+  const paths = workspacePaths(workspace);
+  const env = workspaceEnvironment(paths);
+  const { attempts, metadata } = await fetchRegistryMetadata(
+    options,
+    workspace,
+    env,
+    runner,
+    sleep,
+  );
+  try {
+    const provenance = hasProvenance(metadata);
+    if (options.requireProvenance && !provenance) {
+      throw new RegistryVerificationError(
+        'REGISTRY_METADATA_MISMATCH',
+        `Registry provenance metadata is missing for ${options.packageName}@${options.version}`,
+        attempts,
+      );
+    }
+    const downloaded = downloadRegistryArtifact(
+      options,
+      metadata,
+      attempts,
+      expectedSha256,
+      workspace,
+      paths.downloads,
+      env,
+      runner,
+    );
+    installRegistryArtifact(downloaded.path, paths.installRoot, workspace, env, runner);
+    const smoke = runRegistrySmoke(options, paths, env, runner);
+    return {
+      attempts,
+      report: {
+        version: 1,
+        valid: true,
+        package: { name: options.packageName, version: options.version },
+        registry: {
+          url: officialRegistry,
+          tarball: metadata.dist?.tarball as string,
+          provenance,
+          attempts,
+        },
+        artifact: downloaded.artifact,
+        smoke,
+        verifiedAt: new Date().toISOString(),
+      },
+    };
+  } catch (error) {
+    if (error instanceof RegistryVerificationError && error.attempts === 0) {
+      throw new RegistryVerificationError(error.code, error.message, attempts);
+    }
+    throw error;
+  }
+}
+
+export async function verifyRegistryPackage(
+  options: RegistryVerificationOptions,
+  runner: RegistryVerificationRunner = defaultRegistryRunner,
+  sleep: (milliseconds: number) => Promise<void> = (milliseconds) =>
+    new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds)),
+): Promise<RegistryVerificationReport> {
+  validateOptions(options);
+  const target = evidenceTarget(options.evidenceFile);
+  const workspace = createTemporaryWorkspace({
+    owner: 'release',
+    purpose: 'registry-verification',
+    lifecycle: 'retained-for-recovery',
+    retainOnFailure: true,
+  });
+  let attempts = 0;
+  try {
+    const result = await executeVerification(options, workspace.path, runner, sleep);
+    attempts = result.attempts;
+    writeReport(target, result.report);
+    disposeTemporaryWorkspace(workspace);
+    return result.report;
+  } catch (error) {
+    const classified =
+      error instanceof RegistryVerificationError
+        ? error
+        : new RegistryVerificationError(
+            'REGISTRY_RUNTIME_FAILURE',
+            error instanceof Error ? error.message : String(error),
+          );
+    const report: RegistryVerificationFailureReport = {
+      version: 1,
+      valid: false,
+      package: { name: options.packageName, version: options.version },
+      registry: { url: officialRegistry, attempts: classified.attempts || attempts },
+      error: { code: classified.code, message: classified.message },
+      recoveryPath: workspace.path,
+      verifiedAt: new Date().toISOString(),
+    };
+    writeReport(target, report);
+    throw new RegistryVerificationFailure(report, error);
+  }
+}

--- a/scripts/registry-verify.ts
+++ b/scripts/registry-verify.ts
@@ -1,0 +1,67 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command, InvalidArgumentError } from 'commander';
+import { verifyRegistryPackage } from './registry-verification.js';
+import { RegistryVerificationFailure } from './registry-verification-types.js';
+
+function integer(value: string, minimum: number): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new InvalidArgumentError(
+      minimum === 0 ? 'must be a non-negative integer' : 'must be a positive integer',
+    );
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const program = new Command()
+    .name('registry-verify')
+    .requiredOption('--package <name>', 'exact npm package name')
+    .requiredOption('--version <version>', 'exact npm package version')
+    .requiredOption('--expected-artifact <path>', 'exact locally published npm tarball')
+    .requiredOption('--evidence-file <path>', 'machine-readable verification output')
+    .option(
+      '--max-attempts <count>',
+      'bounded registry visibility attempts',
+      (value) => integer(value, 1),
+      6,
+    )
+    .option(
+      '--retry-delay-ms <milliseconds>',
+      'delay between visibility attempts',
+      (value) => integer(value, 0),
+      10_000,
+    )
+    .option('--require-provenance', 'require npm provenance metadata')
+    .requiredOption('--json', 'write the verification report as JSON');
+  program.parse();
+  const options = program.opts<{
+    package: string;
+    version: string;
+    expectedArtifact: string;
+    evidenceFile: string;
+    maxAttempts: number;
+    retryDelayMs: number;
+    requireProvenance?: boolean;
+  }>();
+  const report = await verifyRegistryPackage({
+    packageName: options.package,
+    version: options.version,
+    expectedArtifact: options.expectedArtifact,
+    evidenceFile: options.evidenceFile,
+    maxAttempts: options.maxAttempts,
+    retryDelayMs: options.retryDelayMs,
+    requireProvenance: options.requireProvenance === true,
+  });
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+const entry = process.argv[1] ? resolve(process.argv[1]) : '';
+if (entry === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    if (error instanceof RegistryVerificationFailure) console.error(JSON.stringify(error.report));
+    else console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/__tests__/docs-site.test.ts
+++ b/src/__tests__/docs-site.test.ts
@@ -222,6 +222,20 @@ test('memory and task overview links to the current canonical runtime protocols'
   assert.doesNotMatch(overview, /core\/memory-architecture\.md|topics\/task-lifecycle\.md/);
 });
 
+test('release documentation distinguishes post-publish registry clean-room evidence', () => {
+  const evaluation = read('docs/concepts/evidence-and-evaluation.md');
+  const capabilities = read('docs/capability-evidence.yaml');
+  const contributing = read('CONTRIBUTING.md');
+
+  assert.match(evaluation, /release:verify-registry/);
+  assert.match(evaluation, /registry metadata.*integrity.*隔离安装/s);
+  assert.match(evaluation, /传播延迟.*metadata.*integrity.*运行失败/s);
+  assert.match(capabilities, /id: post-publish-registry-verification/);
+  assert.match(capabilities, /scripts\/registry-verification\.ts/);
+  assert.match(capabilities, /evals\/__tests__\/registry-verification\.test\.ts/);
+  assert.match(contributing, /registry clean-room/i);
+});
+
 test('cross-repository relationships remain a first-class public capability', () => {
   const readme = read('README.md');
   const english = read('README.en.md');

--- a/src/__tests__/github-templates.test.ts
+++ b/src/__tests__/github-templates.test.ts
@@ -31,6 +31,7 @@ interface Workflow {
       if?: unknown;
       permissions?: Record<string, unknown>;
       steps?: Array<{
+        if?: unknown;
         name?: unknown;
         uses?: unknown;
         run?: unknown;
@@ -204,12 +205,22 @@ test('release notes are categorized and only created after npm publication is ve
     readFileSync(join(root, '.github', 'workflows', 'publish.yml'), 'utf8'),
   ) as Workflow;
   const publishSteps = workflow.jobs?.publish?.steps ?? [];
-  assert.ok(
-    publishSteps.some(({ name, run }) =>
-      /Verify npm publication/i.test(`${text(name)} ${text(run)}`),
-    ),
-    'publish job must verify the package is visible in npm',
+  const verification = publishSteps.find(({ name }) =>
+    /Verify npm registry package/i.test(text(name)),
   );
+  const verificationCommand = text(verification?.run);
+  assert.match(verificationCommand, /scripts\/registry-verify\.ts/);
+  assert.match(verificationCommand, /--version "\$\{GITHUB_REF_NAME#v\}"/);
+  assert.match(verificationCommand, /--expected-artifact \.release-ci\/harnessmith-\*\.tgz/);
+  assert.match(verificationCommand, /--require-provenance/);
+  assert.match(verificationCommand, /--evidence-file \.release-ci\/registry-verification\.json/);
+  assert.doesNotMatch(verificationCommand, /npm view/);
+  const evidenceUpload = publishSteps.find(({ name }) =>
+    /Upload registry verification evidence/i.test(text(name)),
+  );
+  assert.equal(evidenceUpload?.if, '$' + '{{ always() }}');
+  assert.match(text(evidenceUpload?.uses), /^actions\/upload-artifact@/);
+  assert.equal(evidenceUpload?.with?.path, '.release-ci/registry-verification.json');
   const release = workflow.jobs?.release;
   assert.equal(release?.needs, 'publish');
   assert.equal(release?.permissions?.contents, 'write');


### PR DESCRIPTION
## Summary / 变更说明

- Verify the exact package version from the official npm registry after publish.
- Compare registry integrity with the locally published tarball and require provenance.
- Run isolated install and CLI smoke checks, then upload stable verification evidence.

## Related Issue / 关联 Issue

Closes #11

## Verification / 验证

- `pnpm run preflight` — 670 checks; 758 passed, 3 skipped.
- `pnpm run test:coverage` — all configured thresholds passed.
- `npm pack --dry-run --ignore-scripts` with an isolated npm cache — 70 files.
- Live verification against public `harnessmith@0.8.0` — provenance, integrity and six smoke checks passed.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The live registry check used the already-published `0.8.0`; this PR does not publish a package.
