### PR TITLE
feat: explain installation status

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -69,6 +69,9 @@ Cursor requires `--project /path/to/project`. See the
 # Inspect ownership and file integrity
 npx harnessmith status --agent codex
 
+# Explain observed state, evidence, risk, and safe actions that are not auto-run
+npx harnessmith status --agent codex --explain
+
 # Restore the previous installation layer
 npx harnessmith restore --agent codex
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Cursor 需用 `--project /path/to/project` 指定项目根。目标路径、别�
 # 查看所有权与文件完整性
 npx harnessmith status --agent codex
 
+# 解释观察状态、证据、风险和不会自动执行的安全下一步
+npx harnessmith status --agent codex --explain
+
 # 恢复上一安装层
 npx harnessmith restore --agent codex
 

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -48,6 +48,20 @@ claims:
       - src/__tests__/args.test.ts
       - src/__tests__/adapter-conformance.test.ts
 
+  - id: explainable-installation-status
+    status: implemented
+    owner: outer installer lifecycle
+    claim: Explain observed installation state, ownership evidence, backup state, risk, and non-automatic safe next actions while preserving Host-dependent conclusions as inconclusive.
+    implementation:
+      - src/status-inspection.ts
+      - src/status-explanation.ts
+      - src/command-executor.ts
+      - src/program.ts
+    verification:
+      - src/__tests__/status-explain.test.ts
+      - src/__tests__/args.test.ts
+      - src/__tests__/adapter-conformance.test.ts
+
   - id: temporary-resource-lifecycle
     status: implemented
     owner: outer lifecycle and verification tooling

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -22,7 +22,11 @@ recovery commands, and Host-owned boundaries. Reuse that plan interactively, or 
 npx harnessmith setup --agent codex
 npx harnessmith setup --agent codex --yes --json
 npx harnessmith status --agent codex
+npx harnessmith status --agent codex --explain
 ```
+
+Use `--explain` when raw integrity status is not enough to choose a next step. It reports observed state, owner, evidence,
+risk, and stable action codes without executing them. Host-limited checks remain explicitly `inconclusive`.
 
 Every interactive step can be cancelled before writing. Setup still refuses unmanaged and modified targets by default;
 confirmation does not bypass ownership safeguards. Unsupported hosts stop before destination resolution or writes.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -50,7 +50,11 @@ npx harnessmith setup --agent codex --yes --json
 
 ```bash
 npx harnessmith status --agent codex
+npx harnessmith status --agent codex --explain
 ```
+
+当普通 `status` 的校验结果不足以决定下一步时，`--explain` 会显示 observed state、owner、证据、风险与稳定 action code；
+这些动作不会自动执行。受限于 Host 的检查明确返回 `inconclusive`，而不是把安装完整误报成真实会话 healthy。
 
 安装失败时，事务会尝试回滚；按错误中的指引先重新 dry-run 并检查 `status`，只有存在上一安装层时才使用
 `restore`。安装成功或确定性健康检查通过，不等于真实 Host 行为已经通过：模型行为、工具权限、认证与运行时事件均为

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,6 +28,7 @@ owner: maintainers
 | `-y, --yes` | 禁用提示；未指定宿主时默认 Codex |
 | `--dry-run` | 只预览目标，不执行写入 |
 | `--no-init-global` | 跳过共享全局 Memory 初始化 |
+| `--explain` | 仅用于 `status`；解释状态、证据、风险和安全下一步 |
 | `-v, --version` | 输出版本 |
 | `-h, --help` | 输出帮助 |
 
@@ -52,6 +53,20 @@ npx harnessmith setup --agent cursor --project /path/to/project --yes --json
 成功报告中的 `installed-and-healthy` 只表示安装所有权与内嵌 Runtime 的确定性检查通过；不代表真实 Host 中的模型行为、
 工具权限、认证或运行时事件已经通过。
 
+## 可解释状态 `status --explain`
+
+```bash
+npx harnessmith status --agent codex --explain
+npx harnessmith status --agent codex --explain --json
+```
+
+解释输出使用稳定的 `observedState`、`reasonCode` 和 action `code`，逐项列出安装记录、受管理输出与备份证据。
+本地状态可判定为 `managed`、`modified`、`unmanaged`、`partial` 或 `missing`；`unsupported` 表示没有 Adapter
+契约并在路径解析前停止。Harness capability、Host configuration 和真实 Host behavior 分开报告，无法从本地证明的 Host
+结论固定为 `inconclusive` / `host-dependent`，不会误报为 healthy。
+
+建议动作只作为下一步展示，带有 `automatic: false`、`destructive: false` 和授权要求，不会由 `status` 自动执行。
+
 ## 示例
 
 ```bash
@@ -70,6 +85,7 @@ npx harnessmith install --agent cursor --project /path/to/project
 
 # 自动化检查
 npx harnessmith status --agent codex --json
+npx harnessmith status --agent codex --explain --json
 npx harnessmith capabilities --json
 
 # 回退生命周期

--- a/llms.txt
+++ b/llms.txt
@@ -104,6 +104,7 @@ If `--no-init-global` was used, do not run the global-memory checks above; verif
 
 ```bash
 npx --yes harnessmith status --agent <agents> --project <project-path> --json
+npx --yes harnessmith status --agent <agents> --project <project-path> --explain --json
 node <harness-path>/bin/harness.mjs --version
 ```
 
@@ -135,6 +136,9 @@ the project-root `.gitignore` or `.ignore`.
   instruction to `<filename>.backup-<timestamp>` and the runtime to `agent-harness.backup-<timestamp>`.
 - Do not use `sudo`, delete or move files manually, delete locks, publish, commit, or configure remotes. Request
   only the minimum filesystem or network permission needed for the selected installation.
+- Use `status --explain --json` when ownership alone is insufficient. Preserve `observedState`, `reasonCode`, evidence,
+  and action codes. Suggested actions have `automatic: false`; do not execute restore, takeover, or Host changes without
+  the user's authorization. Host configuration and real behavior remain `inconclusive` until Host evidence exists.
 - Lifecycle commands attempt rollback along recorded paths. If rollback is incomplete, preserve stderr and every
   recovery path, report the installation as blocked, and do not claim the previous state was restored.
 - Upgrade by rerunning `npx --yes harnessmith`; use the outer CLI for status, restore, and uninstall:

--- a/src/__tests__/args.test.ts
+++ b/src/__tests__/args.test.ts
@@ -51,6 +51,19 @@ test('Commander supports lifecycle commands and safety flags', async () => {
   assert.equal(result.force, true);
 });
 
+test('Commander exposes explain mode only through status options', async () => {
+  let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
+  const program = createProgram(async (command, options) => {
+    result = { command, ...options };
+  });
+  await program.parseAsync(['status', '--agent', 'codex', '--explain', '--json'], {
+    from: 'user',
+  });
+  assert.ok(result);
+  assert.equal(result.command, 'status');
+  assert.equal(result.explain, true);
+});
+
 test('Commander exposes guided setup through the shared install options', async () => {
   let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
   const program = createProgram(async (command, options) => {

--- a/src/__tests__/status-explain.test.ts
+++ b/src/__tests__/status-explain.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter } from '../adapters.js';
+import { installAll } from '../install.js';
+import { inspectStatusAll } from '../lifecycle.js';
+import { explainStatus } from '../status-explanation.js';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const cli = join(packageRoot, 'bin', 'harnessmith.mjs');
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const env = {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, 'codex-home'),
+    HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+    HARNESS_REPOSITORY_ROOT: root,
+    HARNESS_OWNER: 'status-explain-test',
+  };
+  return { root, env, adapter: createAdapter('codex', { env }) };
+}
+
+test('status explanation classifies missing and unmanaged targets without writing', () => {
+  const { adapter } = fixture('harnessmith-status-uninstalled-');
+  const missing = explainStatus(inspectStatusAll([adapter])[0]);
+  assert.equal(missing.observedState, 'missing');
+  assert.equal(missing.reasonCode, 'INSTALLATION_MISSING');
+  assert.equal(missing.actions[0].code, 'SETUP_PREVIEW');
+  assert.ok(missing.actions.every(({ automatic }) => automatic === false));
+  assert.equal(existsSync(adapter.home), false);
+
+  mkdirSync(adapter.home, { recursive: true });
+  writeFileSync(adapter.instructions[0].path, 'unmanaged instructions\n');
+  const unmanaged = explainStatus(inspectStatusAll([adapter])[0]);
+  assert.equal(unmanaged.observedState, 'unmanaged');
+  assert.equal(unmanaged.reasonCode, 'UNMANAGED_TARGETS');
+  assert.ok(unmanaged.actions.some(({ code }) => code === 'INSPECT_OWNERSHIP'));
+  assert.equal(readFileSync(adapter.instructions[0].path, 'utf8'), 'unmanaged instructions\n');
+  assert.ok(unmanaged.stateDefinitions.unsupported);
+});
+
+test('status explanation reports managed, modified, partial, and backup evidence', () => {
+  const { env, adapter } = fixture('harnessmith-status-installed-');
+  mkdirSync(adapter.home, { recursive: true });
+  writeFileSync(adapter.instructions[0].path, 'original instructions\n');
+  installAll([adapter], { env, force: true, noInitGlobal: true });
+
+  const managed = explainStatus(inspectStatusAll([adapter])[0]);
+  assert.equal(managed.observedState, 'managed');
+  assert.equal(managed.reasonCode, 'MANAGED_INSTALLATION');
+  assert.ok(managed.evidence.backups.some(({ state }) => state === 'present'));
+  assert.equal(managed.boundaries.hostBehavior.conclusion, 'inconclusive');
+  assert.equal(managed.boundaries.hostBehavior.state, 'host-dependent');
+
+  writeFileSync(adapter.instructions[0].path, 'user-modified instructions\n');
+  const modified = explainStatus(inspectStatusAll([adapter])[0]);
+  assert.equal(modified.observedState, 'modified');
+  assert.equal(modified.reasonCode, 'MANAGED_OUTPUT_MODIFIED');
+  assert.ok(modified.actions.some(({ code }) => code === 'INSPECT_DIFF'));
+
+  rmSync(adapter.harness, { recursive: true });
+  const partial = explainStatus(inspectStatusAll([adapter])[0]);
+  assert.equal(partial.observedState, 'partial');
+  assert.equal(partial.reasonCode, 'PARTIAL_INSTALLATION');
+  assert.ok(partial.actions.some(({ code }) => code === 'RESTORE_PREVIEW'));
+});
+
+test('status explain JSON and text share state, reason, and safe next action semantics', () => {
+  const { root, env } = fixture('harnessmith-status-cli-');
+  const adapter = createAdapter('codex', { env });
+  installAll([adapter], { env, noInitGlobal: true });
+  const baseArgs = ['status', '--agent', 'codex', '--explain'];
+  const json = spawnSync(process.execPath, [cli, ...baseArgs, '--json'], {
+    cwd: root,
+    env,
+    encoding: 'utf8',
+  });
+  const text = spawnSync(process.execPath, [cli, ...baseArgs], {
+    cwd: root,
+    env,
+    encoding: 'utf8',
+  });
+
+  assert.equal(json.status, 0, json.stderr);
+  assert.equal(text.status, 0, text.stderr);
+  const report = JSON.parse(json.stdout);
+  assert.equal(report.observedState, 'managed');
+  assert.match(text.stdout, new RegExp(report.observedState));
+  assert.match(text.stdout, new RegExp(report.reasonCode));
+  assert.match(text.stdout, new RegExp(report.actions[0].code));
+  assert.match(text.stdout, /not executed automatically/i);
+  assert.doesNotMatch(text.stdout, /automatic=true/i);
+});
+
+test('status explain reports unsupported adapters without resolving or writing paths', () => {
+  const { root, env } = fixture('harnessmith-status-unsupported-');
+  const result = spawnSync(
+    process.execPath,
+    [cli, 'status', '--agent', 'windsurf', '--explain', '--json'],
+    { cwd: root, env, encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stderr, '');
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.observedState, 'unsupported');
+  assert.equal(report.reasonCode, 'ADAPTER_UNSUPPORTED');
+  assert.equal(report.actions[0].code, 'LIST_SUPPORTED_ADAPTERS');
+  assert.equal(existsSync(join(root, 'codex-home')), false);
+});

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -2,11 +2,12 @@ import type { Readable, Writable } from 'node:stream';
 import { adapterCapabilities, createAdapter } from './adapters.js';
 import { normalizeAgents } from './agents.js';
 import { installAll } from './install.js';
-import { restoreAll, statusAll, uninstallAll } from './lifecycle.js';
+import { inspectStatusAll, restoreAll, statusAll, uninstallAll } from './lifecycle.js';
 import { describeLifecycle } from './lifecycle-plan.js';
 import type { HarnessmithCommand } from './program.js';
 import { assertNonOverlappingAdapters, describeInstall } from './records.js';
 import { executeSetup } from './setup-command.js';
+import { explainStatus, explainUnsupportedStatus } from './status-explanation.js';
 import type { Adapter, CliOptions, Io, LifecycleCommand, LifecyclePlan } from './types.js';
 import { HarnessmithError } from './types.js';
 import {
@@ -14,6 +15,7 @@ import {
   finishInteractive,
   printInstallResults,
   printPlans,
+  printStatusExplanations,
   printStatuses,
   selectAgents,
   startInteractive,
@@ -97,8 +99,18 @@ function executeLifecycle(
   interactive: boolean,
 ): number {
   if (command === 'status') {
-    const statuses = statusAll(adapters);
-    if (options.json || !interactive) {
+    const inspections = options.explain ? inspectStatusAll(adapters) : [];
+    const statuses = options.explain
+      ? inspections.map(({ status }) => status)
+      : statusAll(adapters);
+    const explanations = inspections.map(explainStatus);
+    if (options.explain && options.json) {
+      explanations.forEach((explanation) => {
+        context.io.log(JSON.stringify(explanation));
+      });
+    } else if (options.explain) {
+      printStatusExplanations(explanations, context.io);
+    } else if (options.json || !interactive) {
       statuses.forEach((status) => {
         context.io.log(JSON.stringify(status));
       });
@@ -206,7 +218,24 @@ export async function executeCommand(
     !options.yes && isTty(context.input) && isTty(context.output) && !options.json;
   if (interactive) startInteractive(context.output);
   if (command === 'capabilities') return executeCapabilities(options, context);
-  const adapters = await resolveAdapters(options, context);
+  let adapters: Adapter[];
+  try {
+    adapters = await resolveAdapters(options, context);
+  } catch (error) {
+    if (
+      command === 'status' &&
+      options.explain &&
+      error instanceof HarnessmithError &&
+      error.code === 'CLI_USAGE' &&
+      error.message.startsWith('Unsupported agent:')
+    ) {
+      const explanation = explainUnsupportedStatus(options.agent);
+      if (options.json) context.io.log(JSON.stringify(explanation));
+      else printStatusExplanations([explanation], context.io);
+      return 2;
+    }
+    throw error;
+  }
   if (command === 'setup') return executeSetup(adapters, options, context, interactive);
   return command === 'install'
     ? executeInstall(adapters, options, context, interactive)

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -15,14 +15,13 @@ import {
 import { withAdapterLocks } from './operation-lock.js';
 import {
   assertNonOverlappingAdapters,
-  digestManagedOutput,
   managedBlockMarker,
   readInstallRecord,
   restoreSnapshots,
   snapshotFiles,
 } from './records.js';
 import { assertSafePath, ignoreRoot } from './safe-path.js';
-import type { Adapter, AdapterStatus, InstallOptions, InstallRecord } from './types.js';
+import type { Adapter, InstallOptions, InstallRecord } from './types.js';
 import { errorMessage, HarnessmithError } from './types.js';
 
 interface RestoreState {
@@ -157,36 +156,7 @@ function restoreOnce(
   }
 }
 
-export function statusAll(adapters: Adapter[]): AdapterStatus[] {
-  assertNonOverlappingAdapters(adapters);
-  return withAdapterLocks(
-    adapters,
-    () =>
-      adapters.map((adapter) => {
-        assertLifecyclePaths(adapter);
-        const record = readInstallRecord(adapter);
-        if (record) assertLifecyclePaths(adapter, [{ path: adapter.record, record }]);
-        return {
-          adapter: adapter.name,
-          installed: Boolean(record),
-          record: adapter.record,
-          capabilities: adapter.capabilities,
-          packageVersion: record?.packageVersion || null,
-          installedAt: record?.installedAt || null,
-          outputs:
-            record?.outputs.map(({ path, checksum }) => ({
-              path,
-              status: !existsSync(path)
-                ? 'missing'
-                : digestManagedOutput(adapter, path) === checksum
-                  ? 'managed'
-                  : 'modified',
-            })) || [],
-        };
-      }),
-    { createHomes: false },
-  );
-}
+export { inspectStatusAll, statusAll } from './status-inspection.js';
 
 export function restoreAll(adapters: Adapter[], options: Pick<InstallOptions, 'force'> = {}) {
   assertNonOverlappingAdapters(adapters);

--- a/src/program.ts
+++ b/src/program.ts
@@ -78,6 +78,8 @@ export function createProgram(
     ['uninstall', 'restore all layers and remove the installation'],
   ] as const) {
     const command = program.command(name).description(description);
+    if (name === 'status')
+      command.option('--explain', 'explain evidence, risk, and safe next actions');
     command.action(() => execute(name, command.optsWithGlobals<CliOptions>()));
   }
   return program;

--- a/src/status-explanation.ts
+++ b/src/status-explanation.ts
@@ -1,0 +1,163 @@
+import { existsSync } from 'node:fs';
+import type { Adapter, AdapterStatus, AdapterStatusInspection } from './types.js';
+
+const stateDefinitions = {
+  managed: 'Every recorded output exists and matches its recorded checksum.',
+  modified: 'At least one managed output differs from its recorded checksum.',
+  unmanaged: 'A planned destination exists without a matching Harnessmith installation record.',
+  partial: 'An installation record exists, but at least one recorded output is missing.',
+  missing: 'No installation record or planned destination exists.',
+  unsupported: 'No Adapter contract exists; stop before resolving or writing paths.',
+  'host-dependent': 'Host-owned configuration and behavior require evidence from that Host.',
+} as const;
+
+type ObservedState = 'managed' | 'modified' | 'unmanaged' | 'partial' | 'missing';
+
+interface SafeAction {
+  code: string;
+  command: string;
+  automatic: false;
+  destructive: false;
+  requiresAuthorization: boolean;
+}
+
+function classify(status: AdapterStatus, plan: AdapterStatusInspection['plan']): ObservedState {
+  if (status.installed) {
+    if (status.outputs.some(({ status: value }) => value === 'missing')) return 'partial';
+    if (status.outputs.some(({ status: value }) => value === 'modified')) return 'modified';
+    return 'managed';
+  }
+  return plan.outputs.some(({ state }) => state === 'unmanaged') ? 'unmanaged' : 'missing';
+}
+
+function reasonCode(state: ObservedState) {
+  return {
+    managed: 'MANAGED_INSTALLATION',
+    modified: 'MANAGED_OUTPUT_MODIFIED',
+    unmanaged: 'UNMANAGED_TARGETS',
+    partial: 'PARTIAL_INSTALLATION',
+    missing: 'INSTALLATION_MISSING',
+  }[state];
+}
+
+function action(code: string, command: string, requiresAuthorization = false): SafeAction {
+  return { code, command, automatic: false, destructive: false, requiresAuthorization };
+}
+
+function safeActions(adapter: Adapter, state: ObservedState): SafeAction[] {
+  const selector = `--agent ${adapter.name}${adapter.project ? ` --project ${adapter.project}` : ''}`;
+  if (state === 'managed') {
+    return [
+      action('STATUS_RECHECK', `harnessmith status ${selector} --explain`),
+      action('HOST_VERIFY', 'Verify behavior in a real Host session', true),
+    ];
+  }
+  if (state === 'modified') {
+    return [
+      action('INSPECT_DIFF', `harnessmith status ${selector} --explain`),
+      action('VERIFY_BACKUPS', `harnessmith restore ${selector} --dry-run`),
+    ];
+  }
+  if (state === 'partial') {
+    return [
+      action('RESTORE_PREVIEW', `harnessmith restore ${selector} --dry-run`),
+      action('SETUP_PREVIEW', `harnessmith setup ${selector} --dry-run`),
+    ];
+  }
+  if (state === 'unmanaged') {
+    return [action('INSPECT_OWNERSHIP', `harnessmith setup ${selector} --dry-run`)];
+  }
+  return [action('SETUP_PREVIEW', `harnessmith setup ${selector} --dry-run`)];
+}
+
+export function explainStatus({ adapter, status, record, plan }: AdapterStatusInspection) {
+  const state = classify(status, plan);
+  const backups = record
+    ? [record.recordBackup, ...record.outputs.map(({ backup }) => backup)]
+        .filter((path): path is string => Boolean(path))
+        .map((path) => ({
+          path,
+          state: existsSync(path) ? ('present' as const) : ('missing' as const),
+        }))
+    : [];
+  return {
+    version: 1,
+    command: 'status' as const,
+    adapter: adapter.name,
+    observedState: state,
+    reasonCode: reasonCode(state),
+    owner: 'harnessmith-installer' as const,
+    risk:
+      state === 'managed'
+        ? ('low' as const)
+        : state === 'missing'
+          ? ('none' as const)
+          : ('requires-review' as const),
+    evidence: {
+      record: { path: adapter.record, state: record ? ('present' as const) : ('missing' as const) },
+      outputs: status.installed
+        ? status.outputs
+        : plan.outputs.map(({ path, state: outputState }) => ({ path, status: outputState })),
+      backups,
+    },
+    actions: safeActions(adapter, state),
+    boundaries: {
+      harnessCapability: {
+        state: 'supported' as const,
+        owner: 'harnessmith-adapter' as const,
+        evidence: adapter.capabilities,
+      },
+      hostConfiguration: {
+        state: 'host-dependent' as const,
+        owner: 'host' as const,
+        reasonCode: 'HOST_CONFIGURATION_NOT_CHECKED' as const,
+        conclusion: 'inconclusive' as const,
+      },
+      hostBehavior: {
+        state: 'host-dependent' as const,
+        owner: 'host' as const,
+        reasonCode: 'REAL_HOST_BEHAVIOR_NOT_OBSERVED' as const,
+        conclusion: 'inconclusive' as const,
+      },
+    },
+    stateDefinitions,
+  };
+}
+
+export function explainUnsupportedStatus(requestedAgents: string[]) {
+  return {
+    version: 1,
+    command: 'status' as const,
+    adapter: requestedAgents.join(',') || 'unknown',
+    observedState: 'unsupported' as const,
+    reasonCode: 'ADAPTER_UNSUPPORTED' as const,
+    owner: 'none' as const,
+    risk: 'unsupported' as const,
+    evidence: { requestedAgents },
+    actions: [action('LIST_SUPPORTED_ADAPTERS', 'harnessmith capabilities --json')],
+    boundaries: {
+      harnessCapability: {
+        state: 'unsupported' as const,
+        owner: 'none' as const,
+        evidence: null,
+      },
+      hostConfiguration: {
+        state: 'host-dependent' as const,
+        owner: 'host' as const,
+        reasonCode: 'HOST_CONFIGURATION_NOT_CHECKED' as const,
+        conclusion: 'inconclusive' as const,
+      },
+      hostBehavior: {
+        state: 'host-dependent' as const,
+        owner: 'host' as const,
+        reasonCode: 'REAL_HOST_BEHAVIOR_NOT_OBSERVED' as const,
+        conclusion: 'inconclusive' as const,
+      },
+    },
+    stateDefinitions,
+  };
+}
+
+export type StatusExplanation =
+  | ReturnType<typeof explainStatus>
+  | ReturnType<typeof explainUnsupportedStatus>;

--- a/src/status-inspection.ts
+++ b/src/status-inspection.ts
@@ -1,0 +1,49 @@
+import { existsSync } from 'node:fs';
+import { assertLifecyclePaths } from './lifecycle-plan.js';
+import { withAdapterLocks } from './operation-lock.js';
+import {
+  assertNonOverlappingAdapters,
+  describeInstall,
+  digestManagedOutput,
+  readInstallRecord,
+} from './records.js';
+import type { Adapter, AdapterStatus, AdapterStatusInspection } from './types.js';
+
+function inspectAdapterStatus(adapter: Adapter): AdapterStatusInspection {
+  assertLifecyclePaths(adapter);
+  const record = readInstallRecord(adapter);
+  if (record) assertLifecyclePaths(adapter, [{ path: adapter.record, record }]);
+  return {
+    adapter,
+    record,
+    plan: describeInstall(adapter),
+    status: {
+      adapter: adapter.name,
+      installed: Boolean(record),
+      record: adapter.record,
+      capabilities: adapter.capabilities,
+      packageVersion: record?.packageVersion || null,
+      installedAt: record?.installedAt || null,
+      outputs:
+        record?.outputs.map(({ path, checksum }) => ({
+          path,
+          status: !existsSync(path)
+            ? 'missing'
+            : digestManagedOutput(adapter, path) === checksum
+              ? 'managed'
+              : 'modified',
+        })) || [],
+    },
+  };
+}
+
+export function inspectStatusAll(adapters: Adapter[]): AdapterStatusInspection[] {
+  assertNonOverlappingAdapters(adapters);
+  return withAdapterLocks(adapters, () => adapters.map(inspectAdapterStatus), {
+    createHomes: false,
+  });
+}
+
+export function statusAll(adapters: Adapter[]): AdapterStatus[] {
+  return inspectStatusAll(adapters).map(({ status }) => status);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,13 @@ export interface AdapterStatus {
   outputs: Array<{ path: string; status: ManagedStatus }>;
 }
 
+export interface AdapterStatusInspection {
+  adapter: Adapter;
+  status: AdapterStatus;
+  record: InstallRecord | null;
+  plan: InstallPlan;
+}
+
 export type LifecycleCommand = 'restore' | 'uninstall';
 export type LifecycleChangeAction = 'remove' | 'restore-backup' | 'remove-managed-block';
 
@@ -148,6 +155,7 @@ export interface CliOptions {
   yes?: boolean;
   dryRun?: boolean;
   initGlobal?: boolean;
+  explain?: boolean;
 }
 
 export interface RunContext {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -3,6 +3,7 @@ import { confirm, intro, isCancel, log, multiselect, note, outro } from '@clack/
 import pc from 'picocolors';
 import { supportedAgents } from './agents.js';
 import type { SetupGuide, SetupVerification } from './setup.js';
+import type { StatusExplanation } from './status-explanation.js';
 import type { AdapterStatus, InstallPlan, InstallResult, Io } from './types.js';
 
 type PromptInput = Readable & { isTTY?: boolean };
@@ -134,6 +135,20 @@ export function printStatuses(statuses: AdapterStatus[], io: Io = console): void
             : pc.red(label);
       io.log(`  ${state} ${output.path}`);
     }
+  }
+}
+
+export function printStatusExplanations(explanations: StatusExplanation[], io: Io = console): void {
+  for (const explanation of explanations) {
+    io.log(
+      `${explanation.adapter}: state=${explanation.observedState}, reason=${explanation.reasonCode}, owner=${explanation.owner}`,
+    );
+    for (const next of explanation.actions) {
+      io.log(`  next ${next.code}  ${next.command} (not executed automatically)`);
+    }
+    io.log(
+      `  Host behavior: ${explanation.boundaries.hostBehavior.conclusion} (${explanation.boundaries.hostBehavior.reasonCode})`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary / 变更说明

- Add `status --explain` with stable observed-state, reason, evidence, risk, and action codes.
- Classify managed, modified, unmanaged, partial, missing, unsupported, and Host-dependent boundaries without resolving unsupported paths.
- Snapshot install records, outputs, and backups under the existing Adapter locks; suggested actions remain non-automatic and non-destructive.

## Related Issue / 关联 Issue

Closes #105

## Verification / 验证

- `pnpm run preflight` — 755 checks; 143 files, 979 passed, 3 skipped.
- `pnpm run test:coverage` — unit and script coverage gates passed.
- `HUSKY=0 npm_config_cache=/private/tmp/harnessmith-npm-cache npm pack --dry-run` — passed; 83 files.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

Host configuration and real behavior remain explicitly inconclusive until Host evidence exists.
