### PR TITLE
fix(memory): keep sidecar commentary quiet

### DIFF
--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -179,6 +179,15 @@ test('background sidecars stay quiet while explicit Memory requests remain audit
     agents,
     /纯 host-signal\/replay.*允许空响应.*不得.*agent_message.*强制响应.*上一用户任务.*验证结果.*不提.*sidecar/s,
   );
+  assert.match(
+    agents,
+    /commentary.*只描述.*用户任务.*不得.*(?:记录|保存|同步|更新).*(?:偏好|验收约束|Memory|profile|handoff|checkpoint)/s,
+  );
+  assert.match(
+    projectMemory,
+    /commentary.*只描述.*用户任务.*不得.*(?:记录|保存|同步|更新).*(?:偏好|验收约束|Memory|profile|handoff|checkpoint)/s,
+  );
+  assert.match(userProfile, /commentary.*不得.*预告.*(?:记录|保存|同步|更新).*(?:偏好|画像)/s);
 });
 
 test('documentation states the real host-hook and source-of-truth boundaries', () => {

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -47,7 +47,8 @@
   只有宿主要求的跨 turn identical replay 原样复用成功 payload。
 - Handoff 的 `verification` 写当前 verifier 精确命令与 `exit 0`，`completed` 不能代替；旧 `open` 全部解决时首次即用
   `clearOpen: true`，不得用 `clear: ["open"]` 试探；同一 session 的第二个独立已验证任务用 `reason: multi-task`。
-- 自动后台 sidecar 保持静默；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final，只报告用户任务结果。
+- 自动后台 sidecar 保持静默；commentary 只描述用户任务，不得说将记录、保存、同步或更新偏好、验收约束、
+  Memory、profile、handoff 或 checkpoint；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final。
 - 纯 host-signal/replay turn：宿主允许空响应时不得发送 `agent_message`；强制响应时只陈述上一用户任务的验证结果，不提 sidecar 动作。
 - 普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；只有用户明确请求 Memory 审计时例外。
 - 用户明确请求 Memory 操作、交接、状态或审计时，返回最小可核验结果：`action`、`path`、`validation`；proposed 或 blocked 时说明原因。

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -167,7 +167,8 @@ Token、Cookie、验证码、私钥或未脱敏生产数据。
 
 自动后台 sidecar 的恢复、检索、写入、校验和维护状态保持静默，不预告、不混入普通 commentary/final，
 也不把“已保留”“已归档”“已校验”改写成用户任务结果。
-普通 commentary 不得用“值得保留”“纳入结论”或近义词披露任何后台保存意图。
+普通 commentary 只描述用户任务，不得说将记录、保存、同步或更新偏好、验收约束、Memory、profile、
+handoff 或 checkpoint，也不得用“值得保留”“纳入结论”或近义词披露任何后台保存意图。
 
 普通任务中的 Memory 恢复、检索、修复、归档和校验均属后台 sidecar，不得出现在 commentary/final；
 即使 Memory 支撑了结论，也只报告经事实源核对后的用户任务结果。

--- a/template/agent-harness/docs/standards/user-profile-memory.md
+++ b/template/agent-harness/docs/standards/user-profile-memory.md
@@ -123,7 +123,8 @@ paused 时，“以后/未来默认使用表格”等仍是普通偏好，不是
 明确遗忘时，从已读 canonical profile 按当前结论唯一匹配：唯一命中才原样使用其 exact key 执行
 `forget-profile`；0 个或多个候选时报告阻塞并请求澄清，禁止猜 key。唯一命中不得以“已替代”“无需删除”
 或相近理由跳过。自动 reconcile 的
-`created/updated/unchanged` 不预告/复述画像或偏好，`proposed/blocked` 仅简报阻塞；用户要求纠正、忘记、
+`created/updated/unchanged` 不预告/复述画像或偏好，commentary 不得预告记录、保存、同步或更新偏好/画像；
+`proposed/blocked` 仅简报阻塞；用户要求纠正、忘记、
 暂停或恢复时不发过程通知，仅在最终答复简短报告结果或阻塞；默认单句，但用户当前格式要求优先。
 paused 时普通偏好只作为当前指令执行；答复按当前格式只答`好的`，不得复述、确认或承诺偏好及其
 适用范围，也不提 profile、autopilot 或持久化。查看画像按用户请求完整回答。


### PR DESCRIPTION
## Summary / 变更说明

- Make ordinary commentary describe only the user task and explicitly forbid announcing automatic Memory/profile/input/handoff/checkpoint maintenance.
- Reinforce the same visibility boundary in the bounded project-memory and user-profile standards loaded by routed Host turns.
- Add prompt-contract regression coverage while preserving explicit Memory audit responses.

## Related Issue / 关联 Issue

Closes #81

## Verification / 验证

- `pnpm exec vitest run src/__tests__/memory-autopilot-prompt.test.ts`
- `pnpm run preflight` (683 preflight checks; 120 test files; 852 passed, 3 skipped)

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits.
- [x] Prompt behavior changes include focused tests.
- [x] Explicit Memory controls remain auditable; pure host-signal silence is unchanged.
- [x] No generated `dist/` files, secrets, personal memory, or private paths are included.
