### PR TITLE
fix(eval): retry structured capacity failures

### DIFF
--- a/evals/__tests__/eval-codex-matrix-support.test.ts
+++ b/evals/__tests__/eval-codex-matrix-support.test.ts
@@ -11,6 +11,57 @@ async function support() {
   );
 }
 
+test('structured Codex capacity failures remain retryable transport failures', async () => {
+  const { evaluateCodexTurnCompletion } = await support();
+  const completion = evaluateCodexTurnCompletion({
+    status: 1,
+    signal: null,
+    error: 'evaluator-failure:host-exit',
+    stderr: '',
+    stdout:
+      '{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}\n',
+  });
+
+  assert.equal(completion.completed, false);
+  assert.equal(completion.transportFailure, true);
+});
+
+test('scenario aggregation preserves completion-classified transport failures', async () => {
+  const { classifyCodexScenarioHostFailures } = await support();
+  const classification = classifyCodexScenarioHostFailures([
+    {
+      result: {
+        captureKind: 'evaluator-failure',
+        error: 'evaluator-failure:host-exit',
+      },
+      completion: { transportFailure: true },
+    },
+  ]);
+
+  assert.deepEqual(classification, {
+    transportFailed: true,
+    hostEvaluatorFailed: false,
+  });
+});
+
+test('scenario aggregation preserves genuine evaluator failures', async () => {
+  const { classifyCodexScenarioHostFailures } = await support();
+  const classification = classifyCodexScenarioHostFailures([
+    {
+      result: {
+        captureKind: 'evaluator-failure',
+        error: 'evaluator-failure:host-exit',
+      },
+      completion: { transportFailure: false },
+    },
+  ]);
+
+  assert.deepEqual(classification, {
+    transportFailed: false,
+    hostEvaluatorFailed: true,
+  });
+});
+
 test('resumed Codex turns retain their additional writable roots through config', async () => {
   const { buildCodexTurn } = await support();
   const args = buildCodexTurn({

--- a/evals/__tests__/eval-codex-matrix.test.ts
+++ b/evals/__tests__/eval-codex-matrix.test.ts
@@ -142,24 +142,6 @@ test('repository-map scenario grants the exact personal-map write without source
   assert.match(scenario.prompt, /do not modify repository source files/i);
 });
 
-test('structured Codex capacity failures remain retryable transport failures', async () => {
-  const support = await import(
-    // @ts-expect-error The tracked evaluator support module is intentionally plain ESM.
-    '../../scripts/eval-codex-matrix-support.mjs'
-  );
-  const completion = support.evaluateCodexTurnCompletion({
-    status: 1,
-    signal: null,
-    error: 'evaluator-failure:host-exit',
-    stderr: '',
-    stdout:
-      '{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}\n',
-  });
-
-  assert.equal(completion.completed, false);
-  assert.equal(completion.transportFailure, true);
-});
-
 test('scenario fixture binds the supplied candidate and prepares without launching Codex', () => {
   const directory = temporaryDirectory();
   const artifact = join(directory, 'candidate.tgz');

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -331,6 +331,21 @@ export function evaluateCodexTurnCompletion(result, { requireAgentCompletion = t
   };
 }
 
+export function classifyCodexScenarioHostFailures(turnResults) {
+  const transportFailed = turnResults.some(
+    (turn) =>
+      turn?.result?.captureKind === 'transport-failure' ||
+      turn?.completion?.transportFailure === true,
+  );
+  const hostEvaluatorFailed = turnResults.some(
+    (turn) =>
+      turn?.completion?.transportFailure !== true &&
+      (turn?.result?.captureKind === 'evaluator-failure' ||
+        (turn?.result?.captureKind !== 'transport-failure' && Boolean(turn?.result?.error))),
+  );
+  return { transportFailed, hostEvaluatorFailed };
+}
+
 function parseSingleJsonObject(value) {
   const trimmed = String(value ?? '').trim();
   if (!trimmed) return null;

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -22,6 +22,7 @@ import {
   canonicalPathWithin,
   classifyBoundaryCommand,
   checkpointIdempotencyIsProven,
+  classifyCodexScenarioHostFailures,
   containsApiWorkerBoundary,
   containsAssertedObsoleteRecall,
   containsRetryInvestigationContext,
@@ -3015,12 +3016,7 @@ write(join(recordDir, 'observations.json'), observationsText);
 const hostTurnsPassed = everyTurnCompleted;
 const evaluatorHealthy = evaluatorErrors.length === 0 && treeErrors.length === 0;
 const checks = [hostTurnsPassed, evidenceComplete, evaluatorHealthy, ...passValues, ...forbiddenValues];
-const transportFailed = turnResults.some((turn) => turn.result.captureKind === 'transport-failure');
-const hostEvaluatorFailed = turnResults.some(
-  (turn) =>
-    turn.result.captureKind === 'evaluator-failure' ||
-    (turn.result.captureKind !== 'transport-failure' && Boolean(turn.result.error)),
-);
+const { transportFailed, hostEvaluatorFailed } = classifyCodexScenarioHostFailures(turnResults);
 let outcome = transportFailed
   ? 'infra-inconclusive'
   : !evidenceComplete || !evaluatorHealthy || hostEvaluatorFailed


### PR DESCRIPTION
## Summary / 变更说明

- Preserve completion-classified structured Codex capacity failures as transport failures during scenario aggregation.
- Keep genuine evaluator failures classified as evaluator failures.
- Add aggregation regression coverage and keep the matrix test file within the lint line limit.

## Related Issue / 关联 Issue

Closes #75

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix-support.test.ts evals/__tests__/eval-codex-matrix.test.ts`
- `pnpm run preflight` (676 preflight checks; 117 test files; 831 passed, 3 skipped)

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits.
- [x] Behavior changes include focused tests.
- [x] Capability boundaries remain unchanged; only failure classification is corrected.
- [x] No generated `dist/` files, secrets, personal memory, or private paths are included.
