### PR TITLE
chore(release): prepare 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnessmith",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Distribute and safely manage a cross-host personal harness and durable work state.",
   "repository": {
     "type": "git",

--- a/release-attestation.json
+++ b/release-attestation.json
@@ -1,12 +1,12 @@
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "packageName": "harnessmith",
-  "packageVersion": "0.8.0",
-  "tag": "v0.8.0",
-  "artifactSha256": "c6c1c828767b7743f4b34d67d93f4d36a3b8955d7b52370a072e8eb940be1137",
-  "behaviorSha256": "3f9e194533f1ca94cd121e1ef510bdb2f3daaa82ced83f352c2e589bdc5693b4",
+  "packageVersion": "0.9.0",
+  "tag": "v0.9.0",
+  "artifactSha256": "c82c207195f54737680946cb4d99fd20b84979fedfd498324024a8f5ddc746d0",
+  "behaviorSha256": "6fdab16d1f326ce2b1132dd6bdca4f38edbbcedbea49f48921daceaf2ae74644",
   "harnessVersion": "2.6.0",
-  "rulesSha256": "14991ba38de731fdcdbecc10df6f51edb9d9684cc4c8b4c7824b925a6cc0b050",
+  "rulesSha256": "f6484e294660ce05d9d289a7c72f81f0ad4dc5bbdcf4e807ac697b10d4baf8bb",
   "scenarios": {
     "bootstrap-global-memory": "6083a39adb7b37e281ee795dd22c14d0dc0504556c147e18aa8b61282aa5a967",
     "progressive-disclosure": "6d25689a827a44f3aa1d7c4e268510ae14e8f844325f1e1eb3f757a192aa0df0",
@@ -22,40 +22,98 @@
     "memory-autopilot-phase-only": "d2f921cc843522ec5707d091d1a96f8d7a425c6cf34d6f2694364e1d8aae191a",
     "memory-autopilot-multi-task": "bbf99b68d7b23ed4c520e5e7f137487530f9076a06729b2f7ec0fca177bb8d19",
     "memory-profile-cross-task-recall": "4e828fc1207215d86bd80d265d412563c6d0f5aca274ba3c9e5faafb09f9aab7",
-    "cross-repository-map-writeback": "6480e2e7725a164f4f3f43932d9fa0a7a47be120f19042d91aa3971162c1abac"
+    "cross-repository-map-writeback": "25de2e061a2501e35f7e6ec9aea6190889eff332e4cd1592295a87b0a77ec234"
   },
   "requiredHosts": [
     "codex"
   ],
-  "coverageCount": 0,
-  "exactArtifactCoverageCount": 0,
-  "inheritedBehaviorCoverageCount": 0,
-  "inheritedFrom": [],
-  "assurance": "maintainer-attested-risk-exception",
-  "riskAcceptance": {
-    "schemaVersion": 1,
-    "acceptedAt": "2026-08-29T05:20:44Z",
-    "authorizedBy": "user",
-    "reason": "User explicitly accepted the exact Harnesssmith 0.8.0 candidate Host Eval coverage risk and authorized publication before resolving the execution-model problem tracked by GitHub Issue #44. The post-merge Codex Host coverage remains infrastructure-inconclusive after repeated transport timeouts and is not represented as passing.",
-    "uncoveredScenarios": [
-      "codex/bootstrap-global-memory",
-      "codex/progressive-disclosure",
-      "codex/memory-fact-separation",
-      "codex/destructive-boundary",
-      "codex/safe-path-boundary",
-      "codex/machine-error-contract",
-      "codex/memory-lifecycle-boundary",
-      "codex/project-memory-recall-writeback",
-      "codex/experience-distillation-promotion",
-      "codex/task-acceptance-gate",
-      "codex/memory-autopilot-unprompted",
-      "codex/memory-autopilot-phase-only",
-      "codex/memory-autopilot-multi-task",
-      "codex/memory-profile-cross-task-recall",
-      "codex/cross-repository-map-writeback"
+  "coverageCount": 15,
+  "exactArtifactCoverageCount": 1,
+  "inheritedBehaviorCoverageCount": 14,
+  "inheritedFrom": [
+    {
+      "packageVersion": "0.9.0",
+      "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+    }
+  ],
+  "evidence": {
+    "exact": [
+      "codex/machine-error-contract"
     ],
-    "packageVersion": "0.8.0",
-    "packageArtifactSha256": "c6c1c828767b7743f4b34d67d93f4d36a3b8955d7b52370a072e8eb940be1137"
+    "inherited": [
+      {
+        "cell": "codex/bootstrap-global-memory",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/progressive-disclosure",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-fact-separation",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/destructive-boundary",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/safe-path-boundary",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-lifecycle-boundary",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/project-memory-recall-writeback",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/experience-distillation-promotion",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/task-acceptance-gate",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-autopilot-unprompted",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-autopilot-phase-only",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-autopilot-multi-task",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/memory-profile-cross-task-recall",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      },
+      {
+        "cell": "codex/cross-repository-map-writeback",
+        "packageVersion": "0.9.0",
+        "packageArtifactSha256": "059bc995597ec14f91dcaae9dc5c201b0e416453749e0ef7e5a65affa25f244a"
+      }
+    ],
+    "infraBlocked": []
   },
-  "preparedAt": "2026-08-29T05:26:37.985Z"
+  "assurance": "maintainer-attested-structure",
+  "preparedAt": "2026-08-31T08:12:24.170Z"
 }


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

Prepare the protected-branch release commit for `harnessmith@0.9.0`: bump the package version and bind the release attestation to the frozen candidate, current behavior/rules fingerprints, and fresh Host Eval gate evidence.

## Related Issue / 关联 Issue

Closes #85

## Verification / 验证

- `pnpm run release:prepare` — passed release quality, unit coverage, scripts coverage, and the 15-cell Host Eval gate.
- Candidate SHA-256: `c82c207195f54737680946cb4d99fd20b84979fedfd498324024a8f5ddc746d0`.
- Host Eval: 15/15 coverage; 1 exact (`codex/machine-error-contract`), 14 dependency-aware inherited, 0 infra blocked.
- `node --import tsx scripts/release-version.ts ci-verify --artifact .release/c82c207195f54737-harnessmith-0.9.0.tgz --tag v0.9.0` — passed.
- npm registry, GitHub Release, and remote tag preflight confirmed `0.9.0` absent before publication.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 本 PR 仅冻结已验证 release metadata，无新增行为。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 发布边界已由 attestation 与现有文档覆盖。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

After merge, the signed `v0.9.0` tag will be recreated against the actual protected-branch merge commit and pushed to trigger publication.
