### PR TITLE
fix(eval): align profile control verdicts

### DIFF
--- a/evals/__tests__/eval-codex-matrix-support.test.ts
+++ b/evals/__tests__/eval-codex-matrix-support.test.ts
@@ -62,6 +62,45 @@ test('scenario aggregation preserves genuine evaluator failures', async () => {
   });
 });
 
+test('explicit profile controls accept equivalent Markdown audit tables', async () => {
+  const { isRoutineMemoryAnnouncement } = await support();
+  const message = [
+    '| action | path | validation |',
+    '|---|---|---|',
+    '| forgotten | `global-memory/memory/profile.md` | Harness returned `updated` |',
+  ].join('\n');
+
+  assert.equal(
+    isRoutineMemoryAnnouncement({
+      turnLabel: 'forget-profile',
+      turnKind: 'user',
+      message,
+      beforeMemoryMutation: false,
+      hasRoutineMemoryMutation: true,
+    }),
+    false,
+  );
+});
+
+test('code-review profile keys accept stable review dimensions only', async () => {
+  const { isCodeReviewProfileKey } = await support();
+
+  assert.equal(isCodeReviewProfileKey('review.ordering', 'communication.status-summary'), true);
+  assert.equal(
+    isCodeReviewProfileKey('engineering.code-review-order', 'communication.status-summary'),
+    true,
+  );
+  assert.equal(
+    isCodeReviewProfileKey('identity.current-role', 'communication.status-summary'),
+    false,
+  );
+  assert.equal(isCodeReviewProfileKey('Review.Ordering', 'communication.status-summary'), false);
+  assert.equal(
+    isCodeReviewProfileKey('communication.status-summary', 'communication.status-summary'),
+    false,
+  );
+});
+
 test('resumed Codex turns retain their additional writable roots through config', async () => {
   const { buildCodexTurn } = await support();
   const args = buildCodexTurn({

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -1217,7 +1217,12 @@ export function isRoutineMemoryAnnouncement({
     )
   ) {
     if (beforeMemoryMutation && hasRoutineMemoryMutation && text) return true;
-    if (/\baction\s*:/iu.test(text) && /\bpath\s*:/iu.test(text) && /\bvalidation\s*:/iu.test(text)) {
+    const inlineAudit =
+      /\baction\s*:/iu.test(text) &&
+      /\bpath\s*:/iu.test(text) &&
+      /\bvalidation\s*:/iu.test(text);
+    const tableAudit = /\|\s*action\s*\|\s*path\s*\|\s*validation\s*\|/iu.test(text);
+    if (inlineAudit || tableAudit) {
       return false;
     }
     return /memory|handoff|checkpoint|记忆|交接|沉淀/i.test(text);
@@ -1297,6 +1302,15 @@ export function isRoutineMemoryAnnouncement({
   if (hasRoutineMemoryMutation && explicitSidecarContext) return true;
   if (formalMemorySourceContext && !explicitSidecarContext) return false;
   return /memory|profile|sidecar|handoff|checkpoint|记忆|画像|交接|沉淀/i.test(text);
+}
+
+export function isCodeReviewProfileKey(key, existingKey) {
+  const value = String(key ?? '');
+  return Boolean(
+    value !== String(existingKey ?? '') &&
+      value.length <= 100 &&
+      /^(?:communication|engineering|review)\.[a-z0-9]+(?:[.-][a-z0-9]+)*$/u.test(value),
+  );
 }
 
 function assertedFencedApiBoundaryTargets(content) {

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -39,6 +39,7 @@ import {
   inspectJsonPayloadPath,
   inspectProjectScopePath,
   isExplicitProfileControlRoutingViolation,
+  isCodeReviewProfileKey,
   isRoutineMemoryAnnouncement,
   isRoutineMemoryMaintenanceDisclosure,
   isUnauditableCloseHandoffCommand,
@@ -2249,10 +2250,10 @@ if (scenarioId === 'memory-autopilot-unprompted') {
   const explicitPausedUpdateKey = String(
     explicitPausedUpdateInvocation?.payload?.value?.key ?? '',
   );
-  const safeExplicitPausedUpdateKey =
-    /^(?:communication|engineering)\.[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(
-      explicitPausedUpdateKey,
-    ) && explicitPausedUpdateKey !== reconciledProfileKey;
+  const safeExplicitPausedUpdateKey = isCodeReviewProfileKey(
+    explicitPausedUpdateKey,
+    reconciledProfileKey,
+  );
   const escapedExplicitPausedUpdateKey = explicitPausedUpdateKey.replace(
     /[.*+?^${}()|[\]\\]/g,
     '\\$&',


### PR DESCRIPTION
## Summary / 变更说明

- Accept equivalent Markdown `action` / `path` / `validation` audit tables for explicit profile controls without treating them as routine sidecar announcements.
- Align code-review profile-key validation with the Harness stable-key contract for `communication`, `engineering`, and `review` dimensions.
- Add focused regression coverage for accepted and rejected formats.

## Related Issue / 关联 Issue

Closes #79

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix-support.test.ts`
- `pnpm run preflight` (683 preflight checks; 120 test files; 852 passed, 3 skipped)

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits.
- [x] Evaluator behavior changes include focused tests.
- [x] Pure host-signal silence and sidecar visibility boundaries remain unchanged.
- [x] No generated `dist/` files, secrets, personal memory, or private paths are included.
