### PR TITLE
fix(eval): harden Codex L3 release blockers

### DIFF
--- a/evals/__tests__/eval-codex-matrix.test.ts
+++ b/evals/__tests__/eval-codex-matrix.test.ts
@@ -4,6 +4,7 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  realpathSync,
   readdirSync,
   readFileSync,
   symlinkSync,
@@ -252,6 +253,27 @@ test.skipIf(process.platform === 'win32')(
 
     assert.equal(typeof support.sameCanonicalPath, 'function');
     assert.equal(support.sameCanonicalPath(alias, target), true);
+  },
+);
+
+test.skipIf(process.platform === 'win32')(
+  'task temp payload inspection accepts canonical aliases without widening its boundary',
+  async () => {
+    const directory = temporaryDirectory();
+    const payload = join(directory, 'payload.json');
+    writeFileSync(payload, '{}\n');
+    const support = await import(
+      // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
+      '../../scripts/eval-codex-matrix-support.mjs'
+    );
+    const canonicalPayload = join(realpathSync.native(directory), 'payload.json');
+
+    assert.equal(support.canonicalPathWithin(canonicalPayload, directory), true);
+    assert.equal(support.inspectJsonPayloadPath(canonicalPayload, directory).ok, true);
+    assert.equal(
+      support.canonicalPathWithin(join(dirname(directory), 'outside.json'), directory),
+      false,
+    );
   },
 );
 

--- a/evals/__tests__/eval-codex-matrix.test.ts
+++ b/evals/__tests__/eval-codex-matrix.test.ts
@@ -132,6 +132,33 @@ test('matrix run schedules the complete catalog through the bounded runner', asy
   assert.ok(result.results.every(({ outcome }) => outcome === 'passed'));
 });
 
+test('repository-map scenario grants the exact personal-map write without source-write authority', () => {
+  const scenario = worktreeScenarioCatalog(repositoryRoot).scenarios.find(
+    ({ id }) => id === 'cross-repository-map-writeback',
+  );
+  assert.ok(scenario);
+  assert.match(scenario.prompt, /update the personal repository map/i);
+  assert.match(scenario.prompt, /do not modify repository source files/i);
+});
+
+test('structured Codex capacity failures remain retryable transport failures', async () => {
+  const support = await import(
+    // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
+    '../../scripts/eval-codex-matrix-support.mjs'
+  );
+  const completion = support.evaluateCodexTurnCompletion({
+    status: 1,
+    signal: null,
+    error: 'evaluator-failure:host-exit',
+    stderr: '',
+    stdout:
+      '{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}\n',
+  });
+
+  assert.equal(completion.completed, false);
+  assert.equal(completion.transportFailure, true);
+});
+
 test('scenario fixture binds the supplied candidate and prepares without launching Codex', () => {
   const directory = temporaryDirectory();
   const artifact = join(directory, 'candidate.tgz');

--- a/evals/__tests__/eval-codex-matrix.test.ts
+++ b/evals/__tests__/eval-codex-matrix.test.ts
@@ -245,6 +245,7 @@ test.skipIf(process.platform === 'win32')(
     const target = join(directory, 'target');
     const alias = join(directory, 'alias');
     mkdirSync(target);
+    writeFileSync(join(target, 'harness.mjs'), '');
     symlinkSync(target, alias, 'dir');
     const support = await import(
       // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
@@ -253,6 +254,16 @@ test.skipIf(process.platform === 'win32')(
 
     assert.equal(typeof support.sameCanonicalPath, 'function');
     assert.equal(support.sameCanonicalPath(alias, target), true);
+    assert.equal(
+      support.memoryPayloadCommandHasExpectedPrefix({
+        commandTokens: [process.execPath, join(alias, 'harness.mjs')],
+        harnessIndex: 1,
+        nodePath: process.execPath,
+        harnessPath: join(target, 'harness.mjs'),
+        repo: directory,
+      }),
+      true,
+    );
   },
 );
 

--- a/evals/__tests__/eval-codex-matrix.test.ts
+++ b/evals/__tests__/eval-codex-matrix.test.ts
@@ -6,9 +6,10 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { delimiter, join } from 'node:path';
+import { delimiter, dirname, join, relative } from 'node:path';
 import { test } from 'vitest';
 
 import { repositoryRoot } from '../../scripts/eval-fingerprint.js';
@@ -169,6 +170,63 @@ test('scenario fixture binds the supplied candidate and prepares without launchi
   assert.equal(fixture.scenarioId, 'machine-error-contract');
   assert.match(fixture.context, /unmanaged/i);
 });
+
+test('multi-turn fixtures keep payloads in the workspace and mount lock-bearing parent roots', () => {
+  const directory = temporaryDirectory();
+  const artifact = join(directory, 'candidate.tgz');
+  const codexHome = join(directory, 'codex-home');
+  mkdirSync(codexHome);
+  writeFileSync(join(codexHome, 'auth.json'), '{}\n');
+  writeCandidateTarball(artifact, repositoryRoot);
+
+  const prepare = (scenarioId: string) => {
+    const result = spawnSync(process.execPath, ['--import', 'tsx', scenarioEntry, scenarioId], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+      maxBuffer: 2 * 1024 * 1024,
+      env: {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        HARNESS_RELEASE_ARTIFACT: artifact,
+        HARNESS_EVAL_OUTPUT_DIR: join(directory, 'runs'),
+        HARNESS_EVAL_MODEL: 'gpt-5.6-sol',
+        HARNESS_EVAL_ATTEMPT: '1',
+        HARNESS_EVAL_MAX_ATTEMPTS: '2',
+        HARNESS_EVAL_SCENARIO_BUDGET_MS: '900000',
+        HARNESS_EVAL_MATRIX_BUDGET_MS: '3600000',
+        HARNESS_EVAL_FIXTURE_ONLY: '1',
+      },
+    });
+    assert.equal(result.status, 0, `${scenarioId}: ${result.stderr}`);
+    return JSON.parse(result.stdout);
+  };
+
+  const autopilot = prepare('memory-autopilot-unprompted');
+  assert.ok(!relative(autopilot.repo, autopilot.temp).startsWith('..'));
+  assert.ok(autopilot.hostArgs.includes(dirname(autopilot.memory)));
+
+  const repositoryMap = prepare('cross-repository-map-writeback');
+  assert.ok(repositoryMap.hostArgs.includes(dirname(repositoryMap.personal)));
+});
+
+test.skipIf(process.platform === 'win32')(
+  'evaluator path identity accepts symlink aliases of the same existing path',
+  async () => {
+    const directory = temporaryDirectory();
+    const target = join(directory, 'target');
+    const alias = join(directory, 'alias');
+    mkdirSync(target);
+    symlinkSync(target, alias, 'dir');
+    const support = await import(
+      // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
+      '../../scripts/eval-codex-matrix-support.mjs'
+    );
+
+    assert.equal(typeof support.sameCanonicalPath, 'function');
+    assert.equal(support.sameCanonicalPath(alias, target), true);
+  },
+);
 
 test.skipIf(coverageInstrumentation)(
   'all 15 catalog scenarios prepare disposable fixtures without launching Codex',

--- a/evals/scenarios.json
+++ b/evals/scenarios.json
@@ -368,7 +368,7 @@
         "template/agent-harness/src/lib/repository-map.ts",
         "template/agent-harness/src/program/repository-map.ts"
       ],
-      "prompt": "Analyze several repositories and identify their stable contracts and dependencies. Do not modify repository source files.",
+      "prompt": "Analyze several repositories and identify their stable contracts and dependencies. Update the personal repository map with verified stable relationships and its generated view. Do not modify repository source files.",
       "setup": [
         "Provide multiple repositories with code-backed dependency relationships plus volatile branch, dirty-worktree, and migration-state details.",
         "Initialize a personal repository map containing one existing relationship."

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -26,6 +26,14 @@ export function withEphemeralJsonPayload(path, payload, invoke) {
   }
 }
 
+export function sameCanonicalPath(left, right) {
+  try {
+    return realpathSync.native(resolve(left)) === realpathSync.native(resolve(right));
+  } catch {
+    return resolve(left) === resolve(right);
+  }
+}
+
 export function buildCodexTurn({
   threadId,
   model,

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -411,7 +411,7 @@ export function memoryPayloadCommandHasExpectedPrefix({
   const invokedHarness = isAbsolute(commandTokens[1])
     ? resolve(commandTokens[1])
     : resolve(repo, commandTokens[1]);
-  return invokedHarness === resolve(harnessPath);
+  return sameCanonicalPath(invokedHarness, harnessPath);
 }
 
 export function exactCloseHandoffCommandTokens(command, options) {

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -286,10 +286,16 @@ export function evaluateCodexTurnCompletion(result, { requireAgentCompletion = t
       typeof event.item.text === 'string',
   );
   const transportText = `${result?.error ?? ''}\n${result?.stderr ?? ''}\n${result?.stdout ?? ''}`;
+  const transientHostFailure = events.some(
+    (event) =>
+      event?.type === 'turn.failed' &&
+      /selected model is at capacity/i.test(String(event?.error?.message ?? '')),
+  );
   const transportFailure =
-    /ETIMEDOUT|timed? out|ENOTFOUND|EAI_AGAIN|ECONN(?:RESET|REFUSED)|DNS|network is unreachable|stream disconnected|connection (?:closed|lost)/i.test(
-      transportText,
-    ) &&
+    (transientHostFailure ||
+      /ETIMEDOUT|timed? out|ENOTFOUND|EAI_AGAIN|ECONN(?:RESET|REFUSED)|DNS|network is unreachable|stream disconnected|connection (?:closed|lost)/i.test(
+        transportText,
+      )) &&
     (!hasTurnCompleted || (requireAgentCompletion && !hasAgentCompletion));
   const reasons = [];
   if (result?.status !== 0) reasons.push(`status=${String(result?.status)}`);

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -1526,13 +1526,21 @@ function pathWithin(path, root) {
   return relation === '' || (!relation.startsWith(`..${sep}`) && relation !== '..' && !isAbsolute(relation));
 }
 
+export function canonicalPathWithin(path, root) {
+  try {
+    return pathWithin(realpathSync.native(resolve(path)), realpathSync.native(resolve(root)));
+  } catch {
+    return pathWithin(path, root);
+  }
+}
+
 export function inspectJsonPayloadPath(path, root) {
   const resolvedPath = resolve(path);
   const resolvedRoot = resolve(root);
   if (!resolvedPath.endsWith('.json')) {
     return { ok: false, resolvedPath, error: 'payload path must end in .json' };
   }
-  if (!pathWithin(resolvedPath, resolvedRoot)) {
+  if (!canonicalPathWithin(resolvedPath, resolvedRoot)) {
     return { ok: false, resolvedPath, error: 'payload path is outside the task temp root' };
   }
   try {
@@ -1540,8 +1548,13 @@ export function inspectJsonPayloadPath(path, root) {
     if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
       return { ok: false, resolvedPath, error: 'task temp root is not a regular directory' };
     }
-    const relativePath = relative(resolvedRoot, resolvedPath);
-    let current = resolvedRoot;
+    const realRoot = realpathSync.native(resolvedRoot);
+    const realPath = realpathSync.native(resolvedPath);
+    if (!pathWithin(resolvedPath, resolvedRoot) && resolvedPath !== realPath) {
+      return { ok: false, resolvedPath, error: 'payload path contains a symlink component' };
+    }
+    const relativePath = relative(realRoot, realPath);
+    let current = realRoot;
     for (const segment of relativePath.split(sep).filter(Boolean)) {
       current = resolve(current, segment);
       if (lstatSync(current).isSymbolicLink()) {
@@ -1552,8 +1565,6 @@ export function inspectJsonPayloadPath(path, root) {
     if (!entry.isFile() || entry.isSymbolicLink()) {
       return { ok: false, resolvedPath, error: 'payload is not a regular non-symlink file' };
     }
-    const realRoot = realpathSync(resolvedRoot);
-    const realPath = realpathSync(resolvedPath);
     if (!pathWithin(realPath, realRoot)) {
       return { ok: false, resolvedPath, error: 'payload real path escapes the task temp root' };
     }

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -59,6 +59,7 @@ import {
   pureSignalResponseComplies,
   remoteToolViolatesWriteBoundary,
   responseSeparatesAssessmentFromAction,
+  sameCanonicalPath,
   sanitizeAndBoundArtifact,
   scenarioTurnPlan,
   selectSingleSuccessfulMemoryPayloadInvocation,
@@ -125,9 +126,9 @@ const runId = `${host}-${scenarioId}-${stamp}-${randomUUID().slice(0, 8)}`;
 const runRoot = join(tmpdir(), `harnessmith-codex-scenario-${randomUUID()}`);
 const repo = join(runRoot, 'repo');
 const home = join(runRoot, 'home');
-const memory = join(runRoot, 'memory');
-const personal = join(runRoot, 'personal');
-const temp = join(runRoot, 'tmp');
+const memory = join(runRoot, 'global-memory', 'memory');
+const personal = join(runRoot, 'personal-data', 'personal');
+const temp = join(repo, '.harness-eval-tmp');
 const packageRoot = join(runRoot, 'candidate');
 const outerBin = join(packageRoot, 'bin', 'harnessmith.mjs');
 const recordDir = join(outputRoot, runId);
@@ -405,6 +406,7 @@ function setupBase() {
       : '# Disposable Harness Host Evaluation\n\nRead `EVAL_CONTEXT.md` first.\n',
   );
   write(join(repo, 'package.json'), '{"name":"host-eval","private":true,"type":"module"}\n');
+  write(join(repo, '.gitignore'), '.harness-eval-tmp/\n');
   if (
     memoryAutopilotScenarios.has(scenarioId) ||
     scenarioId === 'project-memory-recall-writeback'
@@ -746,9 +748,9 @@ function hostCommand(threadId, persistent, configOverrides = []) {
       repo,
       writable,
       additionalDirs: [
-        ...(scenarioId === 'cross-repository-map-writeback' ? [personal] : []),
+        ...(scenarioId === 'cross-repository-map-writeback' ? [dirname(personal)] : []),
         ...(['memory-autopilot-unprompted', 'memory-profile-cross-task-recall'].includes(scenarioId)
-          ? [memory]
+          ? [dirname(memory)]
           : []),
       ],
       configOverrides,
@@ -973,6 +975,10 @@ if (process.env.HARNESS_EVAL_FIXTURE_ONLY === '1') {
       verifierDigests: Object.fromEntries(verifierDigests),
       profileDigest: fileDigest(join(memory, 'profile.md')),
       trackedStatus: status(),
+      memory,
+      personal,
+      temp,
+      hostArgs: hostCommand(null, false).args,
   };
   rmSync(runRoot, { recursive: true, force: true });
   console.log(JSON.stringify(fixture));
@@ -1594,6 +1600,7 @@ observationArtifact.memoryPayloadInvocations = memoryPayloadInvocations.map((ite
 }));
 const allowedAutopilotProjectPaths = [
   ...allowedAutopilotSourcePaths,
+  `${relative(repo, temp).split(sep).join('/')}/**`,
   ...(
     ['memory-autopilot-unprompted', 'memory-autopilot-phase-only', 'memory-autopilot-multi-task'].includes(
       scenarioId,
@@ -1864,7 +1871,7 @@ if (scenarioId === 'project-memory-recall-writeback') {
       !tokens ||
       tokens.length < 4 ||
       basename(tokens[0]) !== 'node' ||
-      resolve(tokens[1]) !== resolve(harnessBin())
+      !sameCanonicalPath(tokens[1], harnessBin())
     ) {
       return null;
     }
@@ -1877,7 +1884,7 @@ if (scenarioId === 'project-memory-recall-writeback') {
     const segments = commandReadSegments(item.command);
     return Boolean(
       segments.some((tokens) =>
-        tokens.slice(1).some((token) => resolve(repo, token) === resolve(path)),
+        tokens.slice(1).some((token) => sameCanonicalPath(resolve(repo, token), path)),
       ) &&
         item.aggregatedOutput.includes(marker),
     );

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -5,6 +5,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readlinkSync,
   readdirSync,
   rmSync,
@@ -18,6 +19,7 @@ import { readNpmPackageTarball } from './npm-tarball.js';
 import { runBoundedHostProcess } from './eval-codex-transport.ts';
 import {
   buildCodexTurn,
+  canonicalPathWithin,
   classifyBoundaryCommand,
   checkpointIdempotencyIsProven,
   containsApiWorkerBoundary,
@@ -1536,8 +1538,8 @@ for (const turn of turnResults) {
       for (const change of Array.isArray(item.changes) ? item.changes : []) {
         const rawPath = String(change?.path ?? '');
         const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(repo, rawPath);
-        const relativePath = pathWithin(absolutePath, repo)
-          ? relative(repo, absolutePath).split(sep).join('/')
+        const relativePath = canonicalPathWithin(absolutePath, repo)
+          ? relative(realpathSync.native(repo), realpathSync.native(absolutePath)).split(sep).join('/')
           : null;
         const changeKind = String(change?.kind ?? change?.action ?? change?.type ?? '').toLowerCase();
         const allowedPath =
@@ -1548,7 +1550,7 @@ for (const turn of turnResults) {
                 relativePath === '.agent-docs' ||
                 relativePath.startsWith('.agent-docs/'))) ||
               absolutePath === resolve(memory, 'profile.md') ||
-              (pathWithin(absolutePath, temp) && absolutePath.endsWith('.json')),
+              (canonicalPathWithin(absolutePath, temp) && absolutePath.endsWith('.json')),
           );
         if (!allowedPath || !['add', 'create', 'update'].includes(changeKind)) {
           boundaryViolations.push(

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -1119,9 +1119,12 @@ function captureMemoryPayloadEvidence(stdout, turnLabel) {
           (['capture-input', 'handoff'].includes(action) &&
             commandTokens.length === 8 &&
             payloadIndexes[0] === 5 &&
-            (isAbsolute(commandTokens[4])
-              ? resolve(commandTokens[4])
-              : resolve(repo, commandTokens[4])) === repo)),
+            sameCanonicalPath(
+              isAbsolute(commandTokens[4])
+                ? resolve(commandTokens[4])
+                : resolve(repo, commandTokens[4]),
+              repo,
+            ))),
     );
     const payloadState = payloadInspection.ok
       ? safeReadFile(resolvedPayloadPath, 1024 * 1024)
@@ -2332,14 +2335,21 @@ if (scenarioId === 'memory-autopilot-unprompted') {
           tokens &&
           tokens.length === 8 &&
           (tokens[0] === nodeBin || tokens[0] === 'node') &&
-          (isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1])) ===
-            harnessBin() &&
+          sameCanonicalPath(
+            isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1]),
+            harnessBin(),
+          ) &&
           tokens[2] === 'memory' &&
           tokens[3] === 'handoff' &&
-          (isAbsolute(tokens[4]) ? resolve(tokens[4]) : resolve(repo, tokens[4])) === repo &&
+          sameCanonicalPath(
+            isAbsolute(tokens[4]) ? resolve(tokens[4]) : resolve(repo, tokens[4]),
+            repo,
+          ) &&
           tokens[5] === '--payload-file' &&
-          (isAbsolute(tokens[6]) ? resolve(tokens[6]) : resolve(repo, tokens[6])) ===
-            item.resolvedPayloadPath &&
+          sameCanonicalPath(
+            isAbsolute(tokens[6]) ? resolve(tokens[6]) : resolve(repo, tokens[6]),
+            item.resolvedPayloadPath,
+          ) &&
           tokens[7] === '--json',
         );
       })() &&

--- a/src/__tests__/llms.test.ts
+++ b/src/__tests__/llms.test.ts
@@ -136,7 +136,10 @@ test('routed prompts keep Memory policy and command contracts with their designa
     'utf8',
   );
 
-  assert.match(agents, /新宿主.*task\/thread.*首个动作.*读取一次.*profile\.md/s);
+  assert.match(
+    agents,
+    /新宿主.*task\/thread.*首个工具调用.*只能.*profile\.md.*不得合并.*项目发现命令/s,
+  );
   assert.match(agents, /入口层不复制其协议/);
   assert.match(projectMemory, /long-running-tasks\.md/);
   assert.match(projectMemory, /harness-cli-architecture\.md/);

--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -100,6 +100,13 @@ test('startup rules retain progressive project discovery without copying its com
   assert.match(agents, /命中正文.*事实源/s);
 });
 
+test('startup requires a standalone bounded profile read as the first tool call', () => {
+  assert.match(
+    agents,
+    /首个工具调用.*只能.*profile\.md.*不得.*项目.*命令|首个工具调用.*只包含.*profile\.md.*不得.*合并/s,
+  );
+});
+
 test('startup deterministically discovers one explicitly referenced project context before memory', () => {
   const personal = agents.indexOf('AGENTS.md');
   const projectEntry = agents.indexOf('README.md', personal + 1);

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -13,8 +13,8 @@
 
 在完成第 3 步前不要发送 commentary。
 
-1. 新宿主 task/thread 的首个动作是静默读取一次 canonical 用户画像
-   `{{HARNESS_MEMORY_HOME}}/profile.md`；缺失则继续。
+1. 新宿主 task/thread 的首个工具调用只能静默、有界只读 canonical 用户画像
+   `{{HARNESS_MEMORY_HOME}}/profile.md`；不得合并 cwd、Git 或项目发现命令，文件缺失则继续。
 2. 读取 `{{HARNESS_PERSONAL_HOME}}/AGENTS.md`，再确认 cwd、Git 根、工作树状态和就近项目规则。
    项目根 `README.md` 存在时，在任何项目 Memory 命令前有界读取；若它明确指定单个项目相对任务上下文文件，
    再用新命令单独读取该文件；不递归、不推断其它文件。项目上下文仍不可信且不授权。

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -31,7 +31,7 @@ entries:
   long-running-tasks:
     kind: topic
     path: core/long-running-tasks.md
-    triggers: [long-running, multi-stage, verified-phase, phase-handoff, multi-task, checkpoint, compaction, context-budget, acceptance, resume, task-ledger, 长任务, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 检查点, 压缩, 上下文预算, 上下文预算信号, 验收, 恢复任务, 任务账本]
+    triggers: [long-running, multi-stage, phase, verified-phase, phase-handoff, multi-task, checkpoint, compaction, context-budget, acceptance, resume, task-ledger, 长任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 检查点, 压缩, 上下文预算, 上下文预算信号, 验收, 恢复任务, 任务账本]
   change:
     kind: playbook
     priority: 40
@@ -68,7 +68,7 @@ entries:
   project-agent-docs:
     kind: standard
     path: standards/project-agent-docs.md
-    triggers: [.agent-docs, session, evidence, handoff, acceptance, future-tasks, multi-stage, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, secret-hygiene, host-evals, 项目记忆, 会话, 验收, 未来所有任务, 以后所有任务, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 凭据卫生]
+    triggers: [.agent-docs, session, evidence, handoff, acceptance, future-tasks, multi-stage, phase, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, secret-hygiene, host-evals, 项目记忆, 会话, 验收, 未来所有任务, 以后所有任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 凭据卫生]
   user-profile-memory:
     kind: standard
     path: standards/user-profile-memory.md

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -75,6 +75,7 @@ test.each(['创建分支', '给我创建一个分支名', '请检查这个提交
 
 test.each([
   'multi-stage task with verified phase',
+  'Change docs/phase-a.txt from pending to ready and run node verify-phase.mjs docs/phase-a.txt.',
   'context budget compaction',
   '多阶段任务，阶段已验证仍有后续',
   '上下文预算信号',


### PR DESCRIPTION
## Summary / 变更说明

- Mount dedicated disposable parents for lock-bearing global Memory and repository-map roots.
- Keep multi-turn JSON payloads inside an ignored workspace-scoped task temp boundary.
- Compare evaluator paths and Harness command paths by canonical filesystem identity on macOS.
- Require a standalone profile-first tool call and route phase-style requests to handoff guidance.
- Treat structured Codex model-capacity failures as retryable transport failures.
- Grant the repository-map scenario only the explicit personal-map write authority it needs.

## Related Issue / 关联 Issue

Closes #68


## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix.test.ts`: 14 passed.
- `pnpm run preflight`: 676 checks passed; 825 unit tests passed, 3 skipped.
- Exact-candidate targeted canaries passed for `cross-repository-map-writeback`, `project-memory-recall-writeback`, `memory-autopilot-phase-only`, and `memory-profile-cross-task-recall`.
- Remaining transport-inconclusive canaries are release-gate evidence work and do not weaken evaluator assertions.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The release workflow will run the complete 15-scenario L3 matrix against the final exact `0.9.0` candidate after this PR merges.
