### PR TITLE
feat: verify host signal replays

### DIFF
--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -23,6 +23,7 @@ node <harness-path>/bin/harness.mjs --help
 | 检查安装与本地状态 | `doctor`、`health`、`validate`、`version` | 只读 |
 | 查找或维护历史线索 | `memory` | 查询只读；写操作显式执行 |
 | 续接长任务并验证验收项 | `task` | 修改 Task ledger |
+| 核验 Host signal replay | `replay` | 只读，证据不足返回非零 |
 | 维护多个仓库的职责与关系 | `repository-map` | 检查只读；写操作需显式参数 |
 | 接收和汇总受限运行元数据 | `audit` | `record` 写入；查询只读 |
 
@@ -62,6 +63,19 @@ node <harness-path>/bin/harness.mjs validate --project /path/to/project --json
 - `validate` 检查内容、文档路由、结构和可选项目接入；未知 schema 会 fail closed。
 
 warning 不等于失败；受限环境中无法完成的阴性检查应解释为 `inconclusive`，而不是直接认定安装损坏。
+
+## Host signal replay：只读幂等判定
+
+```bash
+node <harness-path>/bin/harness.mjs replay verify --payload-file /absolute/replay-evidence.json --json
+```
+
+`replay verify` 区分 `new-mutation` 与 `identical-replay`。新 mutation 只能使用没有 previous payload 的新
+identity；失败或未完成 attempt 必须换新 payload。identical replay 必须复用相同 path 与 SHA-256、相同命令，
+并证明目标 artifact、workspace 和 verifier candidate 未漂移。stdout 不可见时不会自动判失败或成功：只有上述
+持久化状态和精确 identity 全部成立才返回 `verified / skip-duplicate`；证据不足返回 `inconclusive` 与非零退出码。
+报告本身只读，不执行或重放 mutation，也不把 Host signal 视为额外授权。
+报告校验调用方提供的证据一致性，`sourceOfTruth: false`；事件真实性仍由 Host/evaluator attestation 负责。
 
 ## Memory：保存待核对线索
 

--- a/evals/scenarios.json
+++ b/evals/scenarios.json
@@ -266,6 +266,8 @@
         "template/agent-harness/src/__tests__/memory-autopilot.test.ts#Harness memory autopilot reconciles explicit profile signals in place",
         "template/agent-harness/src/__tests__/memory-autopilot.test.ts#Handoff snapshots preserve recovery fields unless an update explicitly clears them",
         "template/agent-harness/src/__tests__/memory-autopilot.test.ts#Closing a handoff completes the document and the same base continues in a new generation",
+        "template/agent-harness/src/__tests__/host-signal-replay.test.ts#a duplicate host signal replay leaves the persisted Handoff unchanged",
+        "template/agent-harness/src/__tests__/replay-contract.test.ts#an identical replay is proven without stdout only by exact persisted state",
         "template/agent-harness/src/__tests__/memory-input-profile.test.ts#profile autopilot can be paused, still allows forgetting, and resumes explicitly",
         "src/__tests__/llms.test.ts#routed prompts keep Memory policy and command contracts with their designated owners",
         "src/__tests__/memory-autopilot-prompt.test.ts#background sidecars stay quiet while explicit Memory requests remain auditable"

--- a/template/agent-harness/docs/core/harness-cli-architecture.md
+++ b/template/agent-harness/docs/core/harness-cli-architecture.md
@@ -172,6 +172,12 @@ Memory Autopilot 只有五类窄写入口：`capture-input`、`capture-experienc
 托管结果完成校验后才删除文件；schema、身份、领域写入或结果校验失败时保留文件供诊断。调用方不能把
 “已读取”或“schema 已通过”误当成消费成功，也不能用独立清理掩盖领域失败。
 
+`replay verify` 是 Host-neutral、read-only 的跨 turn 幂等判定器，不是事件 hook 或 mutation executor。
+version 1 报告把 `execute`、`skip-duplicate`、`new-payload-required` 与 `ready`、`verified`、`inconclusive`
+正交表达。相同 signal、相同 payload path/digest、相同命令、未漂移的 persisted artifact/workspace 以及绑定
+当前 candidate/workspace 的 verifier 是可判定输入；stdout 仅是可选证据，缺失时不能替代持久化状态证明。
+失败或中断 attempt 的 payload 永久冻结，重试必须使用新路径；报告不扩大 Host 权限。
+
 Harnesssmith 外层临时 workspace 使用带 owner、purpose、创建时间和 lifecycle 的受管理 marker；成功与
 普通失败通过统一 disposer 清理，只有明确的 recovery 需要才保留并返回精确路径。release 候选与 Host Eval
 证据属于 workstream/evidence，不得当作匿名 `/tmp` 内容通配删除。历史维护先运行仓库的 `pnpm run

--- a/template/agent-harness/docs/core/long-running-tasks.md
+++ b/template/agent-harness/docs/core/long-running-tasks.md
@@ -90,6 +90,13 @@ handoff JSON payload 中旧 `open` 全部 resolved 时只接受布尔字段 `cle
 不得覆盖或复用，重试必须创建新路径。只有宿主明确要求的跨 turn identical replay 例外：原样复用上一回合
 已成功 checkpoint 的相同路径和内容，且不得重写文件。
 
+Host 或评测器要求 replay 时，先用 `replay verify --payload-file <evidence> --json` 核验状态机。`new-mutation`
+只允许没有 previous payload 的新 identity；started/failed attempt 固定返回 `new-payload-required`。
+`identical-replay` 必须同时满足 payload path 与 digest 相同、命令相同、目标 artifact 和 workspace 未变化、
+verifier exit 0 且 candidate/workspace digest 与当前状态绑定。重复 signal 的 signal id 相同只改变 reason code，
+不授权再次执行 mutation。stdout 缺失时仅可依赖上述 persisted-state proof；任一字段缺失或漂移均为
+`inconclusive`，不得从 `completed` 文本或预期结果推断成功。
+
 自动命令必须单独执行且不得通过 shell 插值传递自由文本。自动 sidecar 与用户明确请求的 Memory 操作
 采用不同的可见性策略，统一遵循 [project Memory standard](../standards/project-agent-docs.md)；
 host-signal/replay 的执行时机和状态语义仍由本协议定义。

--- a/template/agent-harness/docs/prompt-rules.yaml
+++ b/template/agent-harness/docs/prompt-rules.yaml
@@ -110,3 +110,18 @@ rules:
     boundary:
       - docs/architecture.md
       - template/agent-harness/docs/core/observability.md
+
+  - id: host-signal-replay-proof
+    owner: long-running-tasks
+    principle: Duplicate host signals do not authorize duplicate mutations.
+    rationale: Missing stdout and repeated delivery require exact payload and persisted-state proof.
+    action: Verify new mutation or identical replay evidence with the read-only replay state machine.
+    fallback: Return inconclusive and require a new payload after failed or incomplete attempts.
+    guarantee: enforced
+    evidence:
+      implementation:
+        - template/agent-harness/src/lib/replay-contract.ts
+        - template/agent-harness/src/commands/replay.ts
+      verification:
+        - template/agent-harness/src/__tests__/replay-contract.test.ts
+        - template/agent-harness/src/__tests__/host-signal-replay.test.ts

--- a/template/agent-harness/schemas/replay-report.schema.json
+++ b/template/agent-harness/schemas/replay-report.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:agent-harness:schema:replay-report:v1",
+  "title": "Host signal replay verification report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "schema", "mode", "sourceOfTruth", "result", "decision", "reasonCode", "checks"],
+  "properties": {
+    "version": { "const": 1 },
+    "schema": { "const": "urn:agent-harness:schema:replay-report:v1" },
+    "mode": { "const": "verify-only" },
+    "sourceOfTruth": { "const": false },
+    "result": { "enum": ["ready", "verified", "inconclusive"] },
+    "decision": { "enum": ["execute", "skip-duplicate", "new-payload-required"] },
+    "reasonCode": {
+      "enum": [
+        "new-mutation-ready",
+        "new-mutation-reuses-payload",
+        "new-mutation-command-inexact",
+        "failed-attempt-frozen",
+        "incomplete-attempt-frozen",
+        "duplicate-signal-state-proven",
+        "identical-replay-state-proven",
+        "replay-proof-incomplete"
+      ]
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["payloadIdentity", "commandIdentity", "persistedState", "generationIdentity", "verifierBinding", "outputCompatibility"],
+      "properties": {
+        "payloadIdentity": { "type": "boolean" },
+        "commandIdentity": { "type": "boolean" },
+        "persistedState": { "type": "boolean" },
+        "generationIdentity": { "type": "boolean" },
+        "verifierBinding": { "type": "boolean" },
+        "outputCompatibility": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/template/agent-harness/src/__tests__/host-signal-replay.test.ts
+++ b/template/agent-harness/src/__tests__/host-signal-replay.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { runCli } from '../cli.js';
+import { initProject } from '../commands/init.js';
+import { digestPath } from '../lib/files.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('a duplicate host signal replay leaves the persisted Handoff unchanged', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-host-signal-replay-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  const payload = join(root, 'checkpoint.json');
+  writeFileSync(
+    payload,
+    JSON.stringify({
+      session: 'host-thread-42',
+      title: 'Host signal replay',
+      objective: 'Preserve the verified task state.',
+      completed: 'The requested edit was verified.',
+      verification: 'node verify.mjs docs/status.txt; exit 0',
+      next: 'Continue with docs/follow-up.txt.',
+      reason: 'compaction',
+    }),
+  );
+
+  const first = capturedIo();
+  assert.equal(
+    runCli(['memory', 'handoff', project, '--payload-file', payload, '--json'], {
+      runtime,
+      io: first,
+    }),
+    0,
+  );
+  const path = JSON.parse(first.logs[0]).path;
+  const before = digestPath(join(project, '.agent-docs'));
+  const persisted = readFileSync(path, 'utf8');
+
+  const replay = capturedIo();
+  assert.equal(
+    runCli(['memory', 'handoff', project, '--payload-file', payload, '--json'], {
+      runtime,
+      io: replay,
+    }),
+    0,
+  );
+  assert.equal(JSON.parse(replay.logs[0]).action, 'unchanged');
+  assert.equal(readFileSync(path, 'utf8'), persisted);
+  assert.equal(digestPath(join(project, '.agent-docs')), before);
+});

--- a/template/agent-harness/src/__tests__/replay-contract.test.ts
+++ b/template/agent-harness/src/__tests__/replay-contract.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { runCli } from '../cli.js';
+import { evaluateReplayContract } from '../lib/replay-contract.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+const exactReplay = {
+  version: 1 as const,
+  kind: 'identical-replay' as const,
+  signalId: 'host-signal-2',
+  previousSignalId: 'host-signal-1',
+  payload: { path: '/tmp/checkpoint.json', digest: `sha256:${'a'.repeat(64)}` },
+  previousPayload: { path: '/tmp/checkpoint.json', digest: `sha256:${'a'.repeat(64)}` },
+  commandExact: true,
+  output: { observed: false },
+  persistedState: {
+    path: '/project/.agent-docs/sessions/checkpoint.md',
+    reference: 'memory:sessions/checkpoint',
+    generation: 1,
+    previousGeneration: 1,
+    beforeDigest: `sha256:${'b'.repeat(64)}`,
+    afterDigest: `sha256:${'b'.repeat(64)}`,
+    beforeWorkspaceDigest: `sha256:${'c'.repeat(64)}`,
+    afterWorkspaceDigest: `sha256:${'c'.repeat(64)}`,
+  },
+  verifier: {
+    command: 'node verify.mjs docs/status.txt',
+    exitCode: 0,
+    candidateDigest: `sha256:${'d'.repeat(64)}`,
+    currentCandidateDigest: `sha256:${'d'.repeat(64)}`,
+    workspaceDigest: `sha256:${'c'.repeat(64)}`,
+  },
+};
+
+test('an identical replay is proven without stdout only by exact persisted state', () => {
+  const report = evaluateReplayContract(exactReplay);
+  assert.equal(report.decision, 'skip-duplicate');
+  assert.equal(report.result, 'verified');
+  assert.equal(report.reasonCode, 'identical-replay-state-proven');
+
+  for (const drift of [
+    { persistedState: { ...exactReplay.persistedState, afterDigest: `sha256:${'e'.repeat(64)}` } },
+    { commandExact: false },
+    { persistedState: { ...exactReplay.persistedState, generation: 2 } },
+    {
+      verifier: {
+        ...exactReplay.verifier,
+        currentCandidateDigest: `sha256:${'e'.repeat(64)}`,
+      },
+    },
+  ]) {
+    const rejected = evaluateReplayContract({ ...exactReplay, ...drift });
+    assert.equal(rejected.result, 'inconclusive');
+    assert.notEqual(rejected.decision, 'execute');
+  }
+});
+
+test('new mutation, duplicate delivery, and failed retry have deterministic decisions', () => {
+  const fresh = evaluateReplayContract({
+    ...exactReplay,
+    kind: 'new-mutation',
+    previousPayload: undefined,
+    previousSignalId: undefined,
+  });
+  assert.equal(fresh.decision, 'execute');
+  assert.equal(fresh.reasonCode, 'new-mutation-ready');
+
+  const inexactFresh = evaluateReplayContract({
+    ...exactReplay,
+    kind: 'new-mutation',
+    previousPayload: undefined,
+    previousSignalId: undefined,
+    commandExact: false,
+  });
+  assert.equal(inexactFresh.decision, 'new-payload-required');
+  assert.equal(inexactFresh.reasonCode, 'new-mutation-command-inexact');
+
+  const duplicate = evaluateReplayContract({
+    ...exactReplay,
+    previousSignalId: exactReplay.signalId,
+  });
+  assert.equal(duplicate.decision, 'skip-duplicate');
+  assert.equal(duplicate.reasonCode, 'duplicate-signal-state-proven');
+
+  const failed = evaluateReplayContract({ ...exactReplay, previousAttempt: 'failed' });
+  assert.equal(failed.decision, 'new-payload-required');
+  assert.equal(failed.reasonCode, 'failed-attempt-frozen');
+});
+
+test('replay verification CLI is read-only and schema-backed', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-replay-contract-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const input = join(root, 'replay.json');
+  writeFileSync(input, JSON.stringify(exactReplay));
+  const before = readFileSync(input, 'utf8');
+  const io = capturedIo();
+
+  assert.equal(
+    runCli(['replay', 'verify', '--payload-file', input, '--json'], {
+      runtime: harnessRuntime(root),
+      io,
+    }),
+    0,
+  );
+  assert.equal(JSON.parse(io.logs[0]).result, 'verified');
+  assert.equal(readFileSync(input, 'utf8'), before);
+  const schema = JSON.parse(
+    readFileSync(
+      join(process.cwd(), 'template/agent-harness/schemas/replay-report.schema.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(schema.$id, 'urn:agent-harness:schema:replay-report:v1');
+
+  writeFileSync(
+    input,
+    JSON.stringify({
+      ...exactReplay,
+      persistedState: { ...exactReplay.persistedState, afterDigest: `sha256:${'e'.repeat(64)}` },
+    }),
+  );
+  assert.equal(
+    runCli(['replay', 'verify', '--payload-file', input, '--json'], {
+      runtime: harnessRuntime(root),
+      io: capturedIo(),
+    }),
+    2,
+  );
+});

--- a/template/agent-harness/src/cli.ts
+++ b/template/agent-harness/src/cli.ts
@@ -12,6 +12,7 @@ import { validate } from './commands/validate.js';
 import { containsHighConfidenceSecret } from './lib/secret-hygiene.js';
 import { registerAuditCommands } from './program/audit.js';
 import { registerMemoryCommands } from './program/memory.js';
+import { registerReplayCommands } from './program/replay.js';
 import { registerRepositoryMapCommands } from './program/repository-map.js';
 import { addSearchOptions, type SearchCommandOptions } from './program/search-options.js';
 import { registerTaskCommands } from './program/task.js';
@@ -215,6 +216,7 @@ export function createHarnessProgram(runtime: Runtime = createRuntime(), outputI
   registerTaskCommands(program, runtime, io, run);
   registerMemoryCommands(program, runtime, io, run);
   registerRepositoryMapCommands(program, runtime, io, run);
+  registerReplayCommands(program, io, run);
 
   addSearchOptions(
     program

--- a/template/agent-harness/src/commands/replay.ts
+++ b/template/agent-harness/src/commands/replay.ts
@@ -1,0 +1,35 @@
+import { readBoundedRegularFile } from '../lib/bounded-file.js';
+import {
+  evaluateReplayContract,
+  type ReplayContractInput,
+  type ReplayContractReport,
+} from '../lib/replay-contract.js';
+import { assertNoHighConfidenceSecretInValue } from '../lib/secret-hygiene.js';
+import type { Io } from '../types.js';
+
+const maximumReplayPayloadBytes = 256 * 1024;
+
+export function verifyReplay(
+  payloadFile: string,
+  { json = false }: { json?: boolean } = {},
+  io: Io = console,
+): ReplayContractReport {
+  if (!payloadFile?.trim()) throw new Error('Replay verification requires --payload-file <path>');
+  const payload = readBoundedRegularFile(payloadFile, {
+    maxBytes: maximumReplayPayloadBytes,
+    subject: 'Replay verification payload',
+  });
+  let input: unknown;
+  try {
+    input = JSON.parse(payload.content);
+  } catch (error) {
+    throw new Error(`Replay verification payload contains invalid JSON: ${payload.path}`, {
+      cause: error,
+    });
+  }
+  assertNoHighConfidenceSecretInValue(input, 'Replay verification payload');
+  const report = evaluateReplayContract(input as ReplayContractInput);
+  if (json) io.log(JSON.stringify(report, null, 2));
+  else io.log(`${report.result}: ${report.decision} (${report.reasonCode})`);
+  return report;
+}

--- a/template/agent-harness/src/lib/replay-contract-types.ts
+++ b/template/agent-harness/src/lib/replay-contract-types.ts
@@ -1,0 +1,69 @@
+export type ReplayDecision = 'execute' | 'skip-duplicate' | 'new-payload-required';
+export type ReplayResult = 'ready' | 'verified' | 'inconclusive';
+
+interface ReplayPayloadIdentity {
+  path: string;
+  digest: string;
+}
+
+interface ReplayOutput {
+  observed: boolean;
+  action?: string;
+  path?: string;
+  reference?: string;
+}
+
+export interface ReplayContractInput {
+  version: 1;
+  kind: 'new-mutation' | 'identical-replay';
+  signalId: string;
+  previousSignalId?: string;
+  previousAttempt?: 'started' | 'failed' | 'succeeded';
+  payload: ReplayPayloadIdentity;
+  previousPayload?: ReplayPayloadIdentity;
+  commandExact: boolean;
+  output: ReplayOutput;
+  persistedState: {
+    path: string;
+    reference: string;
+    generation: number;
+    previousGeneration: number;
+    beforeDigest: string;
+    afterDigest: string;
+    beforeWorkspaceDigest: string;
+    afterWorkspaceDigest: string;
+  };
+  verifier: {
+    command: string;
+    exitCode: number;
+    candidateDigest: string;
+    currentCandidateDigest: string;
+    workspaceDigest: string;
+  };
+}
+
+export interface ReplayContractReport {
+  version: 1;
+  schema: 'urn:agent-harness:schema:replay-report:v1';
+  mode: 'verify-only';
+  sourceOfTruth: false;
+  result: ReplayResult;
+  decision: ReplayDecision;
+  reasonCode:
+    | 'new-mutation-ready'
+    | 'new-mutation-reuses-payload'
+    | 'new-mutation-command-inexact'
+    | 'failed-attempt-frozen'
+    | 'incomplete-attempt-frozen'
+    | 'duplicate-signal-state-proven'
+    | 'identical-replay-state-proven'
+    | 'replay-proof-incomplete';
+  checks: {
+    payloadIdentity: boolean;
+    commandIdentity: boolean;
+    persistedState: boolean;
+    generationIdentity: boolean;
+    verifierBinding: boolean;
+    outputCompatibility: boolean;
+  };
+}

--- a/template/agent-harness/src/lib/replay-contract.ts
+++ b/template/agent-harness/src/lib/replay-contract.ts
@@ -1,0 +1,205 @@
+import type {
+  ReplayContractInput,
+  ReplayContractReport,
+  ReplayDecision,
+  ReplayResult,
+} from './replay-contract-types.js';
+
+export type { ReplayContractInput, ReplayContractReport } from './replay-contract-types.js';
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/u;
+
+function nonEmpty(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !value.trim() || /\r|\n/u.test(value)) {
+    throw new Error(`Replay contract ${field} must be one non-empty line`);
+  }
+}
+
+function digest(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !digestPattern.test(value)) {
+    throw new Error(`Replay contract ${field} must be a sha256 digest`);
+  }
+}
+
+function exactKeys(value: object, allowed: string[], field: string): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length > 0)
+    throw new Error(`Replay contract ${field} has unknown key: ${unknown[0]}`);
+}
+
+function assertInput(input: ReplayContractInput): void {
+  if (!input || typeof input !== 'object' || input.version !== 1) {
+    throw new Error('Replay contract requires version 1 input');
+  }
+  exactKeys(
+    input,
+    [
+      'version',
+      'kind',
+      'signalId',
+      'previousSignalId',
+      'previousAttempt',
+      'payload',
+      'previousPayload',
+      'commandExact',
+      'output',
+      'persistedState',
+      'verifier',
+    ],
+    'input',
+  );
+  if (!['new-mutation', 'identical-replay'].includes(input.kind)) {
+    throw new Error(`Invalid replay contract kind: ${String(input.kind)}`);
+  }
+  nonEmpty(input.signalId, 'signalId');
+  nonEmpty(input.payload?.path, 'payload.path');
+  digest(input.payload?.digest, 'payload.digest');
+  exactKeys(input.payload, ['path', 'digest'], 'payload');
+  if (input.previousPayload) {
+    exactKeys(input.previousPayload, ['path', 'digest'], 'previousPayload');
+    nonEmpty(input.previousPayload.path, 'previousPayload.path');
+    digest(input.previousPayload.digest, 'previousPayload.digest');
+  }
+  if (input.previousSignalId !== undefined) nonEmpty(input.previousSignalId, 'previousSignalId');
+  if (
+    input.previousAttempt !== undefined &&
+    !['started', 'failed', 'succeeded'].includes(input.previousAttempt)
+  ) {
+    throw new Error(`Invalid replay previousAttempt: ${String(input.previousAttempt)}`);
+  }
+  nonEmpty(input.persistedState?.path, 'persistedState.path');
+  nonEmpty(input.persistedState?.reference, 'persistedState.reference');
+  exactKeys(
+    input.persistedState,
+    [
+      'path',
+      'reference',
+      'generation',
+      'previousGeneration',
+      'beforeDigest',
+      'afterDigest',
+      'beforeWorkspaceDigest',
+      'afterWorkspaceDigest',
+    ],
+    'persistedState',
+  );
+  if (
+    !Number.isSafeInteger(input.persistedState.generation) ||
+    input.persistedState.generation < 1 ||
+    !Number.isSafeInteger(input.persistedState.previousGeneration) ||
+    input.persistedState.previousGeneration < 1
+  ) {
+    throw new Error('Replay contract generations must be positive safe integers');
+  }
+  for (const field of [
+    'beforeDigest',
+    'afterDigest',
+    'beforeWorkspaceDigest',
+    'afterWorkspaceDigest',
+  ] as const) {
+    digest(input.persistedState?.[field], `persistedState.${field}`);
+  }
+  nonEmpty(input.verifier?.command, 'verifier.command');
+  exactKeys(
+    input.verifier,
+    ['command', 'exitCode', 'candidateDigest', 'currentCandidateDigest', 'workspaceDigest'],
+    'verifier',
+  );
+  for (const field of ['candidateDigest', 'currentCandidateDigest', 'workspaceDigest'] as const) {
+    digest(input.verifier?.[field], `verifier.${field}`);
+  }
+  if (!Number.isInteger(input.verifier.exitCode) || input.verifier.exitCode < 0) {
+    throw new Error('Replay contract verifier.exitCode must be a non-negative integer');
+  }
+  if (typeof input.commandExact !== 'boolean' || typeof input.output?.observed !== 'boolean') {
+    throw new Error('Replay contract commandExact and output.observed must be boolean');
+  }
+  exactKeys(input.output, ['observed', 'action', 'path', 'reference'], 'output');
+}
+
+function report(
+  result: ReplayResult,
+  decision: ReplayDecision,
+  reasonCode: ReplayContractReport['reasonCode'],
+  checks: ReplayContractReport['checks'],
+): ReplayContractReport {
+  return {
+    version: 1,
+    schema: 'urn:agent-harness:schema:replay-report:v1',
+    mode: 'verify-only',
+    sourceOfTruth: false,
+    result,
+    decision,
+    reasonCode,
+    checks,
+  };
+}
+
+export function evaluateReplayContract(input: ReplayContractInput): ReplayContractReport {
+  assertInput(input);
+  const payloadIdentity = Boolean(
+    input.previousPayload &&
+      input.payload.path === input.previousPayload.path &&
+      input.payload.digest === input.previousPayload.digest,
+  );
+  const persistedState =
+    input.persistedState.beforeDigest === input.persistedState.afterDigest &&
+    input.persistedState.beforeWorkspaceDigest === input.persistedState.afterWorkspaceDigest;
+  const generationIdentity =
+    input.kind === 'new-mutation' ||
+    input.persistedState.generation === input.persistedState.previousGeneration;
+  const verifierBinding =
+    input.verifier.exitCode === 0 &&
+    input.verifier.candidateDigest === input.verifier.currentCandidateDigest &&
+    input.verifier.workspaceDigest === input.persistedState.afterWorkspaceDigest;
+  const outputCompatibility = input.output.observed
+    ? input.output.action === 'unchanged' &&
+      input.output.path === input.persistedState.path &&
+      input.output.reference === input.persistedState.reference
+    : true;
+  const checks = {
+    payloadIdentity,
+    commandIdentity: input.commandExact,
+    persistedState,
+    generationIdentity,
+    verifierBinding,
+    outputCompatibility,
+  };
+
+  if (input.previousAttempt === 'failed') {
+    return report('inconclusive', 'new-payload-required', 'failed-attempt-frozen', checks);
+  }
+  if (input.previousAttempt === 'started') {
+    return report('inconclusive', 'new-payload-required', 'incomplete-attempt-frozen', checks);
+  }
+  if (input.kind === 'new-mutation') {
+    if (input.previousPayload) {
+      return report('inconclusive', 'new-payload-required', 'new-mutation-reuses-payload', checks);
+    }
+    if (!input.commandExact) {
+      return report('inconclusive', 'new-payload-required', 'new-mutation-command-inexact', checks);
+    }
+    return report('ready', 'execute', 'new-mutation-ready', {
+      ...checks,
+      payloadIdentity: true,
+    });
+  }
+  if (
+    !payloadIdentity ||
+    !input.commandExact ||
+    !persistedState ||
+    !generationIdentity ||
+    !verifierBinding ||
+    !outputCompatibility
+  ) {
+    return report('inconclusive', 'new-payload-required', 'replay-proof-incomplete', checks);
+  }
+  return report(
+    'verified',
+    'skip-duplicate',
+    input.previousSignalId === input.signalId
+      ? 'duplicate-signal-state-proven'
+      : 'identical-replay-state-proven',
+    checks,
+  );
+}

--- a/template/agent-harness/src/program/replay.ts
+++ b/template/agent-harness/src/program/replay.ts
@@ -1,0 +1,19 @@
+import type { Command } from 'commander';
+import { verifyReplay } from '../commands/replay.js';
+import type { Io } from '../types.js';
+import type { CommandRunner } from './types.js';
+
+export function registerReplayCommands(program: Command, io: Io, run: CommandRunner): void {
+  const replay = program.command('replay').description('verify host-signal replay evidence');
+  replay
+    .command('verify')
+    .description('classify a new mutation or identical replay without mutating state')
+    .requiredOption('--payload-file <path>', 'bounded JSON replay evidence')
+    .option('--json', 'write a machine-readable replay report')
+    .action(
+      run((options: { payloadFile: string; json?: boolean }) => {
+        const report = verifyReplay(options.payloadFile, options, io);
+        return report.result === 'inconclusive' ? 2 : 0;
+      }),
+    );
+}


### PR DESCRIPTION
## Summary / 变更说明

- Add a host-neutral, read-only replay verification state machine.
- Distinguish new mutations, exact replays, duplicate signals, and frozen failed attempts.
- Require persisted-state, generation, candidate, workspace, and verifier identity proof.
- Document the runtime and prompt boundary and register scenario evidence.

## Related Issue / 关联 Issue

Closes #100

## Verification / 验证

- pnpm run preflight
- Preflight passed: 751 checks.
- Vitest passed: 137 files, 946 tests; 3 skipped.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits.
- [x] Behavior changes include focused tests.
- [x] Documentation and schema changes match the implementation.
- [x] The PR targets dev and does not modify main.
