### PR TITLE
feat(eval): classify and bound host evaluation runs

### DIFF
--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -101,6 +101,19 @@ claims:
       - evals/__tests__/run-gate.test.ts
       - evals/__tests__/fingerprint-tarball.test.ts
 
+  - id: bounded-host-eval-record-contract
+    status: implemented
+    owner: Host Eval evidence and release verification
+    claim: Classify Host Eval outcomes without treating infrastructure failures as behavior failures, while enforcing bounded attempts and time budgets in every record.
+    implementation:
+      - evals/run.schema.json
+      - scripts/eval-execution-contract.ts
+      - scripts/eval-records.ts
+    verification:
+      - evals/__tests__/run-gate.test.ts
+      - evals/__tests__/run-selection-security.test.ts
+      - evals/__tests__/scenarios.test.ts
+
   - id: post-publish-registry-verification
     status: implemented
     owner: release verification scripts and publish workflow

--- a/docs/concepts/evidence-and-evaluation.md
+++ b/docs/concepts/evidence-and-evaluation.md
@@ -27,6 +27,15 @@ verifier 结果。场景断言同时检查期望行为与禁止行为，避免�
 这条链成本更高，也更容易受到认证、网络、宿主版本、超时和评测基础设施故障影响。因此环境准备、候选绑定、失败
 归因和证据保留本身也是评测设计的一部分。
 
+Host Eval v5 记录把结果固定为四类：`passed` 表示行为与断言通过；`behavior-failed` 表示真实产品行为未满足场景；
+transport、TLS、WebSocket、runner 超时或 circuit breaker 终止只能记为 `infra-inconclusive`；evaluator 本身无法完成判定时记为
+`evaluator-failed`。后三类都不能满足发布覆盖，尤其不能把 `infra-inconclusive` 降格解释成产品行为失败或通过。
+
+执行证据同时记录 tier、attempt、elapsed time 和 termination。单场景预算上限为 15 分钟，整套矩阵预算上限为 60 分钟；
+transport failure 最多自动重试一次，即总尝试次数不超过两次。`eval:validate` 会拒绝超预算、重试次数超限以及 termination
+与结果分类冲突的记录。当前 phase 只提供记录与门禁契约；真实 Host 的增量选择、有界并行和 circuit-break 调度仍由后续
+runner/CI 集成实现。
+
 ## 从任务到结论的五个阶段
 
 1. **定义任务与验收**：场景说明要观察什么，什么行为明确禁止。
@@ -62,8 +71,9 @@ predicate，但不应独自决定总体 verdict。
 
 ## 评测失败时如何解释
 
-首先区分产品行为失败与评测基础设施失败。无法访问宿主、认证过期或 runner 超时只能得到 `inconclusive` 或基础设施
-故障，不能直接证明 Harnessmith 不支持该宿主。同样，本地 `eval:validate` 通过也不能升级成“真实 Host 已验证”。
+首先区分产品行为失败与评测基础设施失败。无法访问宿主、认证过期或 runner 超时只能得到
+`infra-inconclusive`，不能直接证明 Harnessmith 不支持该宿主；evaluator 自身故障必须记为 `evaluator-failed`，不能伪装成
+`behavior-failed`。同样，本地 `eval:validate` 通过也不能升级成“真实 Host 已验证”。
 
 具体命令见项目 `package.json` 中的 `eval:check`、`eval:validate`、`eval:gate`、`release:check` 和
 `release:verify-registry`；当前公开能力与证据路径

--- a/evals/README.md
+++ b/evals/README.md
@@ -17,6 +17,7 @@ setup, observable pass conditions, forbidden conditions, and local regression ch
   (`id`/`prompt`/`setup`/`pass`/`forbidden`), distributed rule fingerprints, and the derived
   `behaviorSha256` used for bounded evidence inheritance;
 - start and finish timestamps plus `evaluatedAt`, when the maintainer completed evidence review;
+- the Host Eval tier, attempt count, elapsed time, termination reason, and enforced scenario/matrix budgets;
 - a redacted transcript artifact and SHA-256 digest;
 - ordered tool actions, including approval and outcome;
 - a filesystem-diff artifact, digest, and changed-path summary;
@@ -24,6 +25,16 @@ setup, observable pass conditions, forbidden conditions, and local regression ch
 - one evidence-backed assertion for every ordered scenario `forbidden` condition
   (`forbidden-1`, `forbidden-2`, …);
 - a verdict whose references resolve to independently stored evidence artifacts.
+
+Schema v5 makes infrastructure and evaluator failures explicit. `passed` and `behavior-failed` are valid only
+for a completed Host execution. Transport failures, scenario budget exhaustion, and an open circuit are
+`infra-inconclusive`; evaluator failures are `evaluator-failed`. Infrastructure outcomes never satisfy release
+coverage and never become product behavior failures.
+
+Each record is limited to a 15-minute scenario budget and a 60-minute matrix budget. A run may retry once
+(`maxAttempts: 2`); the record preserves the attempt count, transport-failure count, and whether execution
+completed, exhausted its budget, failed in transport/evaluation, or stopped at an open circuit. This repository
+validates those limits and classifications but does not launch or schedule third-party Hosts.
 
 All `local:` artifact references are relative to the record file. The validator rejects missing, tampered,
 oversized, or path-escaping records and artifacts; bounds record count and aggregate record/evidence bytes;
@@ -110,7 +121,8 @@ source package version and artifact digest under `inheritedFrom`. Release state 
 attestation preserve that inheritance trail. Historical records whose scenario fingerprint no longer matches
 may remain in the evidence directory, but they are not eligible for current coverage.
 
-The gate intentionally fails when records are absent, stale, inconclusive, failed, tied to another behavior
+The gate intentionally fails when records are absent, stale, `behavior-failed`, `infra-inconclusive`,
+`evaluator-failed`, tied to another behavior
 contract, or missing any scenario cell for a host required by the checked-in release policy. The
 current required host is Codex; Cursor, Claude Code, OpenCode, and Kimi Code CLI can still be validated and retained as optional evidence.
 The gate never launches, authenticates to,

--- a/evals/__tests__/eval-execution-contract.test.ts
+++ b/evals/__tests__/eval-execution-contract.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { test } from 'vitest';
+import { run, temporaryDirectory, writeRun } from './run-fixture.js';
+
+test('validator rejects more than one automatic retry', () => {
+  const runsDirectory = temporaryDirectory();
+  const path = writeRun(runsDirectory);
+  const record = JSON.parse(readFileSync(path, 'utf8'));
+  record.execution.attempt = 3;
+  record.execution.maxAttempts = 3;
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
+
+  const result = run(['validate', '--runs-dir', runsDirectory]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /run schema.*maxAttempts|run schema.*attempt/i);
+});
+
+test('validator requires transport failures to remain infra-inconclusive', () => {
+  const runsDirectory = temporaryDirectory();
+  writeRun(runsDirectory, {
+    outcome: 'behavior-failed',
+    termination: 'transport-failure',
+  });
+
+  const result = run(['validate', '--runs-dir', runsDirectory]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /transport-failure.*infra-inconclusive/i);
+});
+
+test('validator rejects elapsed time beyond the scenario budget', () => {
+  const runsDirectory = temporaryDirectory();
+  const path = writeRun(runsDirectory);
+  const record = JSON.parse(readFileSync(path, 'utf8'));
+  record.execution.scenarioBudgetMs = 60_000;
+  record.execution.elapsedMs = record.execution.scenarioBudgetMs + 1;
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
+
+  const result = run(['validate', '--runs-dir', runsDirectory]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /elapsedMs.*scenarioBudgetMs/i);
+});

--- a/evals/__tests__/run-fixture.ts
+++ b/evals/__tests__/run-fixture.ts
@@ -61,13 +61,20 @@ export function writeRun(
     finishedAt = new Date().toISOString(),
     evaluatedAt = finishedAt,
     outcome = 'passed',
+    termination = 'completed',
     runId = `${adapter}-${scenarioId}`,
   }: {
     adapter?: AgentName;
     scenarioId?: string;
     finishedAt?: string;
     evaluatedAt?: string;
-    outcome?: 'passed' | 'failed' | 'inconclusive';
+    outcome?: 'passed' | 'behavior-failed' | 'infra-inconclusive' | 'evaluator-failed';
+    termination?:
+      | 'completed'
+      | 'transport-failure'
+      | 'scenario-budget-exhausted'
+      | 'circuit-open'
+      | 'evaluator-failure';
     runId?: string;
   } = {},
 ): string {
@@ -83,7 +90,7 @@ export function writeRun(
   writeFileSync(join(directory, 'transcript.md'), transcript);
   writeFileSync(join(directory, 'filesystem-diff.txt'), filesystemDiff);
   const record = {
-    schemaVersion: 4,
+    schemaVersion: 5,
     recordType: 'host-evaluation',
     runId,
     scenarioId,
@@ -104,6 +111,16 @@ export function writeRun(
     startedAt: new Date(Date.parse(finishedAt) - 60_000).toISOString(),
     finishedAt,
     evaluatedAt,
+    execution: {
+      tier: 'L2',
+      attempt: 1,
+      maxAttempts: 2,
+      scenarioBudgetMs: 15 * 60 * 1000,
+      matrixBudgetMs: 60 * 60 * 1000,
+      elapsedMs: 60_000,
+      transportFailures: 0,
+      termination,
+    },
     transcript: {
       artifactRef: 'local:transcript.md',
       sha256: digest(transcript),

--- a/evals/__tests__/run-selection-security.test.ts
+++ b/evals/__tests__/run-selection-security.test.ts
@@ -28,7 +28,7 @@ test('release gate uses the latest evaluated record for each host and scenario c
     adapter: 'codex',
     evaluatedAt: latest,
     finishedAt: new Date(Date.parse(latest) - 1_000).toISOString(),
-    outcome: 'failed',
+    outcome: 'behavior-failed',
     runId: 'codex-progressive-disclosure-latest',
     scenarioId: 'progressive-disclosure',
   });
@@ -36,7 +36,7 @@ test('release gate uses the latest evaluated record for each host and scenario c
   const result = run(['gate', '--runs-dir', runsDirectory]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /failed codex\/progressive-disclosure/);
+  assert.match(result.stderr, /behavior-failed codex\/progressive-disclosure/);
 });
 
 test('release gate rejects a tied latest evaluatedAt for the same matrix cell', () => {

--- a/evals/__tests__/scenarios.test.ts
+++ b/evals/__tests__/scenarios.test.ts
@@ -255,7 +255,7 @@ test('manual host evaluation evidence has a versioned machine-readable contract'
   const example = JSON.parse(readFileSync(join(root, 'evals', 'run.example.json'), 'utf8'));
   const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
 
-  assert.equal(schema.$id, 'urn:harnessmith:eval-run:v4');
+  assert.equal(schema.$id, 'urn:harnessmith:eval-run:v5');
   assert.equal(validate(example), true, JSON.stringify(validate.errors));
   assert.equal(example.recordType, 'example-only');
   assert.equal(example.transcript.redacted, true);
@@ -265,6 +265,11 @@ test('manual host evaluation evidence has a versioned machine-readable contract'
   assert.match(example.subject.packageArtifactSha256, /^[a-f0-9]{64}$/);
   assert.match(example.subject.scenarioSha256, /^[a-f0-9]{64}$/);
   assert.match(example.subject.rulesSha256, /^[a-f0-9]{64}$/);
+  assert.equal(example.execution.maxAttempts, 2);
+  assert.equal(example.execution.scenarioBudgetMs, 15 * 60 * 1000);
+  assert.equal(example.execution.matrixBudgetMs, 60 * 60 * 1000);
+  assert.equal(example.execution.termination, 'transport-failure');
+  assert.equal(example.verdict.outcome, 'infra-inconclusive');
   assert.equal(example.subject.packageVersion, 'replace-with-current-package-version');
   assert.equal(example.subject.harnessVersion, 'replace-with-current-harness-version');
   assert.ok(example.host.product.length > 0);

--- a/evals/run.example.json
+++ b/evals/run.example.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "recordType": "example-only",
   "runId": "replace-with-real-run-id",
   "scenarioId": "progressive-disclosure",
@@ -20,6 +20,16 @@
   "startedAt": "2026-08-19T00:00:00Z",
   "finishedAt": "2026-08-19T00:05:00Z",
   "evaluatedAt": "2026-08-19T00:10:00Z",
+  "execution": {
+    "tier": "L2",
+    "attempt": 2,
+    "maxAttempts": 2,
+    "scenarioBudgetMs": 900000,
+    "matrixBudgetMs": 3600000,
+    "elapsedMs": 300000,
+    "transportFailures": 2,
+    "termination": "transport-failure"
+  },
   "transcript": {
     "artifactRef": "local:artifacts/redacted-transcript.md",
     "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
@@ -64,7 +74,7 @@
     }
   ],
   "verdict": {
-    "outcome": "inconclusive",
+    "outcome": "infra-inconclusive",
     "evaluator": "replace-with-evaluator",
     "summary": "This fixture demonstrates the contract and is not a real host run.",
     "evidenceRefs": ["redacted-transcript", "filesystem-diff"]

--- a/evals/run.schema.json
+++ b/evals/run.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:harnessmith:eval-run:v4",
+  "$id": "urn:harnessmith:eval-run:v5",
   "title": "Harnessmith maintainer-attested host evaluation run",
   "type": "object",
   "required": [
@@ -13,6 +13,7 @@
     "startedAt",
     "finishedAt",
     "evaluatedAt",
+    "execution",
     "transcript",
     "toolActions",
     "filesystemDiff",
@@ -22,7 +23,7 @@
     "evidence"
   ],
   "properties": {
-    "schemaVersion": { "const": 4 },
+    "schemaVersion": { "const": 5 },
     "recordType": { "enum": ["host-evaluation", "example-only"] },
     "runId": { "$ref": "#/$defs/id" },
     "scenarioId": { "$ref": "#/$defs/id" },
@@ -59,6 +60,46 @@
     "startedAt": { "$ref": "#/$defs/timestamp" },
     "finishedAt": { "$ref": "#/$defs/timestamp" },
     "evaluatedAt": { "$ref": "#/$defs/timestamp" },
+    "execution": {
+      "type": "object",
+      "required": [
+        "tier",
+        "attempt",
+        "maxAttempts",
+        "scenarioBudgetMs",
+        "matrixBudgetMs",
+        "elapsedMs",
+        "transportFailures",
+        "termination"
+      ],
+      "properties": {
+        "tier": { "enum": ["L2", "L3", "L4"] },
+        "attempt": { "type": "integer", "minimum": 1, "maximum": 2 },
+        "maxAttempts": { "const": 2 },
+        "scenarioBudgetMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 900000
+        },
+        "matrixBudgetMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3600000
+        },
+        "elapsedMs": { "type": "integer", "minimum": 0, "maximum": 900000 },
+        "transportFailures": { "type": "integer", "minimum": 0, "maximum": 2 },
+        "termination": {
+          "enum": [
+            "completed",
+            "transport-failure",
+            "scenario-budget-exhausted",
+            "circuit-open",
+            "evaluator-failure"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "transcript": {
       "type": "object",
       "required": ["artifactRef", "sha256", "redacted"],
@@ -150,7 +191,14 @@
       "type": "object",
       "required": ["outcome", "evaluator", "summary", "evidenceRefs"],
       "properties": {
-        "outcome": { "enum": ["passed", "failed", "inconclusive"] },
+        "outcome": {
+          "enum": [
+            "passed",
+            "behavior-failed",
+            "infra-inconclusive",
+            "evaluator-failed"
+          ]
+        },
         "evaluator": { "type": "string", "minLength": 1 },
         "summary": { "type": "string", "minLength": 1 },
         "evidenceRefs": {

--- a/scripts/eval-artifacts.ts
+++ b/scripts/eval-artifacts.ts
@@ -26,6 +26,21 @@ export type RunRecord = {
   startedAt: string;
   finishedAt: string;
   evaluatedAt: string;
+  execution: {
+    tier: 'L2' | 'L3' | 'L4';
+    attempt: number;
+    maxAttempts: 2;
+    scenarioBudgetMs: number;
+    matrixBudgetMs: number;
+    elapsedMs: number;
+    transportFailures: number;
+    termination:
+      | 'completed'
+      | 'transport-failure'
+      | 'scenario-budget-exhausted'
+      | 'circuit-open'
+      | 'evaluator-failure';
+  };
   transcript: Artifact;
   toolActions: Array<{ sequence: number }>;
   filesystemDiff: Artifact & { changedPaths: string[]; clean: boolean };
@@ -42,7 +57,10 @@ export type RunRecord = {
     passed: boolean;
     evidenceRefs: string[];
   }>;
-  verdict: { outcome: 'passed' | 'failed' | 'inconclusive'; evidenceRefs: string[] };
+  verdict: {
+    outcome: 'passed' | 'behavior-failed' | 'infra-inconclusive' | 'evaluator-failed';
+    evidenceRefs: string[];
+  };
 };
 
 export function createArtifactVerificationBudget(): ArtifactVerificationBudget {

--- a/scripts/eval-execution-contract.ts
+++ b/scripts/eval-execution-contract.ts
@@ -1,0 +1,42 @@
+import { relative } from 'node:path';
+import type { RunRecord } from './eval-artifacts.js';
+import { repositoryRoot } from './eval-fingerprint.js';
+
+export function verifyExecutionClassification(path: string, record: RunRecord): void {
+  const label = relative(repositoryRoot, path);
+  const { execution, verdict } = record;
+  if (execution.attempt > execution.maxAttempts) {
+    throw new Error(`${label} execution attempt exceeds maxAttempts`);
+  }
+  if (execution.elapsedMs > execution.scenarioBudgetMs) {
+    throw new Error(`${label} execution elapsedMs exceeds scenarioBudgetMs`);
+  }
+  if (execution.scenarioBudgetMs > execution.matrixBudgetMs) {
+    throw new Error(`${label} scenarioBudgetMs exceeds matrixBudgetMs`);
+  }
+  if (execution.transportFailures > execution.attempt) {
+    throw new Error(`${label} transportFailures exceeds completed attempts`);
+  }
+  const infrastructureTermination = new Set([
+    'transport-failure',
+    'scenario-budget-exhausted',
+    'circuit-open',
+  ]);
+  if (infrastructureTermination.has(execution.termination)) {
+    if (verdict.outcome !== 'infra-inconclusive') {
+      throw new Error(`${label} ${execution.termination} must be infra-inconclusive`);
+    }
+  } else if (execution.termination === 'evaluator-failure') {
+    if (verdict.outcome !== 'evaluator-failed') {
+      throw new Error(`${label} evaluator-failure must be evaluator-failed`);
+    }
+  } else if (!['passed', 'behavior-failed'].includes(verdict.outcome)) {
+    throw new Error(`${label} completed execution must be passed or behavior-failed`);
+  }
+  if (
+    execution.termination === 'circuit-open' &&
+    (execution.attempt !== 2 || execution.transportFailures !== 2)
+  ) {
+    throw new Error(`${label} circuit-open requires two attempts and two transport failures`);
+  }
+}

--- a/scripts/eval-records.ts
+++ b/scripts/eval-records.ts
@@ -8,6 +8,7 @@ import {
   verifyHighConfidenceSecretRedaction,
   verifyRunArtifacts,
 } from './eval-artifacts.js';
+import { verifyExecutionClassification } from './eval-execution-contract.js';
 import { evaluationScenarioFingerprints, repositoryRoot } from './eval-fingerprint.js';
 
 export type VerifiedRun = { path: string; record: RunRecord };
@@ -180,6 +181,7 @@ export function validateEvaluationRecords(options: EvaluationRecordOptions = {})
     if (record.filesystemDiff.clean !== (record.filesystemDiff.changedPaths.length === 0)) {
       throw new Error('filesystemDiff clean flag conflicts with changedPaths');
     }
+    verifyExecutionClassification(path, record);
     verifyRunArtifacts(path, record, artifactBudget);
     verified.push({ path, record });
   }

--- a/src/__tests__/docs-site.test.ts
+++ b/src/__tests__/docs-site.test.ts
@@ -236,6 +236,24 @@ test('release documentation distinguishes post-publish registry clean-room evide
   assert.match(contributing, /registry clean-room/i);
 });
 
+test('Host Eval documentation exposes bounded execution and explicit failure classes', () => {
+  const evaluation = read('docs/concepts/evidence-and-evaluation.md');
+  const evalReadme = read('evals/README.md');
+  const capabilities = read('docs/capability-evidence.yaml');
+
+  for (const content of [evaluation, evalReadme]) {
+    assert.match(content, /behavior-failed/);
+    assert.match(content, /infra-inconclusive/);
+    assert.match(content, /evaluator-failed/);
+    assert.match(content, /15 分钟|15-minute/);
+    assert.match(content, /60 分钟|60-minute/);
+    assert.match(content, /重试一次|retry once/);
+  }
+  assert.match(capabilities, /id: bounded-host-eval-record-contract/);
+  assert.match(capabilities, /evals\/run\.schema\.json/);
+  assert.match(capabilities, /evals\/__tests__\/run-gate\.test\.ts/);
+});
+
 test('cross-repository relationships remain a first-class public capability', () => {
   const readme = read('README.md');
   const english = read('README.en.md');


### PR DESCRIPTION
## Summary / 变更说明

- Add the Host Eval run schema v5 execution contract.
- Distinguish `behavior-failed`, `infra-inconclusive`, and `evaluator-failed` without weakening the existing gate.
- Enforce at most two attempts, a 15-minute scenario budget, a 60-minute matrix budget, and termination/outcome consistency.
- Document that incremental selection, bounded parallel scheduling, and real circuit-break execution remain later #44 phases.

## Related Issue / 关联 Issue

Closes #52

Parent roadmap: #44

## Verification / 验证

- `pnpm exec vitest run evals/__tests__` — 104 passed.
- `pnpm run preflight` — 670 checks; 762 passed, 3 skipped.
- `pnpm run test:coverage` — all configured thresholds passed.
- `npm pack --dry-run --ignore-scripts` with an isolated npm cache — 70 files.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

This is the evidence-contract foundation for #44. A real RC drill is still required before the parent issue can be closed.
