### PR TITLE
refactor(adapters): introduce declarative Adapter Registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,14 @@ host-neutrality test passing.
 
 ## Architecture boundaries
 
-- Host names, paths, formats, and environment variables belong in `src/adapters.ts` or other outer
-  installation code.
+- Host identity metadata (canonical name, label, aliases, capabilities) belongs in
+  `src/adapter-registry.ts`. Host paths, instruction file layout, environment variables, and ignore
+  rules belong in `src/adapters.ts`. Instruction render shapes for markdown/mdc (and future formats)
+  belong in `src/instruction-formats.ts`. Do not put host identity into `template/`.
+- To add a built-in Adapter: register it in `src/adapter-registry.ts`, add an exhaustive path
+  resolver in `src/adapters.ts`, align `evals/run.schema.json` `host.adapter.enum` (preflight
+  enforces this), and rely on `src/__tests__/adapter-conformance.test.ts` for shared lifecycle
+  coverage. Do not add a dynamic plugin loader or Pack Registry.
 - Runtime source is strict TypeScript under `src/` and `template/agent-harness/src/`. Generated `dist/`
   files are build products: change the TypeScript source and run `pnpm run build`; never edit them directly.
 - Biome is the shared formatter and linter, Knip rejects unreachable files or exports, and Secretlint scans

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,9 @@ The gate does not launch or authenticate to any third-party host. 真实宿主�
 
 `src/adapter-registry.ts` 是宿主身份与 capability 的单一清单；`createAdapter()` 解析路径后挂上同一
 份 `capabilities`，并出现在 dry-run、install result 与 status JSON 中。CLI `all` 展开、交互选择、
-capabilities 输出与 Eval `host.adapter` 枚举都从该清单派生或与之对齐。
+capabilities 输出与 Eval `host.adapter` 枚举都从该清单派生或与之对齐。新增内置 Adapter 时：先登记
+registry，再补 `src/adapters.ts` 路径解析，并保持 `evals/run.schema.json` 枚举与 registry 一致；
+共享生命周期由 `adapter-conformance` 套件覆盖，不引入动态插件加载。
 
 | Adapter | Scope | Instruction format | Native activation | Instruction enforcement | Permissions |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,8 +36,9 @@ The gate does not launch or authenticate to any third-party host. 真实宿主�
 
 ## Adapter 能力契约
 
-`createAdapter()` 产生的每个 Adapter 都带有机器可读 `capabilities`，并出现在 dry-run、install
-result 与 status JSON 中。
+`src/adapter-registry.ts` 是宿主身份与 capability 的单一清单；`createAdapter()` 解析路径后挂上同一
+份 `capabilities`，并出现在 dry-run、install result 与 status JSON 中。CLI `all` 展开、交互选择、
+capabilities 输出与 Eval `host.adapter` 枚举都从该清单派生或与之对齐。
 
 | Adapter | Scope | Instruction format | Native activation | Instruction enforcement | Permissions |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -10,9 +10,13 @@ claims:
     owner: outer installer adapters
     claim: Distribute one Personal Harness across Codex, Cursor, Claude Code, and OpenCode.
     implementation:
+      - src/adapter-registry.ts
       - src/adapters.ts
+      - src/instruction-formats.ts
       - src/install.ts
     verification:
+      - src/__tests__/adapter-registry.test.ts
+      - src/__tests__/adapter-conformance.test.ts
       - src/__tests__/install.test.ts
       - src/__tests__/adapters-opencode.test.ts
 

--- a/scripts/eval-fingerprint.ts
+++ b/scripts/eval-fingerprint.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 import type { AnySchema } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
-import { supportedAgentNames } from '../src/agents.js';
+import { evalAdapterEnum } from '../src/adapter-registry.js';
 import type { AgentName } from '../src/types.js';
 import {
   assertCandidatePackageFiles,
@@ -19,7 +19,7 @@ import {
 } from './npm-tarball.js';
 
 export const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-export const supportedAdapters = [...supportedAgentNames] as AgentName[];
+export const supportedAdapters = evalAdapterEnum();
 export const requiredEvaluationAdapters = ['codex'] as const satisfies readonly AgentName[];
 
 type ScenarioContract = {

--- a/scripts/preflight-docs.ts
+++ b/scripts/preflight-docs.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import { fdir } from 'fdir';
 import { parse } from 'yaml';
+import { supportedAgentNames } from '../src/agents.js';
 import { parseFrontmatterDocument } from '../template/agent-harness/src/lib/frontmatter.js';
 import { markdownLinkTargets } from '../template/agent-harness/src/lib/markdown-links.js';
 import { capabilityEvidenceIssues } from './capability-evidence.js';
@@ -163,9 +164,10 @@ function checkPortableTemplate(root: string, check: Check): void {
       );
     }
     check(
-      !/\b(?:codex|cursor|claude|opencode)\b|CODEX_HOME|CLAUDE_CONFIG_DIR|OPENCODE_CONFIG_DIR/i.test(
-        content,
-      ),
+      !new RegExp(
+        String.raw`\b(?:${supportedAgentNames.join('|')})\b|CODEX_HOME|CLAUDE_CONFIG_DIR|OPENCODE_CONFIG_DIR`,
+        'i',
+      ).test(content),
       `host-specific identity leaked into portable template: ${relative(root, path)}`,
     );
   }

--- a/scripts/preflight-package.ts
+++ b/scripts/preflight-package.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { evalAdapterEnum } from '../src/adapter-registry.js';
 
 type Check = (condition: unknown, message: string) => void;
 
@@ -25,6 +26,23 @@ function checkPublicGuidance(root: string, version: string, check: Check): void 
   for (const [path, content] of guidance) {
     check(!content.includes(version), `${path} must not duplicate the package version`);
   }
+}
+
+function checkEvalAdapterEnum(root: string, check: Check): void {
+  const schemaPath = join(root, 'evals', 'run.schema.json');
+  check(existsSync(schemaPath), 'evals/run.schema.json is missing');
+  if (!existsSync(schemaPath)) return;
+  const schema = JSON.parse(read(schemaPath)) as {
+    properties?: { host?: { properties?: { adapter?: { enum?: unknown } } } };
+  };
+  const enumValues = schema.properties?.host?.properties?.adapter?.enum;
+  const expected = evalAdapterEnum();
+  check(
+    Array.isArray(enumValues) &&
+      enumValues.length === expected.length &&
+      enumValues.every((value, index) => value === expected[index]),
+    `evals/run.schema.json host.adapter.enum must match adapter registry: ${expected.join(', ')}`,
+  );
 }
 
 export function checkPackage(root: string, harnessRoot: string, check: Check): void {
@@ -109,4 +127,5 @@ export function checkPackage(root: string, harnessRoot: string, check: Check): v
   );
   check(!workflow.includes('npm ci'), 'CI must not install dependencies with npm');
   checkPublicGuidance(root, manifest.version || '', check);
+  checkEvalAdapterEnum(root, check);
 }

--- a/src/__tests__/adapter-conformance.test.ts
+++ b/src/__tests__/adapter-conformance.test.ts
@@ -64,6 +64,9 @@ for (const entry of adapterRegistry) {
     const { project, env } = fixture(`harnessmith-conform-life-${entry.name}-`);
     const adapter = adapterFor(entry.name, env, project);
 
+    assert.equal(statusAll([adapter])[0].installed, false);
+    assert.equal(existsSync(adapter.home), false);
+
     installAll([adapter], { env, noInitGlobal: true });
     const afterInstall = statusAll([adapter])[0];
     assert.equal(afterInstall.installed, true);
@@ -89,6 +92,7 @@ for (const entry of adapterRegistry) {
     assert.equal(uninstalled[0].adapter, entry.name);
     assert.equal(existsSync(adapter.record), false);
     assert.equal(existsSync(adapter.harness), false);
+    assert.equal(statusAll([adapter])[0].installed, false);
   });
 
   test(`conformance ${entry.name}: refuses unmanaged conflicts without force`, () => {

--- a/src/__tests__/adapter-conformance.test.ts
+++ b/src/__tests__/adapter-conformance.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { adapterRegistry, type AgentName } from '../adapter-registry.js';
+import { createAdapter } from '../adapters.js';
+import { installAll } from '../install.js';
+import { restoreAll, statusAll, uninstallAll } from '../lifecycle.js';
+import { describeInstall } from '../records.js';
+import type { Adapter } from '../types.js';
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  const env = {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, 'codex'),
+    CLAUDE_CONFIG_DIR: join(root, 'claude'),
+    OPENCODE_CONFIG_DIR: join(root, 'opencode'),
+    HARNESS_MEMORY_HOME: join(root, 'memory'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal'),
+    HARNESS_REPOSITORY_ROOT: join(root, 'repositories'),
+    HARNESS_OWNER: 'adapter-conformance',
+  };
+  return { root, project, env };
+}
+
+function adapterFor(name: AgentName, env: NodeJS.ProcessEnv, project: string): Adapter {
+  return createAdapter(name, { env, project });
+}
+
+function primaryInstruction(adapter: Adapter): string {
+  const path = adapter.instructions[0]?.path;
+  assert.ok(path, `${adapter.name} is missing a primary instruction file`);
+  return path;
+}
+
+for (const entry of adapterRegistry) {
+  test(`conformance ${entry.name}: dry-run describes outputs without creating the agent home`, () => {
+    const { project, env } = fixture(`harnessmith-conform-dry-${entry.name}-`);
+    const adapter = adapterFor(entry.name, env, project);
+    const plan = describeInstall(adapter);
+
+    assert.equal(plan.adapter, entry.name);
+    assert.deepEqual(plan.capabilities, entry.capabilities);
+    assert.ok(plan.outputs.length > 0);
+    assert.equal(existsSync(adapter.home), false);
+    assert.equal(existsSync(adapter.record), false);
+  });
+
+  test(`conformance ${entry.name}: install, status, upgrade, restore, and uninstall`, () => {
+    const { project, env } = fixture(`harnessmith-conform-life-${entry.name}-`);
+    const adapter = adapterFor(entry.name, env, project);
+
+    installAll([adapter], { env, noInitGlobal: true });
+    const afterInstall = statusAll([adapter])[0];
+    assert.equal(afterInstall.installed, true);
+    assert.equal(
+      afterInstall.outputs.every(({ status }) => status === 'managed'),
+      true,
+    );
+    assert.ok(existsSync(adapter.record));
+    assert.ok(existsSync(adapter.harness));
+
+    installAll([adapter], { env, noInitGlobal: true });
+    assert.equal(
+      statusAll([adapter])[0].outputs.every(({ status }) => status === 'managed'),
+      true,
+    );
+    assert.ok(existsSync(adapter.record));
+
+    const restored = restoreAll([adapter]);
+    assert.equal(restored[0].adapter, entry.name);
+    assert.ok(existsSync(adapter.record));
+
+    const uninstalled = uninstallAll([adapter]);
+    assert.equal(uninstalled[0].adapter, entry.name);
+    assert.equal(existsSync(adapter.record), false);
+    assert.equal(existsSync(adapter.harness), false);
+  });
+
+  test(`conformance ${entry.name}: refuses unmanaged conflicts without force`, () => {
+    const { project, env } = fixture(`harnessmith-conform-conflict-${entry.name}-`);
+    const adapter = adapterFor(entry.name, env, project);
+    const instruction = primaryInstruction(adapter);
+    mkdirSync(dirname(instruction), { recursive: true });
+    writeFileSync(instruction, 'unmanaged personal rules\n');
+
+    assert.throws(() => installAll([adapter], { env, noInitGlobal: true }), /require --force/);
+    assert.equal(readFileSync(instruction, 'utf8'), 'unmanaged personal rules\n');
+    assert.equal(existsSync(adapter.record), false);
+
+    installAll([adapter], { env, force: true, noInitGlobal: true });
+    assert.match(readFileSync(instruction, 'utf8'), /managed-by: harnessmith/);
+    assert.ok(existsSync(adapter.record));
+  });
+}
+
+test('conformance multi-adapter: preflight rejects a modified peer without mutating others', () => {
+  const { project, env } = fixture('harnessmith-conform-multi-preflight-');
+  const adapters = adapterRegistry.map(({ name }) => adapterFor(name, env, project));
+  installAll(adapters, { env, noInitGlobal: true });
+
+  const victim = adapters[0];
+  const peer = adapters[1];
+  assert.ok(victim && peer);
+  const instruction = primaryInstruction(victim);
+  writeFileSync(instruction, `${readFileSync(instruction, 'utf8')}\nuser edit\n`);
+
+  const peerRecordBefore = readFileSync(peer.record, 'utf8');
+  const peerHarnessBefore = existsSync(peer.harness);
+
+  assert.throws(() => uninstallAll(adapters), /modified/);
+  assert.ok(existsSync(victim.record));
+  assert.ok(existsSync(peer.record));
+  assert.equal(readFileSync(peer.record, 'utf8'), peerRecordBefore);
+  assert.equal(existsSync(peer.harness), peerHarnessBefore);
+});
+
+test('conformance multi-adapter: later failure rolls back earlier adapter mutations', () => {
+  const { root, project, env } = fixture('harnessmith-conform-multi-rollback-');
+  const first = adapterFor('codex', env, project);
+  const second = adapterFor('cursor', env, project);
+  installAll([first, second], { env, noInitGlobal: true });
+
+  const firstRecordBefore = readFileSync(first.record, 'utf8');
+  const firstRules = primaryInstruction(first);
+  const firstRulesBefore = readFileSync(firstRules, 'utf8');
+  const cursorIgnore = second.localIgnoreFiles?.at(-1)?.path;
+  assert.ok(cursorIgnore);
+  rmSync(cursorIgnore);
+  mkdirSync(cursorIgnore);
+
+  assert.throws(() => uninstallAll([first, second]));
+
+  assert.equal(readFileSync(first.record, 'utf8'), firstRecordBefore);
+  assert.equal(readFileSync(firstRules, 'utf8'), firstRulesBefore);
+  assert.ok(existsSync(second.record));
+  assert.ok(existsSync(second.harness));
+  assert.deepEqual(
+    readdirSync(second.home).filter((name) => name.startsWith('.harnessmith-restore-')),
+    [],
+  );
+  assert.ok(existsSync(root));
+});

--- a/src/__tests__/adapter-registry.test.ts
+++ b/src/__tests__/adapter-registry.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import {
+  adapterAliasMap,
+  adapterRegistry,
+  evalAdapterEnum,
+  getAdapterDefinition,
+  supportedAgentNames,
+  type AgentName,
+} from '../adapter-registry.js';
+import { adapterCapabilities, createAdapter } from '../adapters.js';
+import { normalizeAgents, supportedAgents } from '../agents.js';
+import { instructionFormats, instructionRenderer } from '../instruction-formats.js';
+
+test('adapter registry is the single host inventory for CLI selection and aliases', () => {
+  assert.deepEqual(
+    supportedAgentNames,
+    adapterRegistry.map(({ name }) => name),
+  );
+  assert.deepEqual(
+    supportedAgents.map(({ value, label, hint }) => ({ value, label, hint })),
+    adapterRegistry.map(({ name, label, hint }) => ({ value: name, label, hint })),
+  );
+  assert.deepEqual(normalizeAgents(['all']), [...supportedAgentNames]);
+  assert.deepEqual(normalizeAgents(['claude-code']), ['claude']);
+  assert.deepEqual(normalizeAgents(['1', '2', '3', '4']), [...supportedAgentNames]);
+  assert.deepEqual([...adapterAliasMap().entries()].sort(), [
+    ['1', 'codex'],
+    ['2', 'cursor'],
+    ['3', 'claude'],
+    ['4', 'opencode'],
+    ['claude-code', 'claude'],
+  ]);
+});
+
+test('capabilities and labels always come from the registry entry', () => {
+  for (const entry of adapterRegistry) {
+    assert.deepEqual(adapterCapabilities(entry.name), entry.capabilities);
+    assert.equal(getAdapterDefinition(entry.name).label, entry.label);
+  }
+});
+
+test('eval adapter enum is derived from the same registry list', () => {
+  assert.deepEqual(evalAdapterEnum(), [...supportedAgentNames]);
+});
+
+test('instruction format extension points cover every registry capability format', () => {
+  const formats = new Set(
+    adapterRegistry.map(({ capabilities }) => capabilities.instructionFormat),
+  );
+  for (const format of formats) {
+    assert.ok(format in instructionFormats, `missing instruction format extension: ${format}`);
+    const rendered = instructionRenderer(format)('body');
+    assert.match(rendered, /managed-by: harnessmith/);
+    assert.match(rendered, /body/);
+  }
+});
+
+test('createAdapter preserves registry metadata for every registered host', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harnessmith-registry-create-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, 'project'), { recursive: true });
+  const env = {
+    HOME: root,
+    CODEX_HOME: join(root, 'codex'),
+    CLAUDE_CONFIG_DIR: join(root, 'claude'),
+    OPENCODE_CONFIG_DIR: join(root, 'opencode'),
+  };
+
+  for (const entry of adapterRegistry) {
+    const adapter = createAdapter(entry.name, { env, project: join(root, 'project') });
+    assert.equal(adapter.name, entry.name);
+    assert.equal(adapter.label, entry.label);
+    assert.deepEqual(adapter.capabilities, entry.capabilities);
+    assert.ok(adapter.instructions.length > 0);
+  }
+});
+
+test('AgentName union stays aligned with registry order used by install records', () => {
+  const names: AgentName[] = ['codex', 'cursor', 'claude', 'opencode'];
+  assert.deepEqual(names, [...supportedAgentNames]);
+});

--- a/src/__tests__/adapter-registry.test.ts
+++ b/src/__tests__/adapter-registry.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { onTestFinished, test } from 'vitest';
 import {
   adapterAliasMap,
@@ -14,6 +15,8 @@ import {
 import { adapterCapabilities, createAdapter } from '../adapters.js';
 import { normalizeAgents, supportedAgents } from '../agents.js';
 import { instructionFormats, instructionRenderer } from '../instruction-formats.js';
+
+const repositoryRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
 test('adapter registry is the single host inventory for CLI selection and aliases', () => {
   assert.deepEqual(
@@ -45,6 +48,8 @@ test('capabilities and labels always come from the registry entry', () => {
 
 test('eval adapter enum is derived from the same registry list', () => {
   assert.deepEqual(evalAdapterEnum(), [...supportedAgentNames]);
+  const schema = JSON.parse(readFileSync(join(repositoryRoot, 'evals', 'run.schema.json'), 'utf8'));
+  assert.deepEqual(schema.properties.host.properties.adapter.enum, evalAdapterEnum());
 });
 
 test('instruction format extension points cover every registry capability format', () => {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,21 +1,17 @@
 import assert from 'node:assert/strict';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
 import { createAdapter } from '../adapters.js';
 import { installAll } from '../install.js';
-import { restoreAll, statusAll, uninstallAll } from '../lifecycle.js';
 import { describeLifecycle } from '../lifecycle-plan.js';
 
+/**
+ * Adapter-specific / edge-case lifecycle coverage.
+ * Shared dry-run → uninstall / conflict / multi-adapter preflight+rollback lives in
+ * adapter-conformance.test.ts and runs for every registry entry.
+ */
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'harnessmith-lifecycle-unit-'));
   onTestFinished(() => rmSync(root, { recursive: true, force: true }));
@@ -23,7 +19,6 @@ function fixture() {
     ...process.env,
     HOME: root,
     CODEX_HOME: join(root, 'codex'),
-    CLAUDE_CONFIG_DIR: join(root, 'claude'),
     HARNESS_MEMORY_HOME: join(root, 'memory'),
     HARNESS_PERSONAL_HOME: join(root, 'personal'),
     HARNESS_REPOSITORY_ROOT: join(root, 'repositories'),
@@ -31,76 +26,6 @@ function fixture() {
   };
   return { root, env };
 }
-
-test('direct lifecycle API restores one layer and fully uninstalls the previous layer', () => {
-  const { env } = fixture();
-  const adapter = createAdapter('codex', { env });
-  installAll([adapter], { env });
-  installAll([adapter], { env });
-  assert.equal(
-    statusAll([adapter])[0].outputs.every(({ status }) => status === 'managed'),
-    true,
-  );
-
-  const restored = restoreAll([adapter]);
-  assert.equal(restored[0].adapter, 'codex');
-  assert.ok(existsSync(adapter.record));
-  const uninstalled = uninstallAll([adapter]);
-  assert.equal(uninstalled[0].layers, 1);
-  assert.equal(existsSync(adapter.record), false);
-  assert.equal(existsSync(adapter.harness), false);
-});
-
-test('direct multi-Adapter lifecycle preflight leaves every installation untouched', () => {
-  const { env } = fixture();
-  const codex = createAdapter('codex', { env });
-  const claude = createAdapter('claude', { env });
-  installAll([codex, claude], { env });
-  const claudeRules = claude.instructions.at(-1)?.path;
-  assert.ok(claudeRules);
-  writeFileSync(claudeRules, `${readFileSync(claudeRules, 'utf8')}\nuser edit\n`);
-
-  assert.throws(() => uninstallAll([codex, claude]), /modified/);
-  assert.ok(existsSync(codex.record));
-  assert.ok(existsSync(claude.record));
-  assert.ok(existsSync(codex.harness));
-  assert.ok(existsSync(claude.harness));
-});
-
-test('multi-Adapter lifecycle transaction rolls back an earlier Adapter after a later runtime failure', () => {
-  const { root, env } = fixture();
-  const codex = createAdapter('codex', { env });
-  const cursor = createAdapter('cursor', { env, project: root });
-  installAll([codex, cursor], { env });
-  const codexRecordBefore = readFileSync(codex.record, 'utf8');
-  const codexRules = codex.instructions[0].path;
-  const codexRulesBefore = readFileSync(codexRules, 'utf8');
-  const cursorIgnore = cursor.localIgnoreFiles?.at(-1)?.path;
-  assert.ok(cursorIgnore);
-  rmSync(cursorIgnore);
-  mkdirSync(cursorIgnore);
-
-  assert.throws(() => uninstallAll([codex, cursor]));
-
-  assert.equal(readFileSync(codex.record, 'utf8'), codexRecordBefore);
-  assert.equal(readFileSync(codexRules, 'utf8'), codexRulesBefore);
-  assert.ok(existsSync(cursor.record));
-  assert.ok(existsSync(cursor.harness));
-  assert.deepEqual(
-    readdirSync(cursor.home).filter((name) => name.startsWith('.harnessmith-restore-')),
-    [],
-  );
-});
-
-test('status of an uninstalled Adapter is read-only', () => {
-  const { env } = fixture();
-  const adapter = createAdapter('codex', { env });
-
-  const status = statusAll([adapter]);
-
-  assert.equal(status[0].installed, false);
-  assert.equal(existsSync(adapter.home), false);
-});
 
 test('lifecycle preflight rejects a missing installation-record backup before mutation', () => {
   const { env } = fixture();

--- a/src/adapter-registry.ts
+++ b/src/adapter-registry.ts
@@ -1,0 +1,110 @@
+import type { AdapterCapabilities } from './types.js';
+
+/**
+ * Declarative Adapter Registry — single source of truth for host identity metadata.
+ * Path resolution, env vars, and ignore rules stay in adapters.ts.
+ * This is not a plugin loader: only built-in entries are registered.
+ */
+
+export const defaultAdapterEnforcement = {
+  fileOwnership: 'harnessmith',
+  instructions: 'advisory',
+  permissions: 'host-owned',
+} as const satisfies AdapterCapabilities['enforcement'];
+
+export interface AdapterRegistryEntry {
+  readonly name: string;
+  readonly label: string;
+  /** Extra CLI aliases beyond the positional 1-based index. */
+  readonly aliases: readonly string[];
+  readonly hint: string;
+  readonly capabilities: AdapterCapabilities;
+}
+
+export const adapterRegistry = [
+  {
+    name: 'codex',
+    label: 'Codex',
+    aliases: [],
+    hint: 'global configuration',
+    capabilities: {
+      scope: 'global',
+      instructionFormat: 'markdown',
+      nativeRuleActivation: 'host-default',
+      enforcement: defaultAdapterEnforcement,
+    },
+  },
+  {
+    name: 'cursor',
+    label: 'Cursor',
+    aliases: [],
+    hint: 'current project',
+    capabilities: {
+      scope: 'project',
+      instructionFormat: 'mdc',
+      nativeRuleActivation: 'always',
+      enforcement: defaultAdapterEnforcement,
+    },
+  },
+  {
+    name: 'claude',
+    label: 'Claude Code',
+    aliases: ['claude-code'],
+    hint: 'global configuration',
+    capabilities: {
+      scope: 'global',
+      instructionFormat: 'markdown',
+      nativeRuleActivation: 'host-default',
+      enforcement: defaultAdapterEnforcement,
+    },
+  },
+  {
+    name: 'opencode',
+    label: 'OpenCode',
+    aliases: [],
+    hint: 'global configuration',
+    capabilities: {
+      scope: 'global',
+      instructionFormat: 'markdown',
+      nativeRuleActivation: 'host-default',
+      enforcement: defaultAdapterEnforcement,
+    },
+  },
+] as const satisfies readonly AdapterRegistryEntry[];
+
+export type AgentName = (typeof adapterRegistry)[number]['name'];
+
+export type AdapterDefinition = (typeof adapterRegistry)[number];
+
+export const supportedAgentNames: readonly AgentName[] = adapterRegistry.map(({ name }) => name);
+
+const definitionsByName = new Map<string, AdapterDefinition>(
+  adapterRegistry.map((entry) => [entry.name, entry]),
+);
+
+export function getAdapterDefinition(name: AgentName): AdapterDefinition {
+  const definition = definitionsByName.get(name);
+  if (!definition) {
+    throw new Error(`Unknown adapter registry entry: ${name}`);
+  }
+  return definition;
+}
+
+export function isRegisteredAgentName(value: unknown): value is AgentName {
+  return typeof value === 'string' && definitionsByName.has(value);
+}
+
+/** Positional indices (1-based) plus declared aliases → canonical name. */
+export function adapterAliasMap(): Map<string, AgentName> {
+  const aliases = new Map<string, AgentName>();
+  for (const [index, entry] of adapterRegistry.entries()) {
+    aliases.set(String(index + 1), entry.name);
+    for (const alias of entry.aliases) aliases.set(alias, entry.name);
+  }
+  return aliases;
+}
+
+/** Eval run.schema.json `host.adapter.enum` must match this list exactly. */
+export function evalAdapterEnum(): AgentName[] {
+  return [...supportedAgentNames];
+}

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,29 +1,33 @@
 import { existsSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { getAdapterDefinition, type AgentName } from './adapter-registry.js';
 import { type GitInspection, inspectGit } from './git-inspection.js';
+import {
+  instructionRenderer,
+  renderMarkdownInstructions,
+  renderMdcInstructions,
+} from './instruction-formats.js';
 import { canonicalPath, isPathInside } from './safe-path.js';
-import type { Adapter, AdapterCapabilities, AgentName } from './types.js';
+import type { Adapter, AdapterCapabilities } from './types.js';
 import { HarnessmithError } from './types.js';
 
 export { inspectGit, resolveGitExecutable } from './git-inspection.js';
+
+interface AdapterResolveContext {
+  env: NodeJS.ProcessEnv;
+  project: string;
+  userHome: string;
+}
+
+type AdapterResolver = (context: AdapterResolveContext) => Adapter;
 
 function gitInspectionError(action: string, result: Exclude<GitInspection, { ok: true }>): never {
   throw new HarnessmithError('INTEGRITY_ERROR', `Unable to ${action}: ${result.message}`, 3);
 }
 
 export function adapterCapabilities(name: AgentName): AdapterCapabilities {
-  const cursor = name === 'cursor';
-  return {
-    scope: cursor ? 'project' : 'global',
-    instructionFormat: cursor ? 'mdc' : 'markdown',
-    nativeRuleActivation: cursor ? 'always' : 'host-default',
-    enforcement: {
-      fileOwnership: 'harnessmith',
-      instructions: 'advisory',
-      permissions: 'host-owned',
-    },
-  };
+  return getAdapterDefinition(name).capabilities;
 }
 
 function projectRoot(input: string): string {
@@ -49,30 +53,23 @@ function projectRoot(input: string): string {
   return gitInspectionError('resolve the project Git root', inspection);
 }
 
-function plainInstructions(content: string): string {
-  return `<!-- managed-by: harnessmith -->\n\n${content}`;
-}
-
-function mdcInstructions(content: string): string {
-  return `---\ndescription: Personal coding agent harness\nglobs:\nalwaysApply: true\n---\n\n<!-- managed-by: harnessmith -->\n\n${content}`;
-}
-
 function globalMarkdownAdapter(
   name: AgentName,
-  label: string,
   home: string,
   instructionFiles: string[] = ['AGENTS.md'],
 ): Adapter {
+  const definition = getAdapterDefinition(name);
+  const render = instructionRenderer(definition.capabilities.instructionFormat);
   return {
     name,
-    label,
+    label: definition.label,
     home,
     harness: join(home, 'agent-harness'),
     record: join(home, '.harnessmith', 'install.json'),
-    capabilities: adapterCapabilities(name),
+    capabilities: definition.capabilities,
     instructions: instructionFiles.map((file) => ({
       path: join(home, file),
-      render: plainInstructions,
+      render,
     })),
   };
 }
@@ -101,6 +98,90 @@ function gitExcludePath(root: string): { path: string; root: string } | null {
   return { path, root: commonRoot };
 }
 
+function resolveCodexAdapter({ env, userHome }: AdapterResolveContext): Adapter {
+  const agentHome = canonicalPath(env.CODEX_HOME || join(userHome, '.codex'));
+  return globalMarkdownAdapter('codex', agentHome);
+}
+
+function resolveClaudeAdapter({ env, userHome }: AdapterResolveContext): Adapter {
+  const agentHome = canonicalPath(env.CLAUDE_CONFIG_DIR || join(userHome, '.claude'));
+  return globalMarkdownAdapter('claude', agentHome, ['AGENTS.md', 'CLAUDE.md']);
+}
+
+function resolveOpenCodeAdapter({ env, userHome }: AdapterResolveContext): Adapter {
+  const configRoot = canonicalPath(env.XDG_CONFIG_HOME || join(userHome, '.config'));
+  const agentHome = canonicalPath(env.OPENCODE_CONFIG_DIR || join(configRoot, 'opencode'));
+  return globalMarkdownAdapter('opencode', agentHome);
+}
+
+function resolveCursorAdapter({ project }: AdapterResolveContext): Adapter {
+  const definition = getAdapterDefinition('cursor');
+  const root = projectRoot(project);
+  const agentHome = join(root, '.cursor');
+  const excludePath = gitExcludePath(root);
+  return {
+    name: 'cursor',
+    label: definition.label,
+    home: agentHome,
+    project: root,
+    harness: join(agentHome, 'agent-harness'),
+    record: join(agentHome, '.harnessmith', 'install.json'),
+    capabilities: definition.capabilities,
+    instructions: [
+      { path: join(agentHome, 'AGENTS.md'), render: renderMarkdownInstructions },
+      { path: join(agentHome, 'rules', 'agent-harness.mdc'), render: renderMdcInstructions },
+    ],
+    localIgnoreFiles: [
+      ...(excludePath
+        ? [
+            {
+              path: excludePath.path,
+              root: excludePath.root,
+              preserveEmpty: true,
+              lines: [
+                '/.cursor/agent-harness/',
+                '/.cursor/AGENTS.md',
+                '/.cursor/.harnessmith/',
+                '/.cursor/.harnessmith-stage-*',
+                '/.cursor/.harnessmith-restore-*',
+                '/.cursor/.harnessmith-operation.lock',
+                '/.cursor/.ignore',
+                '/.cursor/rules/agent-harness.mdc',
+                '/.cursor/*.backup-*',
+                '/.cursor/rules/agent-harness.mdc.backup-*',
+              ],
+            },
+          ]
+        : []),
+      {
+        path: join(agentHome, '.ignore'),
+        lines: [
+          '/agent-harness/',
+          '/AGENTS.md',
+          '/.harnessmith/',
+          '/.harnessmith-stage-*',
+          '/.harnessmith-restore-*',
+          '/.harnessmith-operation.lock',
+          '/rules/agent-harness.mdc',
+          '/*.backup-*',
+          '/rules/agent-harness.mdc.backup-*',
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Exhaustive resolver map: adding a registry entry without a path resolver fails typecheck.
+ * Host-specific paths and env vars remain here; the registry stays host-identity only.
+ */
+const adapterResolvers = {
+  codex: resolveCodexAdapter,
+  cursor: resolveCursorAdapter,
+  claude: resolveClaudeAdapter,
+  opencode: resolveOpenCodeAdapter,
+} as const satisfies Record<AgentName, AdapterResolver>;
+
 export function createAdapter(
   name: AgentName,
   {
@@ -108,74 +189,13 @@ export function createAdapter(
     project = process.cwd(),
   }: { env?: NodeJS.ProcessEnv; project?: string } = {},
 ): Adapter {
-  const home = canonicalPath(env.HOME || homedir());
-  if (name === 'codex') {
-    const agentHome = canonicalPath(env.CODEX_HOME || join(home, '.codex'));
-    return globalMarkdownAdapter(name, 'Codex', agentHome);
+  const resolver = adapterResolvers[name];
+  if (!resolver) {
+    throw new HarnessmithError('CLI_USAGE', `Unsupported agent: ${name}`, 2);
   }
-  if (name === 'claude') {
-    const agentHome = canonicalPath(env.CLAUDE_CONFIG_DIR || join(home, '.claude'));
-    return globalMarkdownAdapter(name, 'Claude Code', agentHome, ['AGENTS.md', 'CLAUDE.md']);
-  }
-  if (name === 'opencode') {
-    const configRoot = canonicalPath(env.XDG_CONFIG_HOME || join(home, '.config'));
-    const agentHome = canonicalPath(env.OPENCODE_CONFIG_DIR || join(configRoot, 'opencode'));
-    return globalMarkdownAdapter(name, 'OpenCode', agentHome);
-  }
-  if (name === 'cursor') {
-    const root = projectRoot(project);
-    const agentHome = join(root, '.cursor');
-    const excludePath = gitExcludePath(root);
-    return {
-      name,
-      label: 'Cursor',
-      home: agentHome,
-      project: root,
-      harness: join(agentHome, 'agent-harness'),
-      record: join(agentHome, '.harnessmith', 'install.json'),
-      capabilities: adapterCapabilities(name),
-      instructions: [
-        { path: join(agentHome, 'AGENTS.md'), render: plainInstructions },
-        { path: join(agentHome, 'rules', 'agent-harness.mdc'), render: mdcInstructions },
-      ],
-      localIgnoreFiles: [
-        ...(excludePath
-          ? [
-              {
-                path: excludePath.path,
-                root: excludePath.root,
-                preserveEmpty: true,
-                lines: [
-                  '/.cursor/agent-harness/',
-                  '/.cursor/AGENTS.md',
-                  '/.cursor/.harnessmith/',
-                  '/.cursor/.harnessmith-stage-*',
-                  '/.cursor/.harnessmith-restore-*',
-                  '/.cursor/.harnessmith-operation.lock',
-                  '/.cursor/.ignore',
-                  '/.cursor/rules/agent-harness.mdc',
-                  '/.cursor/*.backup-*',
-                  '/.cursor/rules/agent-harness.mdc.backup-*',
-                ],
-              },
-            ]
-          : []),
-        {
-          path: join(agentHome, '.ignore'),
-          lines: [
-            '/agent-harness/',
-            '/AGENTS.md',
-            '/.harnessmith/',
-            '/.harnessmith-stage-*',
-            '/.harnessmith-restore-*',
-            '/.harnessmith-operation.lock',
-            '/rules/agent-harness.mdc',
-            '/*.backup-*',
-            '/rules/agent-harness.mdc.backup-*',
-          ],
-        },
-      ],
-    };
-  }
-  throw new HarnessmithError('CLI_USAGE', `Unsupported agent: ${name}`, 2);
+  return resolver({
+    env,
+    project,
+    userHome: canonicalPath(env.HOME || homedir()),
+  });
 }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,25 +1,22 @@
-import type { AgentName } from './types.js';
+import {
+  adapterAliasMap,
+  adapterRegistry,
+  isRegisteredAgentName,
+  supportedAgentNames,
+  type AgentName,
+} from './adapter-registry.js';
 import { HarnessmithError } from './types.js';
 
-export const supportedAgentNames = [
-  'codex',
-  'cursor',
-  'claude',
-  'opencode',
-] as const satisfies readonly AgentName[];
+export { supportedAgentNames } from './adapter-registry.js';
 
-export const supportedAgents = [
-  { value: 'codex', label: 'Codex', hint: 'global configuration' },
-  { value: 'cursor', label: 'Cursor', hint: 'current project' },
-  { value: 'claude', label: 'Claude Code', hint: 'global configuration' },
-  { value: 'opencode', label: 'OpenCode', hint: 'global configuration' },
-];
+export const supportedAgents = adapterRegistry.map(({ name, label, hint }) => ({
+  value: name,
+  label,
+  hint,
+}));
 
 export function isAgentName(value: unknown): value is AgentName {
-  return (
-    typeof value === 'string' &&
-    supportedAgentNames.includes(value as (typeof supportedAgentNames)[number])
-  );
+  return isRegisteredAgentName(value);
 }
 
 export function collectAgents(value: string, previous: string[] = []): string[] {
@@ -33,20 +30,14 @@ export function collectAgents(value: string, previous: string[] = []): string[] 
 }
 
 export function normalizeAgents(values: string[]): AgentName[] {
-  const aliases = new Map<string, AgentName>([
-    ['1', 'codex'],
-    ['2', 'cursor'],
-    ['3', 'claude'],
-    ['4', 'opencode'],
-    ['claude-code', 'claude'],
-  ]);
+  const aliases = adapterAliasMap();
   const expanded = values.flatMap((value) =>
     value.toLowerCase() === 'all'
       ? supportedAgents.map(({ value: name }) => name)
       : value.split(/[\s,]+/),
   );
   const agents = [...new Set(expanded.filter(Boolean).map((value) => aliases.get(value) || value))];
-  const known = new Set(supportedAgents.map(({ value }) => value));
+  const known = new Set<string>(supportedAgentNames);
   const invalid = agents.filter((value) => !known.has(value));
   if (invalid.length > 0)
     throw new HarnessmithError('CLI_USAGE', `Unsupported agent: ${invalid.join(', ')}`, 2);

--- a/src/instruction-formats.ts
+++ b/src/instruction-formats.ts
@@ -1,0 +1,29 @@
+/**
+ * Instruction format extension points for Adapter-managed rule files.
+ * Host path selection stays in adapters; this module only owns render shapes.
+ * Future formats (for example host-native rule DSLs) register here beside markdown/mdc.
+ */
+
+export type InstructionFormatId = 'markdown' | 'mdc';
+
+export interface InstructionFormatDefinition {
+  readonly id: InstructionFormatId;
+  readonly render: (content: string) => string;
+}
+
+export function renderMarkdownInstructions(content: string): string {
+  return `<!-- managed-by: harnessmith -->\n\n${content}`;
+}
+
+export function renderMdcInstructions(content: string): string {
+  return `---\ndescription: Personal coding agent harness\nglobs:\nalwaysApply: true\n---\n\n<!-- managed-by: harnessmith -->\n\n${content}`;
+}
+
+export const instructionFormats = {
+  markdown: { id: 'markdown', render: renderMarkdownInstructions },
+  mdc: { id: 'mdc', render: renderMdcInstructions },
+} as const satisfies Record<InstructionFormatId, InstructionFormatDefinition>;
+
+export function instructionRenderer(format: InstructionFormatId): (content: string) => string {
+  return instructionFormats[format].render;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from 'node:stream';
+import type { AgentName } from './adapter-registry.js';
 
-export type AgentName = 'codex' | 'cursor' | 'claude' | 'opencode';
+export type { AgentName };
 export type OutputAction = 'create' | 'replace-managed' | 'conflict';
 export type ManagedStatus = 'managed' | 'modified' | 'missing';
 


### PR DESCRIPTION
## Summary
- 建立声明式 `adapter-registry`，统一宿主身份、别名、capabilities，并抽出 `instruction-formats` 扩展点
- 新增参数化 `adapter-conformance` 套件，覆盖 dry-run / install / status / upgrade / restore / uninstall / conflict / 多 Adapter 预检与回滚
- preflight 校验 `evals/run.schema.json` 的 adapter enum 与 registry 清单一致，并更新贡献/架构文档

Closes #8

## Test plan
- [x] `pnpm run build`
- [x] `pnpm exec vitest run src/__tests__/adapter-registry.test.ts src/__tests__/adapter-conformance.test.ts`
- [ ] `pnpm run preflight`（建议在 Linux / CI 上确认；Windows 上 symlink 与文件 mode 相关用例会受环境影响）
- [ ] 确认现有 Codex / Cursor / Claude Code / OpenCode 安装与 lifecycle 行为无回归
