### PR TITLE
fix(eval): harden resumed Codex L3 turns

### DIFF
--- a/evals/__tests__/eval-codex-matrix-support.test.ts
+++ b/evals/__tests__/eval-codex-matrix-support.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+async function support() {
+  return import(
+    // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
+    '../../scripts/eval-codex-matrix-support.mjs'
+  );
+}
+
+test('resumed Codex turns retain their additional writable roots through config', async () => {
+  const { buildCodexTurn } = await support();
+  const args = buildCodexTurn({
+    threadId: '01900000-0000-7000-8000-000000000001',
+    model: 'gpt-5.6-sol',
+    repo: '/tmp/repo',
+    writable: true,
+    additionalDirs: ['/tmp/global-memory', '/tmp/personal-data'],
+  });
+
+  assert.deepEqual(args.slice(0, 3), ['exec', 'resume', '--json']);
+  assert.ok(args.includes('sandbox_mode="workspace-write"'));
+  assert.ok(
+    args.includes(
+      'sandbox_workspace_write.writable_roots=["/tmp/global-memory","/tmp/personal-data"]',
+    ),
+  );
+});
+
+test('verified API Worker boundary accepts equivalent assertions but rejects stale claims', async () => {
+  const { containsApiWorkerBoundary } = await support();
+
+  assert.equal(
+    containsApiWorkerBoundary(
+      '当前架构边界已核实为 `API -> Worker`；`LegacyWorker` 已不再使用。依据是当前事实源。',
+    ),
+    true,
+  );
+  assert.equal(containsApiWorkerBoundary('当前架构边界已核实为 API -> LegacyWorker。'), false);
+  assert.equal(containsApiWorkerBoundary('历史结论：当前架构边界已核实为 API -> Worker。'), false);
+  assert.equal(containsApiWorkerBoundary('API -> Worker 已不再是当前边界。'), false);
+});
+
+test('checkpoint idempotency accepts only state-proven unobserved replay', async () => {
+  const { checkpointIdempotencyIsProven } = await support();
+  const baseline = {
+    followCommandExact: true,
+    repeatedCommandExact: true,
+    samePayloadPath: true,
+    samePayloadSha: true,
+    followOutput: {
+      version: 1,
+      action: 'updated',
+      kind: 'episode',
+      path: '/memory.md',
+      reference: 'memory:sessions/x',
+    },
+    followOutputObserved: true,
+    repeatedOutput: null,
+    repeatedOutputObserved: false,
+    expectedPath: '/memory.md',
+    expectedReference: 'memory:sessions/x',
+    preToFollowChanged: true,
+    followToRepeatUnchanged: true,
+    projectDigestUnchanged: true,
+  };
+
+  assert.equal(checkpointIdempotencyIsProven(baseline), true);
+  assert.equal(checkpointIdempotencyIsProven({ ...baseline, repeatedOutputObserved: true }), false);
+  assert.equal(
+    checkpointIdempotencyIsProven({ ...baseline, followToRepeatUnchanged: false }),
+    false,
+  );
+});

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -44,6 +44,16 @@ export function buildCodexTurn({
   ephemeral = false,
 }) {
   if (threadId) {
+    const resumeSandboxOverrides = writable
+      ? [
+          'sandbox_mode="workspace-write"',
+          ...(additionalDirs.length > 0
+            ? [
+                `sandbox_workspace_write.writable_roots=${JSON.stringify(additionalDirs)}`,
+              ]
+            : []),
+        ]
+      : ['sandbox_mode="read-only"'];
     return [
       'exec',
       'resume',
@@ -51,6 +61,7 @@ export function buildCodexTurn({
       '--model',
       model,
       ...configOverrides.flatMap((value) => ['-c', value]),
+      ...resumeSandboxOverrides.flatMap((value) => ['-c', value]),
       threadId,
       '-',
     ];
@@ -1133,6 +1144,7 @@ export function checkpointIdempotencyIsProven({
   followOutput,
   followOutputObserved,
   repeatedOutput,
+  repeatedOutputObserved,
   expectedPath,
   expectedReference,
   preToFollowChanged,
@@ -1141,6 +1153,8 @@ export function checkpointIdempotencyIsProven({
 }) {
   const parsedFollowOutputObserved = Boolean(followOutput);
   if (Boolean(followOutputObserved) !== parsedFollowOutputObserved) return false;
+  const parsedRepeatedOutputObserved = Boolean(repeatedOutput);
+  if (Boolean(repeatedOutputObserved) !== parsedRepeatedOutputObserved) return false;
   const followOutputCompatible = memoryPayloadOutputIsCompatible(followOutput, {
     kind: 'episode',
     actions: ['created', 'updated'],
@@ -1149,13 +1163,15 @@ export function checkpointIdempotencyIsProven({
   const followIdentityCompatible =
     !followOutputObserved ||
     (followOutput?.path === expectedPath && followOutput?.reference === expectedReference);
-  const repeatedOutputCompatible = Boolean(
-    repeatedOutput?.version === 1 &&
-      repeatedOutput?.action === 'unchanged' &&
-      repeatedOutput?.kind === 'episode' &&
-      repeatedOutput?.path === expectedPath &&
-      repeatedOutput?.reference === expectedReference,
-  );
+  const repeatedOutputCompatible = repeatedOutputObserved
+    ? Boolean(
+        repeatedOutput?.version === 1 &&
+          repeatedOutput?.action === 'unchanged' &&
+          repeatedOutput?.kind === 'episode' &&
+          repeatedOutput?.path === expectedPath &&
+          repeatedOutput?.reference === expectedReference,
+      )
+    : repeatedOutput == null;
   return Boolean(
     followCommandExact &&
       repeatedCommandExact &&
@@ -1369,7 +1385,7 @@ export function containsApiWorkerBoundary(content) {
       .filter(Boolean);
   });
   const assertion =
-    /^(?:(?:verified(?:\s+stable)?\s+(?:fact|statement)|已验证(?:稳定)?事实)\s*[:：]\s*)?(?:(?:the\s+)?(?:(?:verified|current)\s+)*(?:service\s+)?boundary\s*(?:is|:)\s*(?:(?:now|currently)\s+)?API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*)|(?:(?:已验证|当前|目前)\s*)*(?:服务|架构)?边界\s*(?:确认\s*)?(?:是|确?为|：)\s*(?:(?:现在|目前)\s*)?API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*)|(?:(?:当前|目前)(?:架构|正式)?说明(?:中)?|(?:架构|正式)?说明(?:中)?仍明确|(?:当前|目前)?架构确认|(?:当前|目前)架构|(?:当前|目前)(?:架构|正式)?文档(?:中)?(?:明确)?确认边界)\s*(?:仍)?(?:明确)?(?:是|确?为|：)\s*API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*))\s*$/iu;
+        /^(?:(?:verified(?:\s+stable)?\s+(?:fact|statement)|已验证(?:稳定)?事实)\s*[:：]\s*)?(?:(?:the\s+)?(?:(?:verified|current)\s+)*(?:service\s+)?boundary\s*(?:is|:)\s*(?:(?:now|currently)\s+)?API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*)|(?:(?:已验证|当前|目前)\s*)*(?:服务|架构)?边界\s*(?:(?:已)?(?:核实|验证|确认)\s*)?(?:是|为|：)\s*(?:(?:现在|目前)\s*)?API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*)|(?:(?:当前|目前)(?:架构|正式)?说明(?:中)?|(?:架构|正式)?说明(?:中)?仍明确|(?:当前|目前)?架构确认|(?:当前|目前)架构|(?:当前|目前)(?:架构|正式)?文档(?:中)?(?:明确)?确认边界)\s*(?:仍)?(?:明确)?(?:是|确?为|：)\s*API\s*(?:->|→)\s*([A-Za-z][A-Za-z0-9_-]*))\s*$/iu;
   const targets = clauses.flatMap((clause) => {
     const match = assertion.exec(clause);
     return match ? [String(match[1] ?? match[2] ?? match[3]).toLowerCase()] : [];

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -2358,6 +2358,7 @@ if (scenarioId === 'memory-autopilot-unprompted') {
   );
   const followOutput = followInvocation?.parsedOutput;
   const repeatedOutput = repeatedInvocation?.parsedOutput;
+  const repeatedOutputObserved = Boolean(repeatedInvocation?.output.trim());
   const initialVerifier = {
     script: 'verify-autopilot.mjs',
     target: 'docs/status.txt',
@@ -2404,6 +2405,7 @@ if (scenarioId === 'memory-autopilot-unprompted') {
     followOutput,
     followOutputObserved,
     repeatedOutput,
+    repeatedOutputObserved,
     expectedPath: follow?.path,
     expectedReference: follow?.reference,
     preToFollowChanged: Boolean(
@@ -2609,6 +2611,7 @@ if (scenarioId === 'memory-autopilot-unprompted') {
     followOutput: followOutput ?? null,
     followOutputObserved,
     repeatedOutput: repeatedOutput ?? null,
+    repeatedOutputObserved,
     proven: idempotencyProven,
   };
   observationArtifact.closeTiming = {


### PR DESCRIPTION
## Summary / 变更说明

- Reapply the bounded `workspace-write` policy and exact additional writable roots on persistent Codex resume turns.
- Recognize a direct source-verified Chinese `API -> Worker` boundary assertion while continuing to reject historical, negated, and wrong-target claims.
- Prove an identical checkpoint with missing Host stdout only from exact command/payload identity plus unchanged persisted path and digest; malformed observed output remains fail-closed.
- Add focused evaluator regression coverage.

## Related Issue / 关联 Issue

Closes #71

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix.test.ts evals/__tests__/eval-codex-matrix-support.test.ts`
- `pnpm run preflight` (117 test files; 828 passed, 3 skipped; 676 preflight checks)
- `git diff --check`

## Checklist / 检查清单

- [x] Regression tests demonstrated red before implementation and green after implementation.
- [x] Resume permissions remain bounded to the evaluator-provided writable roots.
- [x] Idempotency remains fail-closed unless independent persisted-state invariants all match.
- [x] No generated `dist/` artifacts were committed.
