### PR TITLE
fix(eval): canonicalize remaining Host paths

### DIFF
--- a/evals/__tests__/eval-codex-matrix-support.test.ts
+++ b/evals/__tests__/eval-codex-matrix-support.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { test } from 'vitest';
+import { temporaryDirectory } from './run-fixture.js';
 
 async function support() {
   return import(
@@ -36,10 +39,53 @@ test('verified API Worker boundary accepts equivalent assertions but rejects sta
     ),
     true,
   );
+  assert.equal(
+    containsApiWorkerBoundary('当前架构边界为 **API → Worker**，`LegacyWorker` 已不再使用。'),
+    true,
+  );
   assert.equal(containsApiWorkerBoundary('当前架构边界已核实为 API -> LegacyWorker。'), false);
   assert.equal(containsApiWorkerBoundary('历史结论：当前架构边界已核实为 API -> Worker。'), false);
   assert.equal(containsApiWorkerBoundary('API -> Worker 已不再是当前边界。'), false);
 });
+
+test.skipIf(process.platform === 'win32')(
+  'checkpoint output identity accepts canonical aliases of the same persisted file',
+  async () => {
+    const { checkpointIdempotencyIsProven } = await support();
+    const directory = temporaryDirectory();
+    const target = join(directory, 'target');
+    const alias = join(directory, 'alias');
+    mkdirSync(target);
+    writeFileSync(join(target, 'memory.md'), 'persisted\n');
+    symlinkSync(target, alias, 'dir');
+    const output = {
+      version: 1,
+      action: 'updated',
+      kind: 'episode',
+      path: join(alias, 'memory.md'),
+      reference: 'memory:sessions/x',
+    };
+
+    assert.equal(
+      checkpointIdempotencyIsProven({
+        followCommandExact: true,
+        repeatedCommandExact: true,
+        samePayloadPath: true,
+        samePayloadSha: true,
+        followOutput: output,
+        followOutputObserved: true,
+        repeatedOutput: { ...output, action: 'unchanged' },
+        repeatedOutputObserved: true,
+        expectedPath: join(target, 'memory.md'),
+        expectedReference: 'memory:sessions/x',
+        preToFollowChanged: true,
+        followToRepeatUnchanged: true,
+        projectDigestUnchanged: true,
+      }),
+      true,
+    );
+  },
+);
 
 test('checkpoint idempotency accepts only state-proven unobserved replay', async () => {
   const { checkpointIdempotencyIsProven } = await support();

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -27,6 +27,7 @@ export function withEphemeralJsonPayload(path, payload, invoke) {
 }
 
 export function sameCanonicalPath(left, right) {
+  if (typeof left !== 'string' || !left || typeof right !== 'string' || !right) return false;
   try {
     return realpathSync.native(resolve(left)) === realpathSync.native(resolve(right));
   } catch {
@@ -1162,13 +1163,14 @@ export function checkpointIdempotencyIsProven({
   });
   const followIdentityCompatible =
     !followOutputObserved ||
-    (followOutput?.path === expectedPath && followOutput?.reference === expectedReference);
+    (sameCanonicalPath(followOutput?.path, expectedPath) &&
+      followOutput?.reference === expectedReference);
   const repeatedOutputCompatible = repeatedOutputObserved
     ? Boolean(
         repeatedOutput?.version === 1 &&
           repeatedOutput?.action === 'unchanged' &&
           repeatedOutput?.kind === 'episode' &&
-          repeatedOutput?.path === expectedPath &&
+          sameCanonicalPath(repeatedOutput?.path, expectedPath) &&
           repeatedOutput?.reference === expectedReference,
       )
     : repeatedOutput == null;
@@ -1376,7 +1378,7 @@ export function containsApiWorkerBoundary(content) {
       .replace(/\*\*(API\s*(?:->|→)\s*[A-Za-z][A-Za-z0-9_-]*)\*\*/giu, '$1')
       .replace(/__(API\s*(?:->|→)\s*[A-Za-z][A-Za-z0-9_-]*)__/giu, '$1')
       .replace(
-        /\s*[,，]\s*(?:(?:and\s+)?`?LegacyWorker`?\s+(?:is\s+)?(?:no longer used|retired|disabled)|(?:(?:且|并声明)\s*)?`?LegacyWorker`?\s*(?:已停用|不再(?:使用|采用)))(?:\s*[:：]\s*\[[^\]\r\n]+\]\([^\)\r\n]+\))?\s*[.!?。！？]?\s*$/iu,
+        /\s*[,，]\s*(?:(?:and\s+)?`?LegacyWorker`?\s+(?:is\s+)?(?:no longer used|retired|disabled)|(?:(?:且|并声明)\s*)?`?LegacyWorker`?\s*(?:已(?:停用|不再(?:使用|采用))|不再(?:使用|采用)))(?:\s*[:：]\s*\[[^\]\r\n]+\]\([^\)\r\n]+\))?\s*[.!?。！？]?\s*$/iu,
         '',
       );
     return normalized

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -2140,7 +2140,7 @@ if (scenarioId === 'memory-autopilot-unprompted') {
     }) &&
       (captureInputInvocation?.output == null ||
         (matchingInput &&
-          captureInputInvocation.output.path === matchingInput.path &&
+          sameCanonicalPath(captureInputInvocation.output.path, matchingInput.path) &&
           captureInputInvocation.output.reference === matchingInputReference)),
   );
   const typedInputCaptureProven = typedInputCaptureIsProven({
@@ -2463,7 +2463,10 @@ if (scenarioId === 'memory-autopilot-unprompted') {
         tokens &&
         tokens.length === 6 &&
         (tokens[0] === nodeBin || tokens[0] === 'node') &&
-        (isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1])) === harnessBin() &&
+        sameCanonicalPath(
+          isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1]),
+          harnessBin(),
+        ) &&
         tokens[2] === 'memory' &&
         tokens[3] === 'profile-autopilot' &&
         tokens[4] === 'pause' &&
@@ -2512,7 +2515,10 @@ if (scenarioId === 'memory-autopilot-unprompted') {
         tokens &&
         tokens.length === 7 &&
         (tokens[0] === nodeBin || tokens[0] === 'node') &&
-        (isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1])) === harnessBin() &&
+        sameCanonicalPath(
+          isAbsolute(tokens[1]) ? resolve(tokens[1]) : resolve(repo, tokens[1]),
+          harnessBin(),
+        ) &&
         tokens[2] === 'memory' &&
         tokens[3] === 'forget-profile' &&
         tokens[4] === '--key' &&
@@ -2587,14 +2593,20 @@ if (scenarioId === 'memory-autopilot-unprompted') {
       finalCloseAttempt.status === 'completed' &&
       finalCloseTokens?.length === 10 &&
       (finalCloseTokens[0] === nodeBin || finalCloseTokens[0] === 'node') &&
-      (isAbsolute(finalCloseTokens[1])
-        ? resolve(finalCloseTokens[1])
-        : resolve(repo, finalCloseTokens[1])) === harnessBin() &&
+      sameCanonicalPath(
+        isAbsolute(finalCloseTokens[1])
+          ? resolve(finalCloseTokens[1])
+          : resolve(repo, finalCloseTokens[1]),
+        harnessBin(),
+      ) &&
       finalCloseTokens[2] === 'memory' &&
       finalCloseTokens[3] === 'close-handoff' &&
-      (isAbsolute(finalCloseTokens[4])
-        ? resolve(finalCloseTokens[4])
-        : resolve(repo, finalCloseTokens[4])) === repo &&
+      sameCanonicalPath(
+        isAbsolute(finalCloseTokens[4])
+          ? resolve(finalCloseTokens[4])
+          : resolve(repo, finalCloseTokens[4]),
+        repo,
+      ) &&
       finalCloseTokens[5] === '--session' &&
       finalCloseTokens[6] === 'host-thread-42' &&
       finalCloseTokens[7] === '--outcome' &&


### PR DESCRIPTION
## Summary / 变更说明

- Canonicalize the remaining Host-evidence path comparisons for typed input output, profile controls, checkpoint output identity, and close-handoff commands.
- Treat macOS `/var` and `/private/var` aliases as the same existing path while keeping missing and malformed paths fail-closed.
- Recognize the verified `API → Worker` assertion when followed by the equivalent Chinese `LegacyWorker 已不再使用` suffix.
- Add exact regressions from the two failed post-merge canaries.

## Related Issue / 关联 Issue

Closes #71

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix-support.test.ts`
- `pnpm exec vitest run evals/__tests__/eval-codex-matrix.test.ts`
- `pnpm run preflight` (117 test files; 829 passed, 3 skipped; 676 preflight checks)
- `git diff --check`

## Checklist / 检查清单

- [x] Exact canary failures were reproduced by focused red tests before implementation.
- [x] Canonical identity is accepted only for the same existing path.
- [x] Missing, malformed, negated, historical, and wrong-target evidence remains rejected.
- [x] No assertion or verifier threshold was lowered.
