### PR TITLE
feat(memory): add typed promotion proposals

### DIFF
--- a/template/agent-harness/docs/core/harness-cli-architecture.md
+++ b/template/agent-harness/docs/core/harness-cli-architecture.md
@@ -131,6 +131,12 @@ Memory maintenance 遵循非权威边界：`migrate` 默认只输出 proposal，
 仍被 active index 引用的记忆，`promote` 只输出 proposal。`check --indexed` 要求 active/blocked
 文档可从 index 到达，`maintain` 只读报告候选。Runtime 不得自动写项目正式文档或删除记忆。
 
+`memory promote` 输出 version 2 typed proposal，并由
+`schemas/memory-promotion.schema.json` 约束。调用方必须声明 ADR、docs、tests、schema、lint 或 CI
+目标类型、目标 owner、理由与精确 verifier；报告同时给出 source freshness、目标 dirty state、证据、授权缺口
+和未满足条件。proposal 自身永远不构成正式写入授权；只有目标已存在且提供 adoption evidence 时才产生可追踪的
+supersede candidate，仍须 owner 确认并走 typed lifecycle，不能报告为已采纳或已 supersede。
+
 `memory curate <project> --task <id>` 是只读的 task/workstream 策展报告。它只输出 proposal 候选并显式区分
 phase、task、workstream 完成与用户取消；不得嵌入 `task close`，也不得代替 `promote`、`close-input`、
 `supersede` 或 `archive` 的 mutation 与门禁。

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -191,6 +191,11 @@ proposed 或 blocked 时同时说明原因和所需决策。普通任务仍只�
 维护的结论必须提升到 `docs/`、ADR、测试、schema、lint 或 CI；先确认 owner，再实际写入和验证正式事实源，
 最后把 memory 更新为正式来源引用或 superseded。proposal 不得报告为 promoted。
 
+`memory promote` 的 typed proposal 只允许 ADR、docs、tests、schema、lint 与 CI 六类正式载体。它必须列出
+候选 Memory、目标路径与 owner、理由、原始证据、精确 verifier、source freshness、目标 dirty state、授权状态与
+未满足条件；输出不会创建或修改目标。目标已承接结论时，只有显式 adoption evidence 才能形成 supersede candidate，
+该 candidate 仍不是已采纳事实，也不能绕过 owner 确认、正式 verifier 或 typed lifecycle mutation。
+
 任务或阶段结束后可运行 `memory curate <project> --task <id> --json` 获取只读、proposal-first 策展报告。
 报告把 `phase-complete`、`task-complete`、`workstream-complete` 与 `user-cancel` 分开，并只检查当前
 task/workstream 关联的 Memory；输出 promote、close、supersede、archive、skipped 候选或 `result: none`。

--- a/template/agent-harness/schemas/memory-promotion.schema.json
+++ b/template/agent-harness/schemas/memory-promotion.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:agent-harness:schema:memory-promotion:v2",
+  "title": "Agent Harness Memory Promotion Proposal",
+  "type": "object",
+  "required": [
+    "version",
+    "schema",
+    "mode",
+    "memory",
+    "source",
+    "target",
+    "title",
+    "description",
+    "reason",
+    "evidence",
+    "verification",
+    "authorization",
+    "unmetConditions",
+    "supersedeCandidate",
+    "sourceOfTruth"
+  ],
+  "properties": {
+    "version": { "const": 2 },
+    "schema": { "const": "urn:agent-harness:schema:memory-promotion:v2" },
+    "mode": { "const": "proposal-only" },
+    "memory": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "required": ["kind", "status", "updated", "freshness", "owners"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "minLength": 1 },
+        "updated": { "type": ["string", "null"], "format": "date" },
+        "freshness": { "enum": ["current", "stale", "unknown"] },
+        "owners": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      },
+      "additionalProperties": false
+    },
+    "target": {
+      "type": "object",
+      "required": ["path", "reference", "artifactType", "owner", "exists", "dirty"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "reference": { "type": "string", "minLength": 1 },
+        "artifactType": { "enum": ["adr", "docs", "tests", "schema", "lint", "ci"] },
+        "owner": { "type": "string", "minLength": 1 },
+        "exists": { "type": "boolean" },
+        "dirty": { "type": ["boolean", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "reason": { "type": "string", "minLength": 1 },
+    "evidence": {
+      "type": "object",
+      "required": ["items", "sourceRefs"],
+      "properties": {
+        "items": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "sourceRefs": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      },
+      "additionalProperties": false
+    },
+    "verification": {
+      "type": "object",
+      "required": ["command", "status"],
+      "properties": {
+        "command": { "type": "string", "minLength": 1 },
+        "status": { "const": "required" }
+      },
+      "additionalProperties": false
+    },
+    "authorization": {
+      "type": "object",
+      "required": ["formalWrite"],
+      "properties": {
+        "formalWrite": { "const": "not-authorized-by-proposal" }
+      },
+      "additionalProperties": false
+    },
+    "unmetConditions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "supersedeCandidate": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": [
+            "status",
+            "memory",
+            "authoritativeTarget",
+            "evidence",
+            "requiredLifecycle"
+          ],
+          "properties": {
+            "status": { "const": "candidate" },
+            "memory": { "type": "string", "pattern": "^memory:.+" },
+            "authoritativeTarget": { "type": "string", "minLength": 1 },
+            "evidence": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "requiredLifecycle": { "const": "owner-confirmed-typed-supersede" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "sourceOfTruth": { "const": false }
+  },
+  "additionalProperties": false
+}

--- a/template/agent-harness/src/__tests__/cli.test.ts
+++ b/template/agent-harness/src/__tests__/cli.test.ts
@@ -1,14 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
@@ -224,50 +216,6 @@ test('validation rejects an unsupported embedded memory schema version', () => {
     ),
     true,
   );
-});
-
-test('Harness CLI exposes proposal-only memory promotion', () => {
-  const root = mkdtempSync(join(tmpdir(), 'harness-memory-promote-cli-'));
-  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
-  const project = join(root, 'project');
-  mkdirSync(join(project, '.agent-docs', 'distilled'), { recursive: true });
-  writeFileSync(
-    join(project, '.agent-docs', 'distilled', 'finding.md'),
-    [
-      '---',
-      'title: Finding',
-      'description: Expensive finding',
-      'type: distilled-memory',
-      'memory-kind: distilled',
-      'status: active',
-      'owners: [test-owner]',
-      'created: 2026-08-19',
-      'updated: 2026-08-19',
-      'project: test',
-      'tags: [test]',
-      'scope: []',
-      'source-refs: [docs/source.md]',
-      'source-of-truth: false',
-      'schema-version: 1',
-      '---',
-      '',
-      '# Finding',
-      '',
-    ].join('\n'),
-  );
-  execFileSync('git', ['-C', project, 'init', '-q']);
-  const runtime = harnessRuntime(root);
-  const output = capturedIo();
-
-  assert.equal(
-    runCli(
-      ['memory', 'promote', project, 'distilled/finding', '--target', 'docs/finding.md', '--json'],
-      { runtime, io: output },
-    ),
-    0,
-  );
-  assert.equal(JSON.parse(output.logs[0]).mode, 'proposal-only');
-  assert.equal(existsSync(join(project, 'docs', 'finding.md')), false);
 });
 
 test('doctor and validate pass for an installed fixture and report missing prerequisites', () => {

--- a/template/agent-harness/src/__tests__/memory-promotion-cli.test.ts
+++ b/template/agent-harness/src/__tests__/memory-promotion-cli.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { runCli } from '../cli.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('Harness CLI exposes typed proposal-only memory promotion JSON', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-memory-promote-cli-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(join(project, '.agent-docs', 'distilled'), { recursive: true });
+  writeFileSync(
+    join(project, '.agent-docs', 'distilled', 'finding.md'),
+    `---\ntitle: Finding\ndescription: Expensive finding\ntype: distilled-memory\nmemory-kind: distilled\nstatus: active\nowners: [test-owner]\ncreated: 2026-08-19\nupdated: 2026-08-19\nproject: test\ntags: [test]\nscope: []\nsource-refs: [docs/source.md]\nsource-of-truth: false\nschema-version: 1\n---\n\n# Finding\n`,
+  );
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  const output = capturedIo();
+
+  assert.equal(
+    runCli(
+      [
+        'memory',
+        'promote',
+        project,
+        'distilled/finding',
+        '--target',
+        'docs/finding.md',
+        '--artifact-type',
+        'docs',
+        '--owner',
+        'docs-owner',
+        '--reason',
+        'Promote the finding into maintained documentation.',
+        '--verifier',
+        'pnpm run check:docs',
+        '--json',
+      ],
+      { runtime, io: output },
+    ),
+    0,
+  );
+  const proposal = JSON.parse(output.logs[0]);
+  assert.equal(proposal.version, 2);
+  assert.equal(proposal.mode, 'proposal-only');
+  assert.equal(proposal.target.artifactType, 'docs');
+  assert.equal(proposal.target.owner, 'docs-owner');
+  assert.deepEqual(proposal.unmetConditions, ['formal-write-authorization-required']);
+  assert.equal(existsSync(join(project, 'docs', 'finding.md')), false);
+});

--- a/template/agent-harness/src/__tests__/memory-promotion.test.ts
+++ b/template/agent-harness/src/__tests__/memory-promotion.test.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
 import { initProject } from '../commands/init.js';
 import { resolveMemoryRoot } from '../commands/memory.js';
 import { memoryPromotionProposal } from '../commands/memory-promotion.js';
+import { findingDigest } from '../lib/memory-finding.js';
+import { assertPromotionTargetType } from '../lib/memory-promotion-contract.js';
 import { capturedIo, harnessRuntime } from './helpers/harness.js';
 
 function memoryDocument(title: string): string {
@@ -14,7 +16,7 @@ function memoryDocument(title: string): string {
     '---',
     `title: ${title}`,
     `description: ${title} memory`,
-    'type: session-handoff',
+    'type: analytical-finding',
     'memory-kind: distilled',
     'status: active',
     'owners: [test-owner]',
@@ -23,10 +25,31 @@ function memoryDocument(title: string): string {
     'project: test',
     'tags: [test]',
     'scope: []',
-    'source-refs: []',
+    'source-refs: [docs/source.md]',
     'source-of-truth: false',
     'schema-version: 1',
+    'finding-schema-version: 2',
+    'finding-kind: analysis',
+    'fact-class: settled-fact',
+    `finding-digest: sha256:${findingDigest('analysis', 'Stable finding.')}`,
+    'retention: durable',
     '---',
+    '',
+    '# 结论',
+    '',
+    'Stable finding.',
+    '',
+    '# 理由',
+    '',
+    'The behavior is stable and reusable.',
+    '',
+    '# 应用',
+    '',
+    'Maintain the contract in project documentation.',
+    '',
+    '# 证据',
+    '',
+    '- Reproduced by the focused fixture.',
     '',
   ].join('\n');
 }
@@ -41,18 +64,46 @@ test('memory promotion produces a proposal without writing authoritative docs', 
   initProject(runtime, project, capturedIo());
   const memory = join(project, '.agent-docs', 'distilled', 'finding.md');
   writeFileSync(memory, memoryDocument('Finding'));
+  mkdirSync(join(project, 'docs'), { recursive: true });
+  writeFileSync(join(project, 'docs', 'source.md'), 'Source evidence.\n');
   const target = join(dirname(resolveMemoryRoot(runtime, project)), 'docs', 'finding.md');
 
   const proposal = memoryPromotionProposal(
     runtime,
     project,
     'distilled/finding',
-    'docs/finding.md',
+    {
+      target: 'docs/finding.md',
+      artifactType: 'docs',
+      owner: 'docs-owner',
+      reason: 'The finding should become a team-maintained contract.',
+      verifier: 'pnpm run check:docs',
+    },
     capturedIo(),
   );
 
+  assert.equal(proposal.version, 2);
   assert.equal(proposal.mode, 'proposal-only');
-  assert.equal(proposal.target, target);
+  assert.deepEqual(proposal.target, {
+    path: target,
+    reference: 'docs/finding.md',
+    artifactType: 'docs',
+    owner: 'docs-owner',
+    exists: false,
+    dirty: false,
+  });
+  assert.equal(proposal.reason, 'The finding should become a team-maintained contract.');
+  assert.deepEqual(proposal.evidence, {
+    items: ['Reproduced by the focused fixture.'],
+    sourceRefs: ['docs/source.md'],
+  });
+  assert.equal(proposal.verification.command, 'pnpm run check:docs');
+  assert.equal(proposal.verification.status, 'required');
+  assert.equal(proposal.authorization.formalWrite, 'not-authorized-by-proposal');
+  assert.equal(proposal.source.freshness, 'current');
+  assert.deepEqual(proposal.source.owners, ['test-owner']);
+  assert.deepEqual(proposal.unmetConditions, ['formal-write-authorization-required']);
+  assert.equal(proposal.supersedeCandidate, null);
   assert.equal(proposal.sourceOfTruth, false);
   assert.equal(existsSync(target), false);
   assert.throws(
@@ -61,9 +112,89 @@ test('memory promotion produces a proposal without writing authoritative docs', 
         runtime,
         project,
         'distilled/finding',
-        '.agent-docs/promoted.md',
+        {
+          target: '.agent-docs/promoted.md',
+          artifactType: 'docs',
+          owner: 'docs-owner',
+          reason: 'Invalid target.',
+          verifier: 'pnpm run check:docs',
+        },
         capturedIo(),
       ),
     /authoritative project path/,
   );
+  assert.throws(
+    () =>
+      memoryPromotionProposal(
+        runtime,
+        project,
+        'distilled/finding',
+        {
+          target: 'src/runtime.ts',
+          artifactType: 'docs',
+          owner: 'docs-owner',
+          reason: 'Mislabeled target.',
+          verifier: 'pnpm run check:docs',
+        },
+        capturedIo(),
+      ),
+    /artifact type.*target/i,
+  );
+
+  writeFileSync(target, '# Finding\n\nAdopted contract.\n');
+  execFileSync('git', ['-C', project, 'add', 'docs/finding.md']);
+  const adopted = memoryPromotionProposal(
+    runtime,
+    project,
+    'distilled/finding',
+    {
+      target: 'docs/finding.md',
+      artifactType: 'docs',
+      owner: 'docs-owner',
+      reason: 'The finding is now carried by the formal document.',
+      verifier: 'pnpm run check:docs',
+      adoptionEvidence: ['docs/finding.md#finding'],
+    },
+    capturedIo(),
+  );
+  assert.equal(adopted.target.dirty, true);
+  assert.deepEqual(adopted.unmetConditions, [
+    'formal-write-authorization-required',
+    'target-dirty',
+  ]);
+  assert.deepEqual(adopted.supersedeCandidate, {
+    status: 'candidate',
+    memory: 'memory:distilled/finding',
+    authoritativeTarget: 'docs/finding.md',
+    evidence: ['docs/finding.md#finding'],
+    requiredLifecycle: 'owner-confirmed-typed-supersede',
+  });
+
+  const artifactTargets = [
+    ['adr', 'docs/adr/0001-purpose.md'],
+    ['docs', 'docs/purpose.md'],
+    ['tests', 'src/__tests__/purpose.test.ts'],
+    ['schema', 'schemas/purpose.schema.json'],
+    ['lint', 'biome.json'],
+    ['ci', '.github/workflows/ci.yml'],
+  ] as const;
+  for (const [artifactType, artifactTarget] of artifactTargets) {
+    assert.doesNotThrow(() => assertPromotionTargetType(artifactType, artifactTarget));
+  }
+
+  const schema = JSON.parse(
+    readFileSync(
+      join(process.cwd(), 'template', 'agent-harness', 'schemas', 'memory-promotion.schema.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(schema.$id, proposal.schema);
+  assert.deepEqual(schema.properties.target.properties.artifactType.enum, [
+    'adr',
+    'docs',
+    'tests',
+    'schema',
+    'lint',
+    'ci',
+  ]);
 });

--- a/template/agent-harness/src/__tests__/memory-proposal-serialization-safety.test.ts
+++ b/template/agent-harness/src/__tests__/memory-proposal-serialization-safety.test.ts
@@ -14,7 +14,10 @@ import { join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
 import { initGlobal, initProject } from '../commands/init.js';
 import { memoryMigrate } from '../commands/memory-migration.js';
-import { memoryPromotionProposal } from '../commands/memory-promotion.js';
+import {
+  type MemoryPromotionOptions,
+  memoryPromotionProposal,
+} from '../commands/memory-promotion.js';
 import { maximumMemoryDocumentBytes } from '../lib/memory-path.js';
 import { capturedIo, harnessRuntime } from './helpers/harness.js';
 
@@ -66,6 +69,16 @@ function distilledDocument({
     'Finding body.',
     '',
   ].join('\n');
+}
+
+function promotionOptions(target = 'docs/finding.md'): MemoryPromotionOptions {
+  return {
+    target,
+    artifactType: 'docs',
+    owner: 'docs-owner',
+    reason: 'Promote the bounded finding.',
+    verifier: 'pnpm run check:docs',
+  };
 }
 
 test('migration rejects high-confidence secrets at any nested metadata depth before reporting', () => {
@@ -159,7 +172,7 @@ test('promotion rejects secrets in every serialized metadata field before loggin
     writeFileSync(path, distilledDocument(metadata));
     const io = capturedIo();
     assert.throws(
-      () => memoryPromotionProposal(runtime, project, 'distilled/finding', 'docs/finding.md', io),
+      () => memoryPromotionProposal(runtime, project, 'distilled/finding', promotionOptions(), io),
       /promotion proposal.*high-confidence secret|memory preflight failed/i,
     );
     assert.deepEqual(io.logs, []);
@@ -174,7 +187,13 @@ test('promotion rejects a secret-bearing request target before serializing its p
   let message = '';
 
   try {
-    memoryPromotionProposal(runtime, project, 'distilled/finding', `docs/${token}.md`, io);
+    memoryPromotionProposal(
+      runtime,
+      project,
+      'distilled/finding',
+      promotionOptions(`docs/${token}.md`),
+      io,
+    );
   } catch (error) {
     message = error instanceof Error ? error.message : String(error);
   }
@@ -191,7 +210,7 @@ test('promotion preflight redacts a malformed secret-bearing source document', (
   let message = '';
 
   try {
-    memoryPromotionProposal(runtime, project, 'distilled/finding', 'docs/finding.md', io);
+    memoryPromotionProposal(runtime, project, 'distilled/finding', promotionOptions(), io);
   } catch (error) {
     message = error instanceof Error ? error.message : String(error);
   }
@@ -212,7 +231,7 @@ test('promotion bounds memory reads before parsing frontmatter', () => {
         runtime,
         project,
         'distilled/finding',
-        'docs/finding.md',
+        promotionOptions(),
         capturedIo(),
       ),
     /memory document.*exceeds|byte budget/i,
@@ -232,7 +251,7 @@ test('promotion preflights authoritative target paths against project symlinks',
         runtime,
         project,
         'distilled/finding',
-        'docs/finding.md',
+        promotionOptions(),
         capturedIo(),
       ),
     /symbolic link|resolves outside/i,
@@ -247,7 +266,7 @@ test('promotion validates the full managed root before serializing a proposal', 
   const io = capturedIo();
 
   assert.throws(
-    () => memoryPromotionProposal(runtime, project, 'distilled/finding', 'docs/finding.md', io),
+    () => memoryPromotionProposal(runtime, project, 'distilled/finding', promotionOptions(), io),
     /memory (?:check|preflight) failed/i,
   );
   assert.deepEqual(io.logs, []);
@@ -261,7 +280,14 @@ test('promotion rejects a global memory root reached through its parent path', (
   initGlobal(runtime, capturedIo());
 
   assert.throws(
-    () => memoryPromotionProposal(runtime, parent, 'profile', 'docs/profile.md', capturedIo()),
+    () =>
+      memoryPromotionProposal(
+        runtime,
+        parent,
+        'profile',
+        promotionOptions('docs/profile.md'),
+        capturedIo(),
+      ),
     /promotion requires a project memory scope/i,
   );
 });

--- a/template/agent-harness/src/commands/memory-promotion.ts
+++ b/template/agent-harness/src/commands/memory-promotion.ts
@@ -1,5 +1,6 @@
-import { dirname, resolve } from 'node:path';
-import { parseFrontmatter } from '../lib/frontmatter.js';
+import { existsSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { parseFrontmatterDocument } from '../lib/frontmatter.js';
 import {
   isInside,
   memoryDocumentPath,
@@ -8,30 +9,39 @@ import {
   resolveMemoryRoot,
 } from '../lib/memory-path.js';
 import { validateMemoryPreflight } from '../lib/memory-preflight.js';
+import {
+  assertPromotionTargetType,
+  boundedPromotionValue,
+  type MemoryPromotionOptions,
+  type MemoryPromotionProposal,
+  promotionSource,
+} from '../lib/memory-promotion-contract.js';
 import { resolveProjectRoot } from '../lib/project.js';
+import { createProjectGitBudget, projectGit } from '../lib/project-git.js';
 import { assertSafePath, sameCanonicalPath } from '../lib/safe-path.js';
 import { assertNoHighConfidenceSecret } from '../lib/secret-hygiene.js';
 import type { Io, Runtime } from '../types.js';
 
-export interface MemoryPromotionProposal {
-  version: 1;
-  mode: 'proposal-only';
-  memory: string;
-  target: string;
-  title: string;
-  description: string;
-  sourceRefs: string[];
-  sourceOfTruth: false;
+export type {
+  MemoryPromotionOptions,
+  MemoryPromotionProposal,
+} from '../lib/memory-promotion-contract.js';
+
+function targetDirty(project: string, reference: string): boolean | null {
+  const status = projectGit(
+    project,
+    ['status', '--porcelain=v1', '--untracked-files=all', '--', reference],
+    createProjectGitBudget({}),
+  );
+  return status === null ? null : status.length > 0;
 }
 
-export function memoryPromotionProposal(
+function promotionPaths(
   runtime: Runtime,
   input: string,
   name: string,
-  targetName: string,
-  io: Io = console,
-): MemoryPromotionProposal {
-  assertNoHighConfidenceSecret([input, name, targetName], 'Memory promotion request');
+  options: MemoryPromotionOptions,
+) {
   if (input === 'global') throw new Error('Promotion requires a project memory scope');
   const project = resolveProjectRoot(input);
   assertSafePath(project, project);
@@ -44,38 +54,117 @@ export function memoryPromotionProposal(
   }
   assertSafePath(project, root);
   const source = memoryDocumentPath(root, name);
-  const target = resolve(project, targetName);
+  const target = resolve(project, options.target);
   if (target === project || !isInside(project, target) || isInside(root, target)) {
     throw new Error(
       `Promotion target must be an authoritative project path outside .agent-docs: ${target}`,
     );
   }
   assertSafePath(project, target);
+  const targetReference = relative(project, target).split(sep).join('/');
+  assertPromotionTargetType(options.artifactType, targetReference);
+  return { project, root, source, target, targetReference };
+}
+
+function readPromotionSource(root: string, source: string) {
   validateMemoryPreflight(root, 'project');
   const sourceContent = readMemoryDocument(source);
   assertNoHighConfidenceSecret([sourceContent], 'Memory promotion source');
-  let metadata: Map<string, unknown>;
+  let parsed: ReturnType<typeof parseFrontmatterDocument>;
   try {
-    metadata = parseFrontmatter(sourceContent);
+    parsed = parseFrontmatterDocument(sourceContent);
   } catch {
     throw new Error('Invalid memory promotion source frontmatter');
   }
-  const title = String(metadata.get('title') || 'untitled');
-  const description = String(metadata.get('description') || '');
-  const sourceRefs = Array.isArray(metadata.get('source-refs'))
-    ? (metadata.get('source-refs') as unknown[]).filter(
-        (value): value is string => typeof value === 'string',
-      )
-    : [];
-  assertNoHighConfidenceSecret([title, description, ...sourceRefs], 'Memory promotion proposal');
-  const proposal: MemoryPromotionProposal = {
-    version: 1,
-    mode: 'proposal-only',
-    memory: memoryReference(root, source),
-    target,
+  if (!parsed.found) throw new Error('Invalid memory promotion source frontmatter');
+  return promotionSource(parsed.metadata, parsed.body);
+}
+
+export function memoryPromotionProposal(
+  runtime: Runtime,
+  input: string,
+  name: string,
+  options: MemoryPromotionOptions,
+  io: Io = console,
+): MemoryPromotionProposal {
+  const owner = boundedPromotionValue(options.owner, 'owner');
+  const reason = boundedPromotionValue(options.reason, 'reason');
+  const verifier = boundedPromotionValue(options.verifier, 'verifier');
+  const adoptionEvidence = (options.adoptionEvidence ?? []).map((item) =>
+    boundedPromotionValue(item, 'adoption evidence'),
+  );
+  assertNoHighConfidenceSecret(
+    [
+      input,
+      name,
+      options.target,
+      options.artifactType,
+      owner,
+      reason,
+      verifier,
+      ...adoptionEvidence,
+    ],
+    'Memory promotion request',
+  );
+  const { project, root, source, target, targetReference } = promotionPaths(
+    runtime,
+    input,
+    name,
+    options,
+  );
+  const {
     title,
     description,
     sourceRefs,
+    evidenceItems,
+    source: sourceReport,
+  } = readPromotionSource(root, source);
+  assertNoHighConfidenceSecret(
+    [title, description, ...sourceRefs, ...evidenceItems],
+    'Memory promotion proposal',
+  );
+  const memory = memoryReference(root, source);
+  const dirty = targetDirty(project, targetReference);
+  const unmetConditions = ['formal-write-authorization-required'];
+  if (dirty === true) unmetConditions.push('target-dirty');
+  else if (dirty === null) unmetConditions.push('target-dirty-unknown');
+  if (sourceReport.freshness === 'stale') unmetConditions.push('source-stale');
+  else if (sourceReport.freshness === 'unknown') unmetConditions.push('source-freshness-unknown');
+  if (sourceRefs.length === 0 && evidenceItems.length === 0) {
+    unmetConditions.push('source-evidence-required');
+  }
+  if (sourceReport.owners.length === 0) unmetConditions.push('source-owner-required');
+  const proposal: MemoryPromotionProposal = {
+    version: 2,
+    schema: 'urn:agent-harness:schema:memory-promotion:v2',
+    mode: 'proposal-only',
+    memory,
+    source: sourceReport,
+    target: {
+      path: target,
+      reference: targetReference,
+      artifactType: options.artifactType,
+      owner,
+      exists: existsSync(target),
+      dirty,
+    },
+    title,
+    description,
+    reason,
+    evidence: { items: evidenceItems, sourceRefs },
+    verification: { command: verifier, status: 'required' },
+    authorization: { formalWrite: 'not-authorized-by-proposal' },
+    unmetConditions,
+    supersedeCandidate:
+      existsSync(target) && adoptionEvidence.length > 0
+        ? {
+            status: 'candidate',
+            memory: `memory:${memory}`,
+            authoritativeTarget: targetReference,
+            evidence: adoptionEvidence,
+            requiredLifecycle: 'owner-confirmed-typed-supersede',
+          }
+        : null,
     sourceOfTruth: false,
   };
   io.log(JSON.stringify(proposal, null, 2));

--- a/template/agent-harness/src/lib/memory-promotion-contract.ts
+++ b/template/agent-harness/src/lib/memory-promotion-contract.ts
@@ -1,0 +1,113 @@
+import { findingListSection } from './memory-finding.js';
+
+export type PromotionArtifactType = 'adr' | 'docs' | 'tests' | 'schema' | 'lint' | 'ci';
+
+export interface MemoryPromotionOptions {
+  target: string;
+  artifactType: PromotionArtifactType;
+  owner: string;
+  reason: string;
+  verifier: string;
+  adoptionEvidence?: string[];
+}
+
+export interface MemoryPromotionProposal {
+  version: 2;
+  schema: 'urn:agent-harness:schema:memory-promotion:v2';
+  mode: 'proposal-only';
+  memory: string;
+  source: {
+    kind: string;
+    status: string;
+    updated: string | null;
+    freshness: 'current' | 'stale' | 'unknown';
+    owners: string[];
+  };
+  target: {
+    path: string;
+    reference: string;
+    artifactType: PromotionArtifactType;
+    owner: string;
+    exists: boolean;
+    dirty: boolean | null;
+  };
+  title: string;
+  description: string;
+  reason: string;
+  evidence: { items: string[]; sourceRefs: string[] };
+  verification: { command: string; status: 'required' };
+  authorization: { formalWrite: 'not-authorized-by-proposal' };
+  unmetConditions: string[];
+  supersedeCandidate: {
+    status: 'candidate';
+    memory: string;
+    authoritativeTarget: string;
+    evidence: string[];
+    requiredLifecycle: 'owner-confirmed-typed-supersede';
+  } | null;
+  sourceOfTruth: false;
+}
+
+export function boundedPromotionValue(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 500 || /\r|\n/.test(normalized)) {
+    throw new Error(`Memory promotion ${label} must be a bounded single line`);
+  }
+  return normalized;
+}
+
+export function assertPromotionTargetType(type: PromotionArtifactType, reference: string): void {
+  const path = reference.toLowerCase();
+  const matches =
+    (type === 'adr' && /^(?:docs\/)?adrs?\/.+\.md$/u.test(path)) ||
+    (type === 'docs' && /^docs\/.+\.md$/u.test(path)) ||
+    (type === 'tests' &&
+      /(?:^|\/)__tests__\/.+\.[cm]?[jt]sx?$|\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(path)) ||
+    (type === 'schema' && /(?:^|\/)schemas?\/.+|\.schema\.(?:json|ya?ml)$/u.test(path)) ||
+    (type === 'lint' &&
+      /(?:^|\/)(?:biome|eslint|markdownlint|secretlint|lint)[^/]*|(?:^|\/)scripts\/[^/]*lint/u.test(
+        path,
+      )) ||
+    (type === 'ci' && /^\.github\/workflows\/.+\.ya?ml$/u.test(path));
+  if (!matches) {
+    throw new Error(`Promotion artifact type ${type} does not match target: ${reference}`);
+  }
+}
+
+function sourceFreshness(metadata: Map<string, unknown>): 'current' | 'stale' | 'unknown' {
+  const status = metadata.get('status');
+  if (status === 'superseded' || status === 'archived') return 'stale';
+  const updated = metadata.get('updated');
+  if (
+    ['active', 'blocked', 'complete'].includes(String(status)) &&
+    typeof updated === 'string' &&
+    /^\d{4}-\d{2}-\d{2}$/u.test(updated)
+  ) {
+    return 'current';
+  }
+  return 'unknown';
+}
+
+export function promotionSource(metadata: Map<string, unknown>, body: string) {
+  const stringList = (field: string) =>
+    Array.isArray(metadata.get(field))
+      ? (metadata.get(field) as unknown[]).filter(
+          (value): value is string => typeof value === 'string' && value.trim().length > 0,
+        )
+      : [];
+  return {
+    title: String(metadata.get('title') || 'untitled'),
+    description: String(metadata.get('description') || ''),
+    sourceRefs: stringList('source-refs'),
+    evidenceItems: [
+      ...new Set([...findingListSection(body, '证据'), ...findingListSection(body, 'Evidence')]),
+    ],
+    source: {
+      kind: String(metadata.get('type') || 'unknown'),
+      status: String(metadata.get('status') || 'unknown'),
+      updated: typeof metadata.get('updated') === 'string' ? String(metadata.get('updated')) : null,
+      freshness: sourceFreshness(metadata),
+      owners: stringList('owners'),
+    },
+  };
+}

--- a/template/agent-harness/src/program/memory.ts
+++ b/template/agent-harness/src/program/memory.ts
@@ -3,7 +3,10 @@ import { memoryCheck, memoryList, memorySearch } from '../commands/memory.js';
 import { type CurationOptions, curateMemory } from '../commands/memory-curation.js';
 import { archiveMemory, memoryMaintenance, supersedeMemory } from '../commands/memory-lifecycle.js';
 import { memoryMigrate } from '../commands/memory-migration.js';
-import { memoryPromotionProposal } from '../commands/memory-promotion.js';
+import {
+  type MemoryPromotionOptions,
+  memoryPromotionProposal,
+} from '../commands/memory-promotion.js';
 import type { Io, Runtime } from '../types.js';
 import { registerMemoryAutopilotCommands } from './memory-autopilot.js';
 import { registerMemoryCaptureEligibilityCommand } from './memory-capture-eligibility.js';
@@ -112,10 +115,18 @@ function registerMemoryMutationCommands(
     .command('promote <scope> <memory>')
     .description('emit a proposal for promoting memory into an authoritative project document')
     .requiredOption('--target <path>', 'project-relative authoritative document path')
+    .requiredOption('--artifact-type <type>', 'adr, docs, tests, schema, lint, or ci')
+    .requiredOption('--owner <owner>', 'owner of the authoritative target')
+    .requiredOption('--reason <reason>', 'bounded reason for promotion')
+    .requiredOption('--verifier <command>', 'exact verifier required after adoption')
+    .option(
+      '--adoption-evidence <reference...>',
+      'evidence that the target already carries the fact',
+    )
     .option('--json', 'write the proposal as JSON')
     .action(
-      run((scope: string, name: string, options: { target: string }) =>
-        memoryPromotionProposal(runtime, scope, name, options.target, io),
+      run((scope: string, name: string, options: MemoryPromotionOptions) =>
+        memoryPromotionProposal(runtime, scope, name, options, io),
       ),
     );
 }


### PR DESCRIPTION
## Summary / 变更说明

- 将 `memory promote` 升级为 version 2 typed proposal，明确正式载体类型、owner、理由、证据、verifier、授权与未满足条件。
- 只检查目标存在性、目标 scoped dirty state 与来源 freshness；proposal 不写正式事实源，也不把候选描述为已采纳。
- 为已由正式载体承接且提供 adoption evidence 的 Memory 输出可追踪 supersede candidate，仍要求 owner 确认和 typed lifecycle。
- 增加 JSON Schema、CLI/契约/序列化安全回归测试及架构边界文档。

## Related Issue / 关联 Issue

Closes #97


## Verification / 验证

- `pnpm exec vitest run template/agent-harness/src/__tests__/memory-promotion.test.ts template/agent-harness/src/__tests__/memory-promotion-cli.test.ts template/agent-harness/src/__tests__/memory-proposal-serialization-safety.test.ts` — 12 passed
- `pnpm run test:coverage:unit` — 132 files, 929 passed, 4 skipped; thresholds passed
- `pnpm run test:scripts-coverage` — 29 files, 215 passed, 2 skipped; thresholds passed
- `pnpm run test:harness` — 74 files, 528 passed, 2 skipped
- `pnpm run preflight` — 740 checks; 132 files, 930 passed, 3 skipped
- `git diff --check` — passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

`memory promote` 始终是 proposal-only；正式写入授权、正式 verifier 与后续 lifecycle mutation 均不由该命令代替。
