### PR TITLE
feat: benchmark prompt routing quality

### DIFF
--- a/docs/concepts/evidence-and-evaluation.md
+++ b/docs/concepts/evidence-and-evaluation.md
@@ -11,6 +11,21 @@ Harnesssmith 不把“命令退出码为 0”“Agent 最终说完成了”和�
 
 ## 两条互补验证链
 
+### Prompt 与 route 的确定性基准
+
+`pnpm run bench:prompt-route` 使用 `evals/prompt-route-corpus.v1.json` 的同一批输入运行 version 1 benchmark。
+报告绑定 corpus digest、仅含 id/query 的 input digest、规则 fingerprint 和当前 router candidate digest；使用
+`--baseline-report <path>` 比较时要求 corpus 与 input digest 完全相同，否则拒绝生成 delta。
+
+确定性指标包括 action routing Top-1 accuracy、topic recall、ambiguity precision/recall/rate、forbidden action
+count 与整例 rule-adherence rate。阈值保存在 versioned corpus 中；每个 case 保留 expected/actual、failure code
+和 `false-positive-guard` / `false-negative-guard` 分类，不能只保留聚合分数。deterministic router 不读取项目事实，
+也没有模型 token 或 Host tool-call 遥测，因此 fact verification、token cost 和 tool-call cost 必须报告
+`not-measured`，不得估算为 0。mock/evaluator 与 real Host 层没有证据时同样报告 `not-provided`。
+
+benchmark `passed` 只证明当前源码对该 corpus 的确定性契约达标，`sourceOfTruth` 与 `hostProof` 均为 false；它
+不能替代下述真实 Host Eval，也不能证明 Agent 实际遵从 Prompt、回查事实或控制 token/tool 成本。
+
 ### 确定性仓库验证
 
 单元测试、类型检查、lint、schema、`preflight`、覆盖率门禁和 `npm pack --dry-run` 在受控仓库环境中运行。

--- a/evals/README.md
+++ b/evals/README.md
@@ -5,6 +5,16 @@ recording a maintainer-observed Codex, Cursor, Claude Code, OpenCode, or Kimi Co
 current release policy requires Codex; Cursor, Claude Code, OpenCode, and Kimi Code CLI records remain supported optional evidence. A schema
 fixture, scenario catalog, mocked transcript, or passing unit test is never real host evidence.
 
+## Deterministic Prompt and route benchmark
+
+`pnpm run bench:prompt-route` runs the versioned bilingual corpus in
+`prompt-route-corpus.v1.json`. The JSON report includes corpus/input digests, rule and candidate fingerprints,
+threshold metrics, per-case false-positive/false-negative audit data, and provenance. A prior JSON report can be
+passed with `--baseline-report`; comparison fails unless both reports use the exact same corpus inputs.
+
+This deterministic layer does not manufacture evaluator or Host telemetry. Fact verification, model tokens, and
+Host tool calls stay `not-measured` until exact evidence exists, and a passing benchmark is not real Host proof.
+
 ## Evidence contract
 
 `scenarios.schema.json` validates the versioned `scenarios.json` catalog, which contains the exact prompt,

--- a/evals/__tests__/prompt-route-benchmark-cli.test.ts
+++ b/evals/__tests__/prompt-route-benchmark-cli.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import {
+  repositoryRoot,
+  runPromptRouteBenchmark,
+} from '../../scripts/prompt-route-benchmark-lib.js';
+
+function run(args: string[]) {
+  return spawnSync(
+    process.execPath,
+    ['--import', 'tsx', 'scripts/prompt-route-benchmark.ts', ...args],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    },
+  );
+}
+
+test('prompt route benchmark CLI is CI-runnable and compares the same inputs', () => {
+  const direct = run(['--json']);
+  assert.equal(direct.status, 0, direct.stderr);
+  const report = JSON.parse(direct.stdout);
+  assert.equal(report.version, 1);
+  assert.equal(report.result, 'passed');
+
+  const root = mkdtempSync(join(tmpdir(), 'harness-prompt-route-benchmark-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const baseline = join(root, 'baseline.json');
+  writeFileSync(baseline, JSON.stringify(runPromptRouteBenchmark()));
+  const compared = run(['--json', '--baseline-report', baseline]);
+  assert.equal(compared.status, 0, compared.stderr);
+  assert.equal(JSON.parse(compared.stdout).comparison.sameInput, true);
+});

--- a/evals/__tests__/prompt-route-benchmark.test.ts
+++ b/evals/__tests__/prompt-route-benchmark.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'vitest';
+import {
+  comparePromptRouteBenchmarks,
+  repositoryRoot,
+  runPromptRouteBenchmark,
+} from '../../scripts/prompt-route-benchmark-lib.js';
+
+test('prompt route benchmark is versioned, reproducible, and passes deterministic thresholds', () => {
+  const first = runPromptRouteBenchmark();
+  const second = runPromptRouteBenchmark();
+
+  assert.deepEqual(second, first);
+  assert.equal(first.version, 1);
+  assert.equal(first.result, 'passed');
+  assert.match(first.corpusDigest, /^sha256:[a-f0-9]{64}$/u);
+  assert.match(first.inputDigest, /^sha256:[a-f0-9]{64}$/u);
+  assert.match(first.rulesFingerprint, /^sha256:[a-f0-9]{64}$/u);
+  assert.match(first.candidateDigest, /^sha256:[a-f0-9]{64}$/u);
+  assert.equal(first.metrics.actionTop1Accuracy.value, 1);
+  assert.equal(first.metrics.topicRecall.value, 1);
+  assert.equal(first.metrics.forbiddenActionCount.value, 0);
+  assert.equal(first.layers.deterministicRouter.status, 'measured');
+  assert.equal(first.layers.mockEvaluator.status, 'not-provided');
+  assert.equal(first.layers.evaluator.status, 'not-provided');
+  assert.equal(first.layers.realHost.status, 'not-provided');
+  assert.equal(first.metrics.factVerification.status, 'not-measured');
+  assert.equal(first.metrics.tokenCost.status, 'not-measured');
+  assert.equal(first.metrics.toolCallCost.status, 'not-measured');
+  assert.equal(first.hostProof, false);
+});
+
+test('the corpus covers bilingual routing risks and keeps false-positive and false-negative samples auditable', () => {
+  const corpus = JSON.parse(
+    readFileSync(join(repositoryRoot, 'evals', 'prompt-route-corpus.v1.json'), 'utf8'),
+  );
+  const categories = new Set<string>(
+    corpus.cases.flatMap((entry: { categories: string[] }) => entry.categories),
+  );
+  for (const required of [
+    'zh',
+    'en',
+    'negation',
+    'quotation',
+    'example',
+    'long',
+    'high-loss-signal',
+    'false-positive-guard',
+    'false-negative-guard',
+  ]) {
+    assert.ok(categories.has(required), required);
+  }
+});
+
+test('baseline comparison requires identical inputs and reports metric deltas', () => {
+  const candidate = runPromptRouteBenchmark();
+  const baseline = { ...candidate, candidateDigest: `sha256:${'f'.repeat(64)}` };
+  const comparison = comparePromptRouteBenchmarks(candidate, baseline);
+  assert.equal(comparison.sameInput, true);
+  assert.equal(comparison.baselineCandidateDigest, baseline.candidateDigest);
+  assert.notEqual(comparison.baselineCandidateDigest, comparison.candidateDigest);
+  assert.deepEqual(new Set(Object.values(comparison.metricDeltas)), new Set([0]));
+
+  assert.throws(
+    () =>
+      comparePromptRouteBenchmarks(candidate, {
+        ...baseline,
+        inputDigest: `sha256:${'0'.repeat(64)}`,
+      }),
+    /same corpus inputs/i,
+  );
+});

--- a/evals/prompt-route-corpus.schema.json
+++ b/evals/prompt-route-corpus.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:harnessmith:prompt-route-corpus:v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "description", "thresholds", "cases"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "description": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actionTop1Accuracy", "topicRecall", "ambiguityPrecision", "ambiguityRecall", "ambiguityRateMaximum", "forbiddenActionCount", "ruleAdherenceRate"],
+      "properties": {
+        "actionTop1Accuracy": { "type": "number", "minimum": 0, "maximum": 1 },
+        "topicRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "ambiguityPrecision": { "type": "number", "minimum": 0, "maximum": 1 },
+        "ambiguityRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "ambiguityRateMaximum": { "type": "number", "minimum": 0, "maximum": 1 },
+        "forbiddenActionCount": { "type": "integer", "minimum": 0 },
+        "ruleAdherenceRate": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "categories", "query", "expected"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 128 },
+          "categories": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+          "query": { "type": "string", "minLength": 1, "maxLength": 4096 },
+          "expected": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status", "top1", "topics", "forbiddenPlaybooks"],
+            "properties": {
+              "status": { "enum": ["matched", "unmatched", "ambiguous"] },
+              "top1": { "type": ["string", "null"], "maxLength": 128 },
+              "topics": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 128 } },
+              "forbiddenPlaybooks": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 128 } }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/evals/prompt-route-corpus.v1.json
+++ b/evals/prompt-route-corpus.v1.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "description": "Versioned bilingual action-routing and response-policy regression corpus",
+  "thresholds": {
+    "actionTop1Accuracy": 1,
+    "topicRecall": 1,
+    "ambiguityPrecision": 1,
+    "ambiguityRecall": 1,
+    "ambiguityRateMaximum": 0.25,
+    "forbiddenActionCount": 0,
+    "ruleAdherenceRate": 1
+  },
+  "cases": [
+    {
+      "id": "zh-review",
+      "categories": ["zh", "action", "false-negative-guard"],
+      "query": "请评审这个变更。",
+      "expected": { "status": "matched", "top1": "review", "topics": [], "forbiddenPlaybooks": [] }
+    },
+    {
+      "id": "en-diagnose-negated-change",
+      "categories": ["en", "negation", "false-positive-guard"],
+      "query": "Diagnose the failing test. Do not implement a fix.",
+      "expected": { "status": "matched", "top1": "diagnose", "topics": [], "forbiddenPlaybooks": ["change"] }
+    },
+    {
+      "id": "mixed-review-git",
+      "categories": ["mixed", "cjk-punctuation", "topic"],
+      "query": "Please review：这个 Git branch 变更方案。",
+      "expected": { "status": "matched", "top1": "review", "topics": ["git-conventions"], "forbiddenPlaybooks": ["change"] }
+    },
+    {
+      "id": "zh-quoted-change",
+      "categories": ["zh", "quotation", "false-positive-guard"],
+      "query": "文档写着“请修改代码”，请分析这段 Prompt。",
+      "expected": { "status": "matched", "top1": "research-and-design", "topics": ["tool-routing"], "forbiddenPlaybooks": ["change"] }
+    },
+    {
+      "id": "en-example-then-diagnose",
+      "categories": ["en", "example", "false-positive-guard"],
+      "query": "For example, review and implement are action words. Now diagnose the actual failure.",
+      "expected": { "status": "matched", "top1": "diagnose", "topics": [], "forbiddenPlaybooks": ["review", "change"] }
+    },
+    {
+      "id": "zh-real-ambiguity",
+      "categories": ["zh", "ambiguity"],
+      "query": "请检查实现；请诊断失败。",
+      "expected": { "status": "ambiguous", "top1": null, "topics": [], "forbiddenPlaybooks": [] }
+    },
+    {
+      "id": "long-high-loss-request",
+      "categories": ["en", "long", "high-loss-signal", "topic"],
+      "query": "Change docs/status.txt from pending to ready. Acceptance: node verify-autopilot.mjs docs/status.txt exits 0 and no other tracked file changes. For all future tasks, keep status summaries to one sentence. This is a multi-stage task with a verified phase and context budget compaction.",
+      "expected": { "status": "matched", "top1": "change", "topics": ["harness-cli-architecture", "long-running-tasks", "project-agent-docs", "user-profile-memory"], "forbiddenPlaybooks": [] }
+    },
+    {
+      "id": "zh-negated-release-review",
+      "categories": ["zh", "negation", "high-loss-signal", "false-positive-guard"],
+      "query": "不要发布，只评审 release 风险。",
+      "expected": { "status": "matched", "top1": "review", "topics": [], "forbiddenPlaybooks": ["release-and-external"] }
+    },
+    {
+      "id": "quoted-meta-unmatched",
+      "categories": ["en", "quotation", "meta", "false-positive-guard"],
+      "query": "The phrase \"implement the fix\" is quoted as an example, not a current instruction.",
+      "expected": { "status": "unmatched", "top1": null, "topics": [], "forbiddenPlaybooks": ["change"] }
+    }
+  ]
+}

--- a/evals/scenarios.json
+++ b/evals/scenarios.json
@@ -42,7 +42,8 @@
         "template/agent-harness/src/__tests__/memory.test.ts#context search combines Harness, global memory, project memory, and project docs",
         "template/agent-harness/src/__tests__/docs-routing.test.ts#CJK punctuation and mixed-language requests preserve action intent",
         "template/agent-harness/src/__tests__/docs-routing.test.ts#response language priority is current explicit, persisted evidence, then detection",
-        "src/__tests__/multilingual-prompt.test.ts#entry guidance routes multilingual response policy without persisting one turn"
+        "src/__tests__/multilingual-prompt.test.ts#entry guidance routes multilingual response policy without persisting one turn",
+        "evals/__tests__/prompt-route-benchmark.test.ts#prompt route benchmark is versioned, reproducible, and passes deterministic thresholds"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eval:schema:check": "node --import tsx scripts/eval-run-schema.ts check",
     "temp:scan": "node --import tsx scripts/temp-resources.ts --json",
     "bench:search": "node --expose-gc --import tsx scripts/search-benchmark.ts",
+    "bench:prompt-route": "node --import tsx scripts/prompt-route-benchmark.ts --json",
     "pretest:coverage": "pnpm run build",
     "test:coverage": "pnpm run test:coverage:unit && pnpm run test:scripts-coverage",
     "test:coverage:unit": "vitest run --coverage",

--- a/scripts/prompt-route-benchmark-evaluate.ts
+++ b/scripts/prompt-route-benchmark-evaluate.ts
@@ -1,0 +1,158 @@
+import { join } from 'node:path';
+import { routeDocumentation } from '../template/agent-harness/src/lib/docs-routing.js';
+import type {
+  MeasuredMetric,
+  PromptRouteBenchmarkReport,
+  PromptRouteCorpus,
+} from './prompt-route-benchmark-types.js';
+
+export interface CorpusEvaluation {
+  cases: PromptRouteBenchmarkReport['cases'];
+  actionTotal: number;
+  actionCorrect: number;
+  expectedTopics: number;
+  recalledTopics: number;
+  predictedAmbiguous: number;
+  expectedAmbiguous: number;
+  trueAmbiguous: number;
+  forbiddenActions: number;
+  adherent: number;
+}
+
+function sameStrings(left: string[], right: string[]): boolean {
+  return JSON.stringify([...left].sort()) === JSON.stringify([...right].sort());
+}
+
+export function evaluateCorpus(
+  corpus: PromptRouteCorpus,
+  repositoryRoot: string,
+): CorpusEvaluation {
+  const docsRoot = join(repositoryRoot, 'template', 'agent-harness', 'docs');
+  const counts = {
+    actionTotal: 0,
+    actionCorrect: 0,
+    expectedTopics: 0,
+    recalledTopics: 0,
+    predictedAmbiguous: 0,
+    expectedAmbiguous: 0,
+    trueAmbiguous: 0,
+    forbiddenActions: 0,
+    adherent: 0,
+  };
+  const cases: PromptRouteBenchmarkReport['cases'] = corpus.cases.map((entry) => {
+    const route = routeDocumentation(docsRoot, [entry.query]);
+    const actual = {
+      status: route.status,
+      top1: route.top1?.name ?? null,
+      topics: route.topics.map(({ name }) => name).sort(),
+      ambiguity: [...route.ambiguity].sort(),
+    };
+    if (entry.expected.top1 !== null) {
+      counts.actionTotal += 1;
+      if (actual.top1 === entry.expected.top1) counts.actionCorrect += 1;
+    }
+    counts.expectedTopics += entry.expected.topics.length;
+    counts.recalledTopics += entry.expected.topics.filter((topic) =>
+      actual.topics.includes(topic),
+    ).length;
+    if (actual.status === 'ambiguous') counts.predictedAmbiguous += 1;
+    if (entry.expected.status === 'ambiguous') counts.expectedAmbiguous += 1;
+    if (actual.status === 'ambiguous' && entry.expected.status === 'ambiguous') {
+      counts.trueAmbiguous += 1;
+    }
+    const forbidden = Boolean(
+      actual.top1 && entry.expected.forbiddenPlaybooks.includes(actual.top1),
+    );
+    if (forbidden) counts.forbiddenActions += 1;
+    const failures: string[] = [];
+    if (actual.status !== entry.expected.status) failures.push('status-mismatch');
+    if (actual.top1 !== entry.expected.top1) failures.push('top1-mismatch');
+    if (!sameStrings(actual.topics, entry.expected.topics)) failures.push('topics-mismatch');
+    if (forbidden) failures.push('forbidden-action-selected');
+    if (failures.length === 0) counts.adherent += 1;
+    return {
+      id: entry.id,
+      categories: entry.categories,
+      expected: entry.expected,
+      actual,
+      failures,
+    };
+  });
+  return { cases, ...counts };
+}
+
+function measured(
+  numerator: number,
+  denominator: number,
+  threshold: number,
+  direction: 'minimum' | 'maximum' = 'minimum',
+): MeasuredMetric {
+  const value = denominator === 0 ? 1 : numerator / denominator;
+  return {
+    status: 'measured',
+    value,
+    numerator,
+    denominator,
+    threshold,
+    passed: direction === 'minimum' ? value >= threshold : value <= threshold,
+  };
+}
+
+export function benchmarkMetrics(
+  corpus: PromptRouteCorpus,
+  evaluation: CorpusEvaluation,
+): PromptRouteBenchmarkReport['metrics'] {
+  const thresholds = corpus.thresholds;
+  return {
+    actionTop1Accuracy: measured(
+      evaluation.actionCorrect,
+      evaluation.actionTotal,
+      thresholds.actionTop1Accuracy,
+    ),
+    topicRecall: measured(
+      evaluation.recalledTopics,
+      evaluation.expectedTopics,
+      thresholds.topicRecall,
+    ),
+    ambiguityPrecision: measured(
+      evaluation.trueAmbiguous,
+      evaluation.predictedAmbiguous,
+      thresholds.ambiguityPrecision,
+    ),
+    ambiguityRecall: measured(
+      evaluation.trueAmbiguous,
+      evaluation.expectedAmbiguous,
+      thresholds.ambiguityRecall,
+    ),
+    ambiguityRate: measured(
+      evaluation.predictedAmbiguous,
+      corpus.cases.length,
+      thresholds.ambiguityRateMaximum,
+      'maximum',
+    ),
+    forbiddenActionCount: measured(
+      evaluation.forbiddenActions,
+      1,
+      thresholds.forbiddenActionCount,
+      'maximum',
+    ),
+    ruleAdherenceRate: measured(
+      evaluation.adherent,
+      corpus.cases.length,
+      thresholds.ruleAdherenceRate,
+    ),
+    factVerification: {
+      status: 'not-measured',
+      reason:
+        'Deterministic routing does not inspect project facts; evaluator or Host evidence is required.',
+    },
+    tokenCost: {
+      status: 'not-measured',
+      reason: 'No model token telemetry was provided; costs are never estimated.',
+    },
+    toolCallCost: {
+      status: 'not-measured',
+      reason: 'No evaluator or Host tool-call telemetry was provided; costs are never estimated.',
+    },
+  };
+}

--- a/scripts/prompt-route-benchmark-lib.ts
+++ b/scripts/prompt-route-benchmark-lib.ts
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AnySchema } from 'ajv';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { benchmarkMetrics, evaluateCorpus } from './prompt-route-benchmark-evaluate.js';
+import type {
+  PromptRouteBenchmarkComparison,
+  PromptRouteBenchmarkReport,
+  PromptRouteCorpus,
+} from './prompt-route-benchmark-types.js';
+
+export const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const corpusRelative = 'evals/prompt-route-corpus.v1.json';
+const schemaRelative = 'evals/prompt-route-corpus.schema.json';
+const rulesSources = [
+  'template/AGENTS.md',
+  'template/agent-harness/docs/core/operating-model.md',
+  'template/agent-harness/docs/manifest.yaml',
+  'template/agent-harness/docs/prompt-rules.yaml',
+  'template/agent-harness/docs/standards/user-profile-memory.md',
+] as const;
+const candidateSources = [
+  ...rulesSources,
+  'template/agent-harness/src/lib/docs-routing.ts',
+  'template/agent-harness/src/lib/response-language.ts',
+] as const;
+
+function sha256(value: string | Buffer): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function fingerprint(paths: readonly string[]): string {
+  const hash = createHash('sha256');
+  for (const path of [...paths].sort()) {
+    hash
+      .update(path)
+      .update('\0')
+      .update(readFileSync(join(repositoryRoot, path)))
+      .update('\0');
+  }
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function readCorpus(): { corpus: PromptRouteCorpus; bytes: Buffer } {
+  const bytes = readFileSync(join(repositoryRoot, corpusRelative));
+  const schema = JSON.parse(
+    readFileSync(join(repositoryRoot, schemaRelative), 'utf8'),
+  ) as AnySchema;
+  const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+  const value = JSON.parse(bytes.toString('utf8')) as unknown;
+  if (!validate(value)) {
+    throw new Error(`Prompt route corpus violates schema: ${JSON.stringify(validate.errors)}`);
+  }
+  const corpus = value as PromptRouteCorpus;
+  const ids = corpus.cases.map(({ id }) => id);
+  if (new Set(ids).size !== ids.length) throw new Error('Prompt route corpus ids must be unique');
+  return { corpus, bytes };
+}
+
+export function runPromptRouteBenchmark(): PromptRouteBenchmarkReport {
+  const { corpus, bytes } = readCorpus();
+  const evaluation = evaluateCorpus(corpus, repositoryRoot);
+  const metrics = benchmarkMetrics(corpus, evaluation);
+  const thresholdMetrics = [
+    metrics.actionTop1Accuracy,
+    metrics.topicRecall,
+    metrics.ambiguityPrecision,
+    metrics.ambiguityRecall,
+    metrics.ambiguityRate,
+    metrics.forbiddenActionCount,
+    metrics.ruleAdherenceRate,
+  ];
+  return {
+    version: 1,
+    schema: 'urn:harnessmith:prompt-route-benchmark:v1',
+    result: thresholdMetrics.every(({ passed }) => passed) ? 'passed' : 'failed',
+    sourceOfTruth: false,
+    hostProof: false,
+    corpusDigest: sha256(bytes),
+    inputDigest: sha256(JSON.stringify(corpus.cases.map(({ id, query }) => ({ id, query })))),
+    rulesFingerprint: fingerprint(rulesSources),
+    candidateDigest: fingerprint(candidateSources),
+    provenance: {
+      runner: 'scripts/prompt-route-benchmark.ts',
+      corpus: corpusRelative,
+      layer: 'deterministic-router',
+    },
+    layers: {
+      deterministicRouter: { status: 'measured', cases: evaluation.cases.length },
+      mockEvaluator: { status: 'not-provided' },
+      evaluator: { status: 'not-provided' },
+      realHost: { status: 'not-provided' },
+    },
+    metrics,
+    auditSamples: {
+      falsePositiveGuards: corpus.cases
+        .filter(({ categories }) => categories.includes('false-positive-guard'))
+        .map(({ id }) => id),
+      falseNegativeGuards: corpus.cases
+        .filter(({ categories }) => categories.includes('false-negative-guard'))
+        .map(({ id }) => id),
+    },
+    cases: evaluation.cases,
+  };
+}
+
+const comparableMetrics = [
+  'actionTop1Accuracy',
+  'topicRecall',
+  'ambiguityPrecision',
+  'ambiguityRecall',
+  'ambiguityRate',
+  'forbiddenActionCount',
+  'ruleAdherenceRate',
+] as const;
+
+export function comparePromptRouteBenchmarks(
+  candidate: PromptRouteBenchmarkReport,
+  baseline: PromptRouteBenchmarkReport,
+): PromptRouteBenchmarkComparison {
+  if (
+    candidate.corpusDigest !== baseline.corpusDigest ||
+    candidate.inputDigest !== baseline.inputDigest
+  ) {
+    throw new Error('Prompt route benchmark comparison requires the same corpus inputs');
+  }
+  return {
+    version: 1,
+    sameInput: true,
+    baselineCandidateDigest: baseline.candidateDigest,
+    candidateDigest: candidate.candidateDigest,
+    metricDeltas: Object.fromEntries(
+      comparableMetrics.map((name) => [
+        name,
+        candidate.metrics[name].value - baseline.metrics[name].value,
+      ]),
+    ),
+  };
+}

--- a/scripts/prompt-route-benchmark-types.ts
+++ b/scripts/prompt-route-benchmark-types.ts
@@ -1,0 +1,101 @@
+type RouteStatus = 'matched' | 'unmatched' | 'ambiguous';
+
+interface PromptRouteCorpusCase {
+  id: string;
+  categories: string[];
+  query: string;
+  expected: {
+    status: RouteStatus;
+    top1: string | null;
+    topics: string[];
+    forbiddenPlaybooks: string[];
+  };
+}
+
+export interface PromptRouteCorpus {
+  schemaVersion: 1;
+  description: string;
+  thresholds: {
+    actionTop1Accuracy: number;
+    topicRecall: number;
+    ambiguityPrecision: number;
+    ambiguityRecall: number;
+    ambiguityRateMaximum: number;
+    forbiddenActionCount: number;
+    ruleAdherenceRate: number;
+  };
+  cases: PromptRouteCorpusCase[];
+}
+
+export interface MeasuredMetric {
+  status: 'measured';
+  value: number;
+  numerator: number;
+  denominator: number;
+  threshold: number;
+  passed: boolean;
+}
+
+interface UnmeasuredMetric {
+  status: 'not-measured';
+  reason: string;
+}
+
+export interface PromptRouteBenchmarkReport {
+  version: 1;
+  schema: 'urn:harnessmith:prompt-route-benchmark:v1';
+  result: 'passed' | 'failed';
+  sourceOfTruth: false;
+  hostProof: false;
+  corpusDigest: string;
+  inputDigest: string;
+  rulesFingerprint: string;
+  candidateDigest: string;
+  provenance: {
+    runner: 'scripts/prompt-route-benchmark.ts';
+    corpus: 'evals/prompt-route-corpus.v1.json';
+    layer: 'deterministic-router';
+  };
+  layers: {
+    deterministicRouter: { status: 'measured'; cases: number };
+    mockEvaluator: { status: 'not-provided' };
+    evaluator: { status: 'not-provided' };
+    realHost: { status: 'not-provided' };
+  };
+  metrics: {
+    actionTop1Accuracy: MeasuredMetric;
+    topicRecall: MeasuredMetric;
+    ambiguityPrecision: MeasuredMetric;
+    ambiguityRecall: MeasuredMetric;
+    ambiguityRate: MeasuredMetric;
+    forbiddenActionCount: MeasuredMetric;
+    ruleAdherenceRate: MeasuredMetric;
+    factVerification: UnmeasuredMetric;
+    tokenCost: UnmeasuredMetric;
+    toolCallCost: UnmeasuredMetric;
+  };
+  auditSamples: {
+    falsePositiveGuards: string[];
+    falseNegativeGuards: string[];
+  };
+  cases: Array<{
+    id: string;
+    categories: string[];
+    expected: PromptRouteCorpusCase['expected'];
+    actual: {
+      status: RouteStatus;
+      top1: string | null;
+      topics: string[];
+      ambiguity: string[];
+    };
+    failures: string[];
+  }>;
+}
+
+export interface PromptRouteBenchmarkComparison {
+  version: 1;
+  sameInput: true;
+  baselineCandidateDigest: string;
+  candidateDigest: string;
+  metricDeltas: Record<string, number>;
+}

--- a/scripts/prompt-route-benchmark.ts
+++ b/scripts/prompt-route-benchmark.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { Command } from 'commander';
+import {
+  comparePromptRouteBenchmarks,
+  runPromptRouteBenchmark,
+} from './prompt-route-benchmark-lib.js';
+import type { PromptRouteBenchmarkReport } from './prompt-route-benchmark-types.js';
+
+const program = new Command()
+  .name('prompt-route-benchmark')
+  .description('run the deterministic Prompt and documentation-route benchmark')
+  .option('--json', 'write the versioned benchmark report')
+  .option('--baseline-report <path>', 'compare against a report produced from the same corpus')
+  .action((options: { json?: boolean; baselineReport?: string }) => {
+    const report = runPromptRouteBenchmark();
+    const comparison = options.baselineReport
+      ? comparePromptRouteBenchmarks(
+          report,
+          JSON.parse(readFileSync(options.baselineReport, 'utf8')) as PromptRouteBenchmarkReport,
+        )
+      : undefined;
+    if (options.json)
+      console.log(JSON.stringify({ ...report, ...(comparison && { comparison }) }, null, 2));
+    else {
+      console.log(
+        `${report.result}: Top-1 ${report.metrics.actionTop1Accuracy.value.toFixed(3)}, topic recall ${report.metrics.topicRecall.value.toFixed(3)}, forbidden ${report.metrics.forbiddenActionCount.value}`,
+      );
+    }
+    if (report.result !== 'passed') process.exitCode = 1;
+  });
+
+program.parse();

--- a/template/agent-harness/docs/prompt-rules.yaml
+++ b/template/agent-harness/docs/prompt-rules.yaml
@@ -102,6 +102,7 @@ rules:
       verification:
         - template/agent-harness/src/__tests__/docs-routing.test.ts
         - src/__tests__/multilingual-prompt.test.ts
+        - evals/__tests__/prompt-route-benchmark.test.ts
 
   - id: payload-consumption-boundary
     owner: harness-cli-architecture

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -116,6 +116,7 @@ test('CJK punctuation and mixed-language requests preserve action intent', () =>
 test.each([
   '不要评审，只分析这个方案。',
   'Do not review; analyze the design instead.',
+  'For example, review and implement are action words. Now diagnose the actual failure.',
   '“请评审这个方案”只是引用，不是当前请求。',
   'The phrase "implement the fix" is an example, not an instruction.',
 ])(
@@ -124,10 +125,16 @@ test.each([
     const report = routeDocumentation(docsRoot, [query]);
     assert.notEqual(
       report.primaryPlaybook?.name,
-      query.includes('implement') ? 'change' : 'review',
+      query.includes('implement the fix') ? 'change' : 'review',
     );
   },
 );
+
+test('Chinese exclusive action prefix selects the requested action after a negated one', () => {
+  const report = routeDocumentation(docsRoot, ['不要发布，只评审 release 风险。']);
+  assert.equal(report.primaryPlaybook?.name, 'review');
+  assert.ok(!report.routes.some(({ name }) => name === 'release-and-external'));
+});
 
 test('response language priority is current explicit, persisted evidence, then detection', () => {
   assert.deepEqual(

--- a/template/agent-harness/src/lib/docs-routing.ts
+++ b/template/agent-harness/src/lib/docs-routing.ts
@@ -101,7 +101,14 @@ function routingMatchIsRequestedAction(term: string, position: number): boolean 
       .at(-1) ?? '';
   const prefix = clause.trim();
   if (prefix === '') return true;
-  return /^(?:(?:please|can you|could you|would you|i want you to|i need you to|let(?:'s| us)|now|then|also)(?:\s+\p{L}+){0,4}|(?:请|请你|帮我|给我|现在|继续|重新|开始|进行|执行|来|需要|要求|希望|想要|逐个|并)|(?:结合|基于|根据)[\p{L}\p{N} ._-]{0,40}(?:来)?)$/u.test(
+  return /^(?:(?:please|can you|could you|would you|i want you to|i need you to|let(?:'s| us)|now|then|also)(?:\s+\p{L}+){0,4}|(?:请|请你|帮我|给我|现在|继续|重新|开始|进行|执行|来|需要|要求|希望|想要|逐个|并|只)|(?:结合|基于|根据)[\p{L}\p{N} ._-]{0,40}(?:来)?)$/u.test(
+    prefix,
+  );
+}
+
+function routingMatchIsIllustrative(term: string, position: number): boolean {
+  const prefix = term.slice(Math.max(0, position - 48), position);
+  return /(?:\b(?:for example|e\.g\.|such as)\s*,?\s*|(?:例如|比如|譬如)\s*[：:,，]?\s*)$/u.test(
     prefix,
   );
 }
@@ -141,6 +148,7 @@ function matchesPlaybookIntent(trigger: string, term: string): boolean {
     (position) =>
       !routingMatchIsNegated(term, position) &&
       !routingMatchIsQuoted(term, position) &&
+      !routingMatchIsIllustrative(term, position) &&
       routingMatchIsRequestedAction(term, position),
   );
 }


### PR DESCRIPTION
## Summary / 变更说明

- Add a versioned bilingual Prompt and route benchmark corpus with schema and auditable thresholds.
- Measure action Top-1, topic recall, ambiguity, forbidden actions, and per-case rule adherence.
- Bind reports to corpus, input, rules, and candidate digests with deterministic provenance and baseline comparison.
- Keep fact verification, token cost, and tool-call cost explicitly not-measured without evaluator or Host telemetry.
- Fix example-clause and Chinese exclusive-prefix routing gaps exposed by the corpus.

## Related Issue / 关联 Issue

Closes #102

## Verification / 验证

- pnpm run bench:prompt-route
- pnpm run preflight
- Preflight passed: 753 checks.
- Vitest passed: 140 files, 961 tests; 3 skipped.
- pre-push repeated the complete preflight successfully.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits.
- [x] Corpus covers Chinese, English, negation, quotation, examples, long prompts, and high-loss signals.
- [x] Benchmark pass is explicitly not presented as real Host proof.
- [x] The PR targets dev and does not modify main.
