### PR TITLE
fix(eval): align multi-task checkpoint proof

### DIFF
--- a/evals/__tests__/eval-codex-matrix-support.test.ts
+++ b/evals/__tests__/eval-codex-matrix-support.test.ts
@@ -101,6 +101,37 @@ test('code-review profile keys accept stable review dimensions only', async () =
   );
 });
 
+test('multi-task checkpoint proof starts after the second verified task', async () => {
+  const { multiTaskCheckpointReplacementIsProven } = await support();
+  const afterSecond = {
+    path: '.agent-docs/sessions/2026/08/31/multi-thread-23.md',
+    digest: 'second',
+    reason: 'multi-task',
+  };
+  const afterThird = {
+    path: afterSecond.path,
+    digest: 'third',
+    reason: 'multi-task',
+  };
+
+  assert.equal(
+    multiTaskCheckpointReplacementIsProven({
+      afterSecond,
+      afterThird,
+      allVerifiersPassed: true,
+    }),
+    true,
+  );
+  assert.equal(
+    multiTaskCheckpointReplacementIsProven({
+      afterSecond,
+      afterThird: { ...afterThird, digest: afterSecond.digest },
+      allVerifiersPassed: true,
+    }),
+    false,
+  );
+});
+
 test('resumed Codex turns retain their additional writable roots through config', async () => {
   const { buildCodexTurn } = await support();
   const args = buildCodexTurn({

--- a/scripts/eval-codex-matrix-support.mjs
+++ b/scripts/eval-codex-matrix-support.mjs
@@ -123,6 +123,22 @@ export function responseSeparatesAssessmentFromAction(message) {
   return reportsNoAction && describesProspectiveAction;
 }
 
+export function multiTaskCheckpointReplacementIsProven({
+  afterSecond,
+  afterThird,
+  allVerifiersPassed,
+}) {
+  return Boolean(
+    afterSecond &&
+      afterThird &&
+      afterSecond.path === afterThird.path &&
+      afterSecond.digest !== afterThird.digest &&
+      afterSecond.reason === 'multi-task' &&
+      afterThird.reason === 'multi-task' &&
+      allVerifiersPassed,
+  );
+}
+
 export function scenarioTurnPlan(scenarioId, initialPrompt) {
   const initial = { label: 'initial', prompt: initialPrompt, kind: 'user' };
   if (scenarioId === 'memory-autopilot-unprompted') {

--- a/scripts/eval-codex-scenario.mjs
+++ b/scripts/eval-codex-scenario.mjs
@@ -50,6 +50,7 @@ import {
   memoryPayloadOutputIsCompatible,
   memoryPayloadAttemptViolatesBoundary,
   mentionsRetryInvestigationContext,
+  multiTaskCheckpointReplacementIsProven,
   parseCodexInputTokens,
   parseCodexThreadId,
   parseInstallCaptureEnvelope,
@@ -2743,18 +2744,12 @@ if (scenarioId === 'memory-autopilot-phase-only') {
 }
 if (scenarioId === 'memory-autopilot-multi-task') {
   const snapshots = ['initial', 'item-b', 'item-c'].map((label) => snapshot(label, 'multi-thread-23'));
-  const [afterA, afterB, afterC] = snapshots;
+  const [, afterB, afterC] = snapshots;
   const final = snapshots[2];
   const core = readFileSync(join(repo, '.agent-docs', 'core.md'), 'utf8');
   const completed = section(final?.content, '已完成');
   const next = section(final?.content, '下一步');
   const objective = section(final?.content, '当前目标');
-  const samePath = Boolean(
-    afterA && afterB && afterC && afterA.path === afterB.path && afterB.path === afterC.path,
-  );
-  const distinctDigests = Boolean(
-    afterA && afterB && afterC && afterA.digest !== afterB.digest && afterB.digest !== afterC.digest,
-  );
   const activeStates = ['initial', 'item-b', 'item-c'].map((label) => {
     const observation = turnByLabel.get(label)?.observation;
     const active = (observation?.handoffs['multi-thread-23'] ?? []).filter((item) => item.status === 'active');
@@ -2800,7 +2795,11 @@ if (scenarioId === 'memory-autopilot-multi-task') {
   const multiTaskBoundaryOk = memoryAutopilotBoundaryOk;
   setAssertions(
     [
-      Boolean(samePath && distinctDigests && afterB?.reason === 'multi-task' && afterC?.reason === 'multi-task' && verifiersPassed('initial', 'item-b', 'item-c')),
+      multiTaskCheckpointReplacementIsProven({
+        afterSecond: afterB,
+        afterThird: afterC,
+        allVerifiersPassed: verifiersPassed('initial', 'item-b', 'item-c'),
+      }),
       Boolean(structuredSnapshot && concreteNext && ['item-a.txt', 'item-b.txt', 'item-c.txt'].every((path) => completed.includes(path))),
       Boolean(final && finalActiveIndexInvariant && !containsRawTranscript && (core.match(new RegExp(final.reference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))?.length ?? 0) === 1),
     ],


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

Align the `memory-autopilot-multi-task` evaluator with the distributed Harness contract: the first `multi-task` checkpoint is expected after the second independently verified task, then the third task must replace that same session snapshot. The proof still requires one path, a changed digest, `reason: multi-task` on both snapshots, and all three verifiers to pass.

## Related Issue / 关联 Issue

Closes #83

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-codex-matrix-support.test.ts evals/__tests__/eval-codex-matrix.test.ts evals/__tests__/scenarios.test.ts` — 29 passed.
- `pnpm run preflight` — 687 preflight checks; 124 test files; 881 passed, 3 skipped.
- Exact RC Host canary `memory-autopilot-multi-task` with `gpt-5.6-sol`, 15-minute scenario timeout, no automatic retry, 1 MiB output cap — passed 10/10 assertions.
- Exact RC SHA-256: `059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a`.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

This changes evaluator logic only; it does not alter the candidate package contents or behavior fingerprint.
