### PR TITLE
feat(memory): unify workflow relationships

### DIFF
--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -73,8 +73,13 @@ Memory 不是事实数据库。它保存来源、上下文、任务恢复信息�
 node <harness-path>/bin/harness.mjs memory list project --json
 node <harness-path>/bin/harness.mjs memory search project "npm cache" --json
 node <harness-path>/bin/harness.mjs memory check project --indexed --json
+node <harness-path>/bin/harness.mjs memory relationships /absolute/project/path --json
 node <harness-path>/bin/harness.mjs memory maintain project --json
 ```
+
+`memory relationships` 是项目级只读报告：统一列出 Task、默认 phase/workstream、Memory owner、session 与
+lifecycle role，并报告 orphan task reference 和 cross-workstream binding。它不把 Task 完成推断为 workstream
+完成，也不把 Handoff 当作 acceptance evidence 或事实源。
 
 `memory maintain` 只报告未索引、过期、重复、可归档和替代关系异常，不会自行删除或改写。旧 metadata 通过
 `memory migrate` 先生成 proposal；只有提案状态为 ready 且显式传入 `--apply` 才写入。`supersede` 建立替代关系，

--- a/template/agent-harness/docs/core/harness-cli-architecture.md
+++ b/template/agent-harness/docs/core/harness-cli-architecture.md
@@ -139,7 +139,14 @@ supersede candidate，仍须 owner 确认并走 typed lifecycle，不能报告�
 
 `memory curate <project> --task <id>` 是只读的 task/workstream 策展报告。它只输出 proposal 候选并显式区分
 phase、task、workstream 完成与用户取消；不得嵌入 `task close`，也不得代替 `promote`、`close-input`、
-`supersede` 或 `archive` 的 mutation 与门禁。
+`supersede` 或 `archive` 的 mutation 与门禁。具有多个 `task:` owner 的共享文档不得因单个 task/workstream
+结束而进入 close 或 archive candidate。
+
+`memory relationships <project>` 输出 version 1、`report-only` 的关系视图。Task ledger 继续拥有验收状态；
+关系视图只确定性派生默认 workstream 与 current phase，并把 Memory 的 task/workstream/session owner 及
+lifecycle role 归一化。报告检测 orphan task reference 与 cross-workstream binding，但不写回 Task 或 Memory，
+也不把 Handoff `recovery-state` 当作 acceptance evidence。`memory maintain` 与 bootstrap 复用同一关系报告，
+避免各入口分别猜测生命周期。
 
 `memory maintain` 输出 version 2 read-only audit：统一列出 duplicate、stale、contradicted、expired、
 unindexed、broken-reference、cycle、budget、来源缺口及现有 input/purpose review 候选。每项包含稳定

--- a/template/agent-harness/docs/core/long-running-tasks.md
+++ b/template/agent-harness/docs/core/long-running-tasks.md
@@ -45,6 +45,8 @@ node {{HARNESS_HOME}}/agent-harness/bin/harness.mjs task close --project /absolu
 
 Task ledger 是任务验收状态与当前 `nextAction` 的唯一事实源；handoff 只保存跨上下文恢复快照。
 Handoff 的 `reason` 取值为 `phase`、`compaction`、`multi-task`、`manual`，触发与优先级均由本节定义。
+已有 Handoff 从一个 `task-id` 切换到另一个 `task-id` 时，Runtime 机械要求 `multi-task`；`phase`、
+`compaction` 或 `manual` 不能掩盖独立任务切换。
 
 长任务不等待宿主会话结束事件。当前 workstream 的 plan/backlog 已核验有具体后续阶段即属“仍有后续”；
 陈旧或不相关 backlog 不触发 phase checkpoint。即使该阶段尚未获本轮执行授权，也只是不执行后续，不得

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -201,7 +201,13 @@ proposed 或 blocked 时同时说明原因和所需决策。普通任务仍只�
 task/workstream 关联的 Memory；输出 promote、close、supersede、archive、skipped 候选或 `result: none`。
 task complete 不自动表示 workstream complete，不能据此关闭仍有效的 input 或 handoff。报告不证明任务完成，
 不执行 mutation；promotion 仍需 owner、授权与事实源验证，close/supersede/archive 仍走现有 typed lifecycle
-命令及其 inbound reference、状态和 cycle 门禁。
+命令及其 inbound reference、状态和 cycle 门禁。多个 `task:` source ref 表示共享 owner；只结束其中一个
+task/workstream 时不得关闭或归档该文档。
+
+`memory relationships <project> --json` 只读汇总 Task、默认 phase/workstream、Memory、session 与 owner 关系，
+并报告 orphan task reference 和 cross-workstream binding。关系报告不是新的权威状态层；Task ledger 继续拥有
+acceptance，Handoff 只拥有 recovery state。任务切换到同一 Handoff 的第二个独立 task 时必须使用
+`checkpoint-reason: multi-task`。
 
 ## 维护与安全
 

--- a/template/agent-harness/schemas/workflow-relations.schema.json
+++ b/template/agent-harness/schemas/workflow-relations.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:agent-harness:schema:workflow-relations:v1",
+  "title": "Workflow relationship report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "schema", "mode", "sourceOfTruth", "tasks", "memory", "conflicts", "summary"],
+  "properties": {
+    "version": { "const": 1 },
+    "schema": { "const": "urn:agent-harness:schema:workflow-relations:v1" },
+    "mode": { "const": "report-only" },
+    "sourceOfTruth": { "const": false },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task", "workstream", "phase", "status"],
+        "properties": {
+          "task": { "type": "string", "minLength": 1 },
+          "workstream": { "type": "string", "minLength": 1 },
+          "phase": { "type": "string", "minLength": 1 },
+          "status": { "enum": ["pending", "in_progress", "blocked", "complete", "superseded"] }
+        }
+      }
+    },
+    "memory": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["reference", "lifecycleRole", "owners", "taskRefs", "workstream", "session"],
+        "properties": {
+          "reference": { "type": "string", "pattern": "^memory:" },
+          "lifecycleRole": { "enum": ["task-progress", "workstream-state", "durable-knowledge", "recovery-state", "other"] },
+          "owners": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "taskRefs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "workstream": { "type": ["string", "null"] },
+          "session": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "reference", "evidence", "risk"],
+        "properties": {
+          "code": { "enum": ["orphan-task-reference", "cross-workstream-binding", "session-task-conflict"] },
+          "reference": { "type": "string", "pattern": "^memory:" },
+          "evidence": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+          "risk": { "enum": ["medium", "high"] }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tasks", "memory", "conflicts"],
+      "properties": {
+        "tasks": { "type": "integer", "minimum": 0 },
+        "memory": { "type": "integer", "minimum": 0 },
+        "conflicts": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/template/agent-harness/src/__tests__/memory-curation.test.ts
+++ b/template/agent-harness/src/__tests__/memory-curation.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
@@ -131,6 +131,39 @@ test('task completion does not close workstream state, while workstream completi
   assert.ok(workstreamComplete.closeCandidates[0].reference.includes('inputs/'));
   assert.doesNotMatch(JSON.stringify(workstreamComplete), /Parallel workstream input/);
   assert.equal(digestPath(memoryRoot), before);
+});
+
+test('workstream completion does not close Memory shared by another task reference', () => {
+  const { project, runtime, taskId } = fixture('shared-owner-task');
+  const created = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Shared workstream constraint',
+      content: 'Keep this while either related task remains active.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const content = readFileSync(created.path, 'utf8');
+  writeFileSync(
+    created.path,
+    content.replace(`source-refs: []`, `source-refs: [task:${taskId}, task:parallel-task]`),
+  );
+
+  const report = curateMemory(
+    runtime,
+    project,
+    { task: taskId, workstream: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  );
+
+  assert.equal(report.closeCandidates.length, 0);
+  assert.ok(report.skipped.some(({ reason }) => /shared task owner.*parallel-task/i.test(reason)));
 });
 
 test('curation handles expired and superseded candidates but blocks active inbound references', () => {

--- a/template/agent-harness/src/__tests__/memory-handoff-document-boundaries.test.ts
+++ b/template/agent-harness/src/__tests__/memory-handoff-document-boundaries.test.ts
@@ -74,6 +74,22 @@ test('handoff reconciliation rejects conflicting clear and replacement values', 
   );
 });
 
+test('changing a task-bound handoff requires the multi-task checkpoint reason', () => {
+  const existing = legacyGenerationOneDocument('# Current goal\n\nResume.').replace(
+    'session-id: document-boundary',
+    'session-id: document-boundary\ntask-id: first-task',
+  );
+  assert.throws(
+    () => reconcileHandoffOptions({ ...base, taskId: 'second-task', reason: 'phase' }, existing),
+    /multi-task.*task transition/i,
+  );
+  assert.equal(
+    reconcileHandoffOptions({ ...base, taskId: 'second-task', reason: 'multi-task' }, existing)
+      .taskId,
+    'second-task',
+  );
+});
+
 test('handoff reconciliation requires explicit clear operations for blank values', () => {
   assert.throws(
     () => reconcileHandoffOptions({ ...base, facts: '  ' }, ''),

--- a/template/agent-harness/src/__tests__/workflow-relations-acceptance.test.ts
+++ b/template/agent-harness/src/__tests__/workflow-relations-acceptance.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { initProject } from '../commands/init.js';
+import { initTask } from '../commands/task.js';
+import { verifyAcceptance } from '../commands/task-verification.js';
+import { renderHandoff } from '../lib/memory-handoff.js';
+import { assertAcceptanceEvidenceRole } from '../lib/workflow-relations.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('a Handoff recovery snapshot cannot satisfy file acceptance evidence', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-handoff-evidence-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  const task = initTask(
+    runtime,
+    { project, id: 'handoff-evidence', objective: 'Reject recovery state', acceptance: ['Proof'] },
+    capturedIo(),
+  );
+  const memoryRoot = join(project, '.agent-docs');
+  const handoff = join(memoryRoot, 'sessions', '2026', '09', '01', 'evidence-handoff.md');
+  mkdirSync(dirname(handoff), { recursive: true });
+  writeFileSync(
+    handoff,
+    renderHandoff(
+      runtime,
+      {
+        session: 'evidence-handoff',
+        title: 'Handoff evidence',
+        objective: 'Resume this task.',
+        completed: 'Captured recovery state.',
+        next: 'Continue implementation.',
+        reason: 'phase',
+      },
+      { sessionId: 'evidence-handoff', sessionBase: 'evidence-handoff', generation: 1 },
+      memoryRoot,
+      '2026-09-01',
+      '2026-09-01',
+    ),
+  );
+
+  assert.throws(
+    () => assertAcceptanceEvidenceRole(project, handoff),
+    /handoff.*recovery.*acceptance evidence/i,
+  );
+  assert.throws(
+    () =>
+      verifyAcceptance(
+        {
+          project,
+          id: task.id,
+          criterion: 'criterion-1',
+          type: 'file',
+          file: handoff,
+        },
+        capturedIo(),
+      ),
+    /handoff.*recovery.*acceptance evidence/i,
+  );
+});

--- a/template/agent-harness/src/__tests__/workflow-relations.test.ts
+++ b/template/agent-harness/src/__tests__/workflow-relations.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { runCli } from '../cli.js';
+import { initProject } from '../commands/init.js';
+import { initTask } from '../commands/task.js';
+import { workflowRelations } from '../commands/workflow-relations.js';
+import { buildWorkflowRelationReport } from '../lib/workflow-relations.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('relation model reports owners, lifecycle roles, orphans, and cross-workstream conflicts', () => {
+  const report = buildWorkflowRelationReport(
+    [
+      { id: 'task-a', status: 'in_progress' },
+      { id: 'task-b', status: 'in_progress' },
+    ],
+    [
+      {
+        reference: 'memory:shared',
+        type: 'working-note',
+        kind: 'working',
+        status: 'active',
+        workstream: 'task-a',
+        sourceRefs: ['task:task-a', 'task:task-b'],
+      },
+      {
+        reference: 'memory:handoff',
+        type: 'session-handoff',
+        kind: 'episode',
+        status: 'active',
+        taskId: 'task-a',
+        workstream: 'different-stream',
+        session: 'session-a',
+        sourceRefs: ['task:task-a'],
+      },
+      {
+        reference: 'memory:orphan',
+        type: 'working-note',
+        kind: 'working',
+        status: 'active',
+        sourceRefs: ['task:missing-task'],
+      },
+    ],
+  );
+
+  assert.equal(report.version, 1);
+  assert.equal(report.mode, 'report-only');
+  assert.deepEqual(report.tasks[0], {
+    task: 'task-a',
+    workstream: 'task-a',
+    phase: 'task-a:phase:current',
+    status: 'in_progress',
+  });
+  assert.deepEqual(report.memory.find(({ reference }) => reference === 'memory:shared')?.owners, [
+    'task:task-a',
+    'task:task-b',
+    'workstream:task-a',
+  ]);
+  assert.equal(
+    report.memory.find(({ reference }) => reference === 'memory:handoff')?.lifecycleRole,
+    'recovery-state',
+  );
+  assert.ok(report.conflicts.some(({ code }) => code === 'orphan-task-reference'));
+  assert.ok(report.conflicts.some(({ code }) => code === 'cross-workstream-binding'));
+});
+
+test('workflow relation CLI emits the shared model without mutating project state', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-workflow-relations-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  initTask(
+    runtime,
+    { project, id: 'relation-task', objective: 'Inspect relations', acceptance: ['Report exists'] },
+    capturedIo(),
+  );
+  const before = execFileSync('git', ['-C', project, 'status', '--porcelain']).toString();
+  const io = capturedIo();
+
+  const report = workflowRelations(runtime, project, { json: true }, io);
+
+  assert.equal(report.tasks[0].task, 'relation-task');
+  assert.equal(JSON.parse(io.logs[0]).mode, 'report-only');
+  assert.equal(execFileSync('git', ['-C', project, 'status', '--porcelain']).toString(), before);
+
+  const cli = capturedIo();
+  assert.equal(runCli(['memory', 'relationships', project, '--json'], { runtime, io: cli }), 0);
+  assert.equal(JSON.parse(cli.logs[0]).summary.tasks, 1);
+});
+
+test('workflow relation schema is packaged with the CLI contract', () => {
+  const schema = JSON.parse(
+    readFileSync(
+      join(process.cwd(), 'template/agent-harness/schemas/workflow-relations.schema.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(schema.$id, 'urn:agent-harness:schema:workflow-relations:v1');
+});

--- a/template/agent-harness/src/commands/memory-curation.ts
+++ b/template/agent-harness/src/commands/memory-curation.ts
@@ -6,6 +6,7 @@ import {
 import { validateMemoryRoot } from '../lib/memory-validation.js';
 import { assertNoHighConfidenceSecret } from '../lib/secret-hygiene.js';
 import { projectRoot, readTask } from '../lib/task-store.js';
+import { otherTaskOwners, taskReferences } from '../lib/workflow-relations.js';
 import { calendarDate } from '../runtime.js';
 import type { Io, Runtime, TaskStatus } from '../types.js';
 
@@ -77,7 +78,6 @@ interface CandidateBuckets {
 }
 
 const activeStatuses = new Set(['active', 'blocked']);
-
 function addArchiveCandidate(
   document: CurationDocument,
   all: CurationDocument[],
@@ -90,6 +90,16 @@ function addArchiveCandidate(
     document.expires !== undefined &&
     document.expires < today;
   if (!expired && !['complete', 'superseded'].includes(document.status)) return false;
+  const owners = taskReferences(document.sourceRefs);
+  if (owners.length > 1) {
+    buckets.skipped.push(
+      candidate(
+        document,
+        `shared task owners remain: ${owners.map((owner) => `task:${owner}`).join(', ')}`,
+      ),
+    );
+    return false;
+  }
   const identity = canonicalMemoryReference(document.reference);
   const inbound = all.filter(
     (source) =>
@@ -121,6 +131,7 @@ function analyzeDocument(
   outcome: CurationOutcome,
   today: string,
   buckets: CandidateBuckets,
+  task: string,
 ): void {
   let actionable = false;
   if (
@@ -137,8 +148,18 @@ function analyzeDocument(
     document.type === 'session-handoff';
   const closesWithWorkstream = ['workstream-complete', 'user-cancel'].includes(outcome);
   if (activeStatuses.has(document.status) && workstreamState && closesWithWorkstream) {
-    buckets.close.push(candidate(document, `workstream outcome is ${outcome}`));
-    actionable = true;
+    const sharedOwners = otherTaskOwners(document.sourceRefs, task);
+    if (sharedOwners.length > 0) {
+      buckets.skipped.push(
+        candidate(
+          document,
+          `shared task owner remains: ${sharedOwners.map((owner) => `task:${owner}`).join(', ')}`,
+        ),
+      );
+    } else {
+      buckets.close.push(candidate(document, `workstream outcome is ${outcome}`));
+      actionable = true;
+    }
   } else if (activeStatuses.has(document.status) && workstreamState) {
     buckets.skipped.push(candidate(document, 'workstream continues after this task or phase'));
   }
@@ -200,7 +221,7 @@ export function curateMemory(
     skipped: [],
   };
   const today = calendarDate(runtime);
-  for (const document of scoped) analyzeDocument(document, all, outcome, today, buckets);
+  for (const document of scoped) analyzeDocument(document, all, outcome, today, buckets, task.id);
 
   const result =
     buckets.promote.length +

--- a/template/agent-harness/src/commands/memory-maintenance.ts
+++ b/template/agent-harness/src/commands/memory-maintenance.ts
@@ -79,6 +79,7 @@ function renderReport(report: MemoryMaintenanceReport, io: Io): void {
     );
   }
   io.log(`Eligibility coverage: ${report.eligibility.evaluated}/${report.eligibility.total}`);
+  io.log(`Workflow relation conflicts: ${report.relations.summary.conflicts}`);
   renderLegacyDetails(report, io);
 }
 

--- a/template/agent-harness/src/commands/task-verification.ts
+++ b/template/agent-harness/src/commands/task-verification.ts
@@ -10,6 +10,7 @@ import {
 import { outputTask } from '../lib/task-output.js';
 import { projectRoot, readTask, withTaskLock, writeTask } from '../lib/task-store.js';
 import { mechanicallyVerifyEvidence } from '../lib/task-verification.js';
+import { assertAcceptanceEvidenceRole } from '../lib/workflow-relations.js';
 import type { Io, TaskRecord } from '../types.js';
 
 export function verifyAcceptance(
@@ -43,6 +44,7 @@ export function verifyAcceptance(
     assertTaskMutable(task);
     const target = task.acceptance.find((item) => item.id === criterion);
     if (!target) throw new Error(`Acceptance criterion does not exist: ${criterion}`);
+    if (type === 'file' && file) assertAcceptanceEvidenceRole(root, file);
     validateMemoryPreflight(join(root, '.agent-docs'), 'project');
     const time = now();
     const result = mechanicallyVerifyEvidence(

--- a/template/agent-harness/src/commands/workflow-relations.ts
+++ b/template/agent-harness/src/commands/workflow-relations.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { validateMemoryRoot } from '../lib/memory-validation.js';
+import { assertNoHighConfidenceSecret } from '../lib/secret-hygiene.js';
+import { projectRoot } from '../lib/task-store.js';
+import {
+  type WorkflowRelationReport,
+  workflowRelationsForProject,
+} from '../lib/workflow-relations.js';
+import type { Io, Runtime } from '../types.js';
+
+function render(report: WorkflowRelationReport, io: Io): void {
+  io.log(
+    `Workflow relationships: ${report.summary.tasks} task(s), ${report.summary.memory} memory document(s)`,
+  );
+  io.log(`Conflicts: ${report.summary.conflicts}`);
+  for (const conflict of report.conflicts) {
+    io.log(`  ${conflict.code}: ${conflict.reference} (${conflict.evidence.join(', ')})`);
+  }
+}
+
+export function workflowRelations(
+  _runtime: Runtime,
+  project: string,
+  { json = false }: { json?: boolean } = {},
+  io: Io = console,
+): WorkflowRelationReport {
+  assertNoHighConfidenceSecret([project], 'Workflow relation request');
+  const root = projectRoot(project);
+  const memoryRoot = join(root, '.agent-docs');
+  validateMemoryRoot(memoryRoot, io, { quietSuccess: true, rootKind: 'project' });
+  const report = workflowRelationsForProject(root, memoryRoot);
+  if (json) io.log(JSON.stringify(report, null, 2));
+  else render(report, io);
+  return report;
+}

--- a/template/agent-harness/src/lib/memory-curation-documents.ts
+++ b/template/agent-harness/src/lib/memory-curation-documents.ts
@@ -16,6 +16,7 @@ export interface CurationDocument {
   retention?: string;
   workstream?: string;
   session?: string;
+  taskId?: string;
   sourceRefs: string[];
   references: string[];
 }
@@ -49,7 +50,11 @@ export function loadCurationDocuments(memoryRoot: string): CurationDocument[] {
       expires: optionalString(parsed.metadata, 'expires'),
       retention: optionalString(parsed.metadata, 'retention'),
       workstream: optionalString(parsed.metadata, 'workstream'),
-      session: optionalString(parsed.metadata, 'session'),
+      session:
+        optionalString(parsed.metadata, 'session-base') ??
+        optionalString(parsed.metadata, 'session-id') ??
+        optionalString(parsed.metadata, 'session'),
+      taskId: optionalString(parsed.metadata, 'task-id'),
       sourceRefs: Array.isArray(sourceRefs)
         ? sourceRefs.filter((entry): entry is string => typeof entry === 'string')
         : [],

--- a/template/agent-harness/src/lib/memory-handoff-document.ts
+++ b/template/agent-harness/src/lib/memory-handoff-document.ts
@@ -7,6 +7,7 @@ import { documentPurposeMetadata } from './memory-document-purpose.js';
 import type { HandoffOptions } from './memory-handoff.js';
 import type { HandoffIdentity } from './memory-handoff-identity.js';
 import { canonicalHandoffSectionTitles } from './memory-handoff-options.js';
+import { assertHandoffTaskTransition } from './workflow-relations.js';
 
 const canonicalHeadingTitles = new Set<string>(canonicalHandoffSectionTitles);
 const recognizedHeadingTitles = new Set<string>([
@@ -108,11 +109,13 @@ export function reconcileHandoffOptions(options: HandoffOptions, existing: strin
   if (existing && status !== 'active' && status !== 'blocked') {
     throw new Error(`Cannot update ${String(status || 'unknown')} handoff: ${options.session}`);
   }
+  const previousTaskId =
+    typeof metadata.get('task-id') === 'string' ? String(metadata.get('task-id')) : undefined;
+  const taskId = options.taskId ?? previousTaskId;
+  assertHandoffTaskTransition(previousTaskId, taskId, options.reason);
   return {
     ...options,
-    taskId:
-      options.taskId ??
-      (typeof metadata.get('task-id') === 'string' ? String(metadata.get('task-id')) : undefined),
+    taskId,
     status:
       options.status ??
       (existing && (status === 'active' || status === 'blocked') ? status : 'active'),

--- a/template/agent-harness/src/lib/memory-maintenance.ts
+++ b/template/agent-harness/src/lib/memory-maintenance.ts
@@ -18,6 +18,11 @@ import {
   isOpaqueMemoryContent,
   metadataReferences,
 } from './memory-validation.js';
+import {
+  buildWorkflowRelationReport,
+  type WorkflowRelationReport,
+  workflowRelationsForProject,
+} from './workflow-relations.js';
 
 export interface MemoryMaintenanceReport {
   version: 2;
@@ -50,6 +55,7 @@ export interface MemoryMaintenanceReport {
   duplicatePurposes: Array<{ purpose: string; paths: string[] }>;
   splitProposals: Array<{ path: string; reasons: string[] }>;
   coreBudget: MemoryCoreBudgetReport;
+  relations: WorkflowRelationReport;
 }
 
 function portablePath(root: string, path: string): string {
@@ -198,6 +204,10 @@ export function memoryMaintenanceReport(root: string, today: string): MemoryMain
       coverage: 0,
       reasonCode: 'maintenance-eligibility-input-unavailable',
     },
+    relations:
+      basename(root) === '.agent-docs'
+        ? workflowRelationsForProject(dirname(root), root)
+        : buildWorkflowRelationReport([], []),
     ...legacy,
   };
 }

--- a/template/agent-harness/src/lib/workflow-relations.ts
+++ b/template/agent-harness/src/lib/workflow-relations.ts
@@ -1,0 +1,203 @@
+import { existsSync } from 'node:fs';
+import { basename, dirname, extname, join, resolve } from 'node:path';
+import type { TaskStatus } from '../types.js';
+import { listFiles } from './file-discovery.js';
+import { parseFrontmatter } from './frontmatter.js';
+import { type CurationDocument, loadCurationDocuments } from './memory-curation-documents.js';
+import { isInside, readMemoryDocument } from './memory-path.js';
+import { assertSafePath, canonicalPath } from './safe-path.js';
+import { readTask } from './task-store.js';
+
+export interface TaskRelationInput {
+  id: string;
+  status: TaskStatus;
+}
+
+export interface MemoryRelationInput {
+  reference: string;
+  type: string;
+  kind: string;
+  status: string;
+  workstream?: string;
+  session?: string;
+  taskId?: string;
+  sourceRefs: string[];
+}
+
+type WorkflowRelationConflictCode =
+  | 'orphan-task-reference'
+  | 'cross-workstream-binding'
+  | 'session-task-conflict';
+
+export interface WorkflowRelationReport {
+  version: 1;
+  schema: 'urn:agent-harness:schema:workflow-relations:v1';
+  mode: 'report-only';
+  sourceOfTruth: false;
+  tasks: Array<{ task: string; workstream: string; phase: string; status: TaskStatus }>;
+  memory: Array<{
+    reference: string;
+    lifecycleRole:
+      | 'task-progress'
+      | 'workstream-state'
+      | 'durable-knowledge'
+      | 'recovery-state'
+      | 'other';
+    owners: string[];
+    taskRefs: string[];
+    workstream: string | null;
+    session: string | null;
+  }>;
+  conflicts: Array<{
+    code: WorkflowRelationConflictCode;
+    reference: string;
+    evidence: string[];
+    risk: 'medium' | 'high';
+  }>;
+  summary: { tasks: number; memory: number; conflicts: number };
+}
+
+export function taskReferences(sourceRefs: string[]): string[] {
+  return [
+    ...new Set(
+      sourceRefs.flatMap((reference) => {
+        const match = /^task:([^\s:]+)$/u.exec(reference.trim());
+        return match ? [match[1]] : [];
+      }),
+    ),
+  ].sort();
+}
+
+export function otherTaskOwners(sourceRefs: string[], task: string): string[] {
+  return taskReferences(sourceRefs).filter((owner) => owner !== task);
+}
+
+export function assertHandoffTaskTransition(
+  previousTask: string | undefined,
+  currentTask: string | undefined,
+  reason: string,
+): void {
+  if (previousTask && currentTask && previousTask !== currentTask && reason !== 'multi-task') {
+    throw new Error(
+      `Checkpoint reason multi-task is required for Handoff task transition from ${previousTask} to ${currentTask}`,
+    );
+  }
+}
+
+export function assertAcceptanceEvidenceRole(projectRoot: string, file: string): void {
+  const canonicalRoot = canonicalPath(projectRoot);
+  const absolute = canonicalPath(resolve(canonicalRoot, file));
+  const memoryRoot = join(canonicalRoot, '.agent-docs');
+  if (extname(absolute).toLowerCase() !== '.md' || !isInside(memoryRoot, absolute)) return;
+  assertSafePath(canonicalRoot, absolute);
+  if (parseFrontmatter(readMemoryDocument(absolute)).get('type') === 'session-handoff') {
+    throw new Error('Handoff recovery state cannot be used as acceptance evidence');
+  }
+}
+
+function lifecycleRole(
+  document: MemoryRelationInput,
+): WorkflowRelationReport['memory'][number]['lifecycleRole'] {
+  if (document.type === 'session-handoff') return 'recovery-state';
+  if (document.kind === 'distilled') return 'durable-knowledge';
+  if (document.kind === 'input' && document.workstream) return 'workstream-state';
+  if (document.kind === 'working') return 'task-progress';
+  return 'other';
+}
+
+export function buildWorkflowRelationReport(
+  tasks: TaskRelationInput[],
+  documents: MemoryRelationInput[],
+): WorkflowRelationReport {
+  const taskIds = new Set(tasks.map(({ id }) => id));
+  const memory = documents.map((document) => {
+    const taskRefs = taskReferences([
+      ...document.sourceRefs,
+      ...(document.taskId ? [`task:${document.taskId}`] : []),
+    ]);
+    const owners = [
+      ...taskRefs.map((task) => `task:${task}`),
+      ...(document.workstream ? [`workstream:${document.workstream}`] : []),
+      ...(document.session ? [`session:${document.session}`] : []),
+    ];
+    return {
+      reference: document.reference,
+      lifecycleRole: lifecycleRole(document),
+      owners: [...new Set(owners)],
+      taskRefs,
+      workstream: document.workstream ?? null,
+      session: document.session ?? null,
+    };
+  });
+  const conflicts: WorkflowRelationReport['conflicts'] = [];
+  for (const relation of memory) {
+    for (const task of relation.taskRefs.filter((task) => !taskIds.has(task))) {
+      conflicts.push({
+        code: 'orphan-task-reference',
+        reference: relation.reference,
+        evidence: [`task:${task}`],
+        risk: 'high',
+      });
+    }
+    if (
+      relation.workstream &&
+      relation.taskRefs.length === 1 &&
+      relation.workstream !== relation.taskRefs[0]
+    ) {
+      conflicts.push({
+        code: 'cross-workstream-binding',
+        reference: relation.reference,
+        evidence: [`task:${relation.taskRefs[0]}`, `workstream:${relation.workstream}`],
+        risk: 'high',
+      });
+    }
+  }
+  const taskRelations = [...tasks]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map(({ id, status }) => ({
+      task: id,
+      workstream: id,
+      phase: `${id}:phase:current`,
+      status,
+    }));
+  return {
+    version: 1,
+    schema: 'urn:agent-harness:schema:workflow-relations:v1',
+    mode: 'report-only',
+    sourceOfTruth: false,
+    tasks: taskRelations,
+    memory,
+    conflicts,
+    summary: { tasks: taskRelations.length, memory: memory.length, conflicts: conflicts.length },
+  };
+}
+
+function relationDocument(document: CurationDocument): MemoryRelationInput {
+  return {
+    reference: document.reference,
+    type: document.type,
+    kind: document.kind,
+    status: document.status,
+    workstream: document.workstream,
+    session: document.session,
+    taskId: document.taskId,
+    sourceRefs: document.sourceRefs,
+  };
+}
+
+export function workflowRelationsForProject(
+  projectRoot: string,
+  memoryRoot = join(projectRoot, '.agent-docs'),
+): WorkflowRelationReport {
+  const workingRoot = join(memoryRoot, 'working');
+  const tasks = existsSync(workingRoot)
+    ? listFiles(workingRoot)
+        .filter((path) => basename(path) === 'task.json')
+        .map((path) => readTask(projectRoot, basename(dirname(path))).value)
+        .map(({ id, status }) => ({ id, status }))
+    : [];
+  return buildWorkflowRelationReport(
+    tasks,
+    loadCurationDocuments(memoryRoot).map(relationDocument),
+  );
+}

--- a/template/agent-harness/src/program/memory.ts
+++ b/template/agent-harness/src/program/memory.ts
@@ -8,6 +8,7 @@ import {
   type MemoryPromotionOptions,
   memoryPromotionProposal,
 } from '../commands/memory-promotion.js';
+import { workflowRelations } from '../commands/workflow-relations.js';
 import type { Io, Runtime } from '../types.js';
 import { registerMemoryAutopilotCommands } from './memory-autopilot.js';
 import { registerMemoryCaptureEligibilityCommand } from './memory-capture-eligibility.js';
@@ -61,6 +62,15 @@ export function registerMemoryCommands(
     .option('--json', 'write a machine-readable curation report')
     .action(
       run((scope: string, options: CurationOptions) => curateMemory(runtime, scope, options, io)),
+    );
+  memory
+    .command('relationships <scope>')
+    .description('report Task, workstream, session, and Memory relationships')
+    .option('--json', 'write a machine-readable relationship report')
+    .action(
+      run((scope: string, options: { json?: boolean }) =>
+        workflowRelations(runtime, scope, options, io),
+      ),
     );
   memory
     .command('maintain [scope]')


### PR DESCRIPTION
## Summary / 变更说明

- add a read-only Task/workstream/session/Memory relationship report and schema
- prevent shared Memory from closing or archiving with only one task
- require `multi-task` for Handoff task transitions and reject Handoff as acceptance evidence
- reuse the relationship model from maintenance/bootstrap and document lifecycle boundaries

## Related Issue / 关联 Issue

Closes #99

## Verification / 验证

- `pnpm exec vitest run template/agent-harness/src/__tests__/workflow-relations.test.ts template/agent-harness/src/__tests__/workflow-relations-acceptance.test.ts template/agent-harness/src/__tests__/memory-curation.test.ts template/agent-harness/src/__tests__/memory-handoff-document-boundaries.test.ts template/agent-harness/src/__tests__/task-evidence.test.ts template/agent-harness/src/__tests__/memory-maintenance-report.test.ts` — passed
- `pnpm run test:harness` — 540 passed, 2 skipped
- `pnpm run preflight` — 746 checks; 942 passed, 3 skipped
- `git diff --check` — passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The report is non-authoritative and report-only. Task acceptance remains ledger-owned; Handoff remains recovery state.
