### PR TITLE
feat: safely adopt existing host rules

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -72,6 +72,10 @@ npx harnessmith status --agent codex
 # Explain observed state, evidence, risk, and safe actions that are not auto-run
 npx harnessmith status --agent codex --explain
 
+# Inventory existing rules without writes, then confirm the exact returned proposalId
+npx harnessmith adopt --agent codex --json
+npx harnessmith adopt --agent codex --proposal <proposalId> --yes --json
+
 # Restore the previous installation layer
 npx harnessmith restore --agent codex
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ npx harnessmith status --agent codex
 # 解释观察状态、证据、风险和不会自动执行的安全下一步
 npx harnessmith status --agent codex --explain
 
+# 只读盘点已有规则并生成接管提案；确认时复用返回的 proposalId
+npx harnessmith adopt --agent codex --json
+npx harnessmith adopt --agent codex --proposal <proposalId> --yes --json
+
 # 恢复上一安装层
 npx harnessmith restore --agent codex
 

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -48,6 +48,21 @@ claims:
       - src/__tests__/args.test.ts
       - src/__tests__/adapter-conformance.test.ts
 
+  - id: safe-existing-rule-adoption
+    status: implemented
+    owner: outer installer adoption workflow
+    claim: Inventory existing global or project Host rules without writes, classify importability, bind confirmation to an exact proposal, and transactionally preserve portable rules in the user-owned personal overlay with provenance and rollback.
+    implementation:
+      - src/adopt.ts
+      - src/adopt-inventory.ts
+      - src/adopt-command.ts
+      - src/install.ts
+      - src/user-data.ts
+    verification:
+      - src/__tests__/adopt.test.ts
+      - src/__tests__/args.test.ts
+      - src/__tests__/adapter-conformance.test.ts
+
   - id: explainable-installation-status
     status: implemented
     owner: outer installer lifecycle

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -18,6 +18,17 @@ npx harnessmith install --agent codex
 目标不存在或仍与上一层安装记录一致时可安全接管。遇到 unmanaged 或已修改文件默认拒绝；`--force` 会先备份再替换，
 应在理解差异后显式使用。
 
+已有规则不应直接用 `--force` 覆盖。先运行 `adopt` 获取只读 inventory 和内容绑定提案，审阅导入 diff、备份与回滚路径后，
+再确认同一个 `proposalId`：
+
+```bash
+npx harnessmith adopt --agent codex --json
+npx harnessmith adopt --agent codex --proposal <proposalId> --yes --json
+```
+
+`adopt` 只导入可移植规则正文；Host-specific 配置只保留在原文件备份中。扫描或确认阶段发现 secret、symlink、未知格式、
+路径越界、受管文件被修改，或提案后内容发生变化时都会停止。实际写入与安装共享预检、锁、备份和事务回滚。
+
 ## 只读预览与状态
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,6 +11,7 @@ owner: maintainers
 | 命令 | 作用 | 是否写入 |
 | --- | --- | --- |
 | `setup` | 预览、确认、安装并验证首个 Harness | dry-run 否；确认后是 |
+| `adopt` | 盘点并安全导入已有 Host 规则 | 默认否；确认精确提案后是 |
 | `harnessmith` / `install` | 安装或升级 Harness | 是 |
 | `status` | 检查安装所有权与完整性 | 否 |
 | `restore` | 恢复上一安装层 | 是 |
@@ -29,6 +30,7 @@ owner: maintainers
 | `--dry-run` | 只预览目标，不执行写入 |
 | `--no-init-global` | 跳过共享全局 Memory 初始化 |
 | `--explain` | 仅用于 `status`；解释状态、证据、风险和安全下一步 |
+| `--proposal <id>` | 仅用于 `adopt`；绑定先前只读扫描返回的精确提案 |
 | `-v, --version` | 输出版本 |
 | `-h, --help` | 输出帮助 |
 
@@ -52,6 +54,25 @@ npx harnessmith setup --agent cursor --project /path/to/project --yes --json
 
 成功报告中的 `installed-and-healthy` 只表示安装所有权与内嵌 Runtime 的确定性检查通过；不代表真实 Host 中的模型行为、
 工具权限、认证或运行时事件已经通过。
+
+## 安全接管 `adopt`
+
+`adopt` 默认只读扫描已有 Host 规则，将内容逐项分类为 managed-compatible、user-owned overlay、冲突规则、
+Host-specific 配置或不可导入内容，并返回导入 diff、备份目标、owner、回滚路径与内容绑定的 `proposalId`。
+
+```bash
+# 第一步只读预览
+npx harnessmith adopt --agent codex --json
+npx harnessmith adopt --agent cursor --project /path/to/project --json
+
+# 审阅后，以原样 proposalId 明确确认
+npx harnessmith adopt --agent codex --proposal <proposalId> --yes --json
+```
+
+非交互写入必须同时提供 `--yes` 和精确 `--proposal`。文件在预览后发生变化时，提案失效并停止；secret、symlink、
+未知格式、越界路径与已修改的受管文件 fail closed。确认后的接管复用安装事务的完整预检、operation lock、精确备份与
+回滚，并只把可移植规则追加到用户所有的 personal overlay；Host frontmatter、受管理分发、可变 state 与项目
+`.agent-docs` 不会混入 overlay。成功后再次运行只返回幂等的 `already-adopted`。
 
 ## 可解释状态 `status --explain`
 
@@ -86,6 +107,7 @@ npx harnessmith install --agent cursor --project /path/to/project
 # 自动化检查
 npx harnessmith status --agent codex --json
 npx harnessmith status --agent codex --explain --json
+npx harnessmith adopt --agent codex --json
 npx harnessmith capabilities --json
 
 # 回退生命周期

--- a/llms.txt
+++ b/llms.txt
@@ -88,6 +88,18 @@ use the published `npx --yes harnessmith` commands below.
 6. Report every installed instruction path, Harness path, backup path, ownership result, and deterministic health result.
    Never report `installed-and-healthy` as proof of behavior in a real Host session.
 
+If the preview reports unmanaged rules that must be preserved, do not jump to `--force`. Use the proposal-bound adoption flow:
+
+```bash
+npx --yes harnessmith adopt --agent <agents> --project <project-path> --json
+npx --yes harnessmith adopt --agent <agents> --project <project-path> --proposal <proposalId> --yes --json
+```
+
+Omit `--project` when Cursor is not selected. The first command is read-only. Review every classification, blocked item,
+import diff, backup target, owner, and rollback path. The second command is allowed only after the user approves that exact
+proposal. Never retry with `--force` when adoption reports a secret, symlink, unknown format, path escape, modified managed
+file, or proposal mismatch. Host-specific frontmatter is backup-only; only portable rule content enters the personal overlay.
+
 ## Post-install verification
 
 Harnessmith always initializes the user-owned personal overlay after a successful install and initializes

--- a/src/__tests__/adopt.test.ts
+++ b/src/__tests__/adopt.test.ts
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter } from '../adapters.js';
+import { applyAdoptPlan, createAdoptPlan } from '../adopt.js';
+import { canonicalPath } from '../safe-path.js';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const cli = join(packageRoot, 'bin', 'harnessmith.mjs');
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  const env = {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, 'codex-home'),
+    HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+    HARNESS_REPOSITORY_ROOT: root,
+    HARNESS_OWNER: 'adopt-test',
+  };
+  return { root, project, env };
+}
+
+function execute(root: string, env: NodeJS.ProcessEnv, args: string[]) {
+  return spawnSync(process.execPath, [cli, ...args], { cwd: root, env, encoding: 'utf8' });
+}
+
+function json(result: ReturnType<typeof execute>) {
+  assert.equal(result.stderr, '');
+  return JSON.parse(result.stdout);
+}
+
+test('adopt defaults to a read-only exact proposal and imports only after proposal-bound confirmation', () => {
+  const { root, env } = fixture('harnessmith-adopt-global-');
+  const source = join(root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(source, '# My rules\n\n- Preserve focused changes.\n');
+
+  const previewResult = execute(root, env, ['adopt', '--agent', 'codex', '--json']);
+  assert.equal(previewResult.status, 0, previewResult.stderr);
+  const preview = json(previewResult);
+  assert.equal(preview.phase, 'proposal');
+  assert.equal(preview.requiresConfirmation, true);
+  assert.ok(
+    preview.inventory.some(
+      ({ classification }: { classification: string }) => classification === 'user-owned-overlay',
+    ),
+  );
+  assert.match(preview.diff, /Preserve focused changes/);
+  assert.ok(
+    preview.backups.some(({ source: path }: { source: string }) => path === canonicalPath(source)),
+    JSON.stringify(preview.backups),
+  );
+  assert.ok(preview.rollbackPaths.includes(canonicalPath(source)));
+  assert.equal(readFileSync(source, 'utf8'), '# My rules\n\n- Preserve focused changes.\n');
+  assert.equal(existsSync(join(root, 'personal-harness')), false);
+
+  const appliedResult = execute(root, env, [
+    'adopt',
+    '--agent',
+    'codex',
+    '--proposal',
+    preview.proposalId,
+    '--yes',
+    '--json',
+  ]);
+  assert.equal(appliedResult.status, 0, appliedResult.stderr);
+  const applied = json(appliedResult);
+  assert.equal(applied.phase, 'complete');
+  assert.equal(applied.result, 'adopted');
+  assert.match(readFileSync(source, 'utf8'), /managed-by: harnessmith/);
+  const personal = readFileSync(join(root, 'personal-harness', 'AGENTS.md'), 'utf8');
+  assert.match(personal, /Preserve focused changes/);
+  assert.match(personal, /harnessmith-adopt:start/);
+  assert.match(personal, new RegExp(preview.proposalId.slice(-12)));
+  assert.ok(preview.backups.every(({ path }: { path: string }) => existsSync(path)));
+});
+
+test('adopt is idempotent after ownership and provenance are established', () => {
+  const { root, env } = fixture('harnessmith-adopt-idempotent-');
+  const source = join(root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(source, '# Existing rules\n');
+  const adapter = createAdapter('codex', { env });
+  const proposal = createAdoptPlan([adapter], env).report;
+  const applied = applyAdoptPlan([adapter], env, {
+    proposal: proposal.proposalId,
+    initGlobal: true,
+  });
+  assert.equal(applied.result, 'adopted');
+  const record = join(root, 'codex-home', '.harnessmith', 'install.json');
+  const recordBefore = readFileSync(record, 'utf8');
+  const entriesBefore = readdirSync(join(root, 'codex-home')).sort();
+
+  const repeated = createAdoptPlan([adapter], env).report;
+  assert.equal(repeated.requiresWrite, false);
+  assert.equal(repeated.inventory[0].classification, 'managed-compatible');
+  assert.equal(readFileSync(record, 'utf8'), recordBefore);
+  assert.deepEqual(readdirSync(join(root, 'codex-home')).sort(), entriesBefore);
+});
+
+test('adopt separates Cursor frontmatter from importable project rules', () => {
+  const { root, project, env } = fixture('harnessmith-adopt-project-');
+  const source = join(project, '.cursor', 'rules', 'agent-harness.mdc');
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(
+    source,
+    '---\ndescription: Existing Cursor rules\nalwaysApply: true\n---\n# Project-neutral rule\n',
+  );
+
+  const adapter = createAdapter('cursor', { env, project });
+  const proposal = createAdoptPlan([adapter], env).report;
+  assert.ok(
+    proposal.inventory.some(
+      ({ classification }: { classification: string }) => classification === 'host-specific-config',
+    ),
+  );
+  assert.ok(
+    proposal.inventory.some(
+      ({ classification }: { classification: string }) => classification === 'user-owned-overlay',
+    ),
+  );
+  assert.ok(proposal.diff);
+  assert.doesNotMatch(proposal.diff, /alwaysApply/);
+  assert.match(proposal.diff, /Project-neutral rule/);
+
+  const applied = applyAdoptPlan([adapter], env, {
+    proposal: proposal.proposalId,
+    initGlobal: true,
+  });
+  assert.equal(applied.result, 'adopted');
+  assert.match(readFileSync(source, 'utf8'), /managed-by: harnessmith/);
+  const personal = readFileSync(join(root, 'personal-harness', 'AGENTS.md'), 'utf8');
+  assert.match(personal, /Project-neutral rule/);
+  assert.doesNotMatch(personal, /alwaysApply/);
+  assert.match(readFileSync(join(project, '.cursor', '.ignore'), 'utf8'), /agent-harness/);
+  assert.ok(proposal.backups.every(({ path }: { path: string }) => existsSync(path)));
+});
+
+test('non-interactive adopt requires the exact proposal before any write', () => {
+  const { root, env } = fixture('harnessmith-adopt-confirmation-');
+  const source = join(root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(source, '# unchanged\n');
+
+  const result = execute(root, env, ['adopt', '--agent', 'codex', '--yes', '--json']);
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /CLI_USAGE/);
+  assert.equal(readFileSync(source, 'utf8'), '# unchanged\n');
+  assert.equal(existsSync(join(root, 'personal-harness')), false);
+});
+
+test('adopt fails closed on secrets, symlinks, binary content, and changed proposals', () => {
+  const secretFixture = fixture('harnessmith-adopt-secret-');
+  const secretSource = join(secretFixture.root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(secretSource), { recursive: true });
+  const secret = ['ghp', '_', 'S'.repeat(24)].join('');
+  writeFileSync(secretSource, `# rules\n${secret}\n`);
+  const secretPlan = createAdoptPlan(
+    [createAdapter('codex', { env: secretFixture.env })],
+    secretFixture.env,
+  ).report;
+  assert.equal(secretPlan.blocked[0].reasonCode, 'SECRET_DETECTED');
+  assert.doesNotMatch(JSON.stringify(secretPlan), new RegExp(secret));
+  assert.equal(readFileSync(secretSource, 'utf8'), `# rules\n${secret}\n`);
+
+  const symlinkFixture = fixture('harnessmith-adopt-symlink-');
+  const outside = join(symlinkFixture.root, 'outside.md');
+  writeFileSync(outside, '# outside\n');
+  const symlinkSource = join(symlinkFixture.root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(symlinkSource), { recursive: true });
+  symlinkSync(outside, symlinkSource);
+  const symlinkPlan = createAdoptPlan(
+    [createAdapter('codex', { env: symlinkFixture.env })],
+    symlinkFixture.env,
+  ).report;
+  assert.equal(symlinkPlan.blocked[0].reasonCode, 'SYMLINK_REJECTED');
+  assert.equal(lstatSync(symlinkSource).isSymbolicLink(), true);
+
+  const binaryFixture = fixture('harnessmith-adopt-binary-');
+  const binarySource = join(binaryFixture.root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(binarySource), { recursive: true });
+  writeFileSync(binarySource, Buffer.from([0, 1, 2, 3]));
+  const binaryPlan = createAdoptPlan(
+    [createAdapter('codex', { env: binaryFixture.env })],
+    binaryFixture.env,
+  ).report;
+  assert.equal(binaryPlan.blocked[0].reasonCode, 'UNKNOWN_FORMAT');
+
+  const changedFixture = fixture('harnessmith-adopt-changed-');
+  const changedSource = join(changedFixture.root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(changedSource), { recursive: true });
+  writeFileSync(changedSource, '# first\n');
+  const changedAdapter = createAdapter('codex', { env: changedFixture.env });
+  const proposal = createAdoptPlan([changedAdapter], changedFixture.env).report;
+  writeFileSync(changedSource, '# changed after preview\n');
+  assert.throws(
+    () =>
+      applyAdoptPlan([changedAdapter], changedFixture.env, {
+        proposal: proposal.proposalId,
+        initGlobal: true,
+      }),
+    /proposal.*changed/i,
+  );
+  assert.equal(readFileSync(changedSource, 'utf8'), '# changed after preview\n');
+});
+
+test('adopt rolls back Host files when post-install initialization fails', () => {
+  const { root, env } = fixture('harnessmith-adopt-rollback-');
+  const source = join(root, 'codex-home', 'AGENTS.md');
+  mkdirSync(dirname(source), { recursive: true });
+  writeFileSync(source, '# original\n');
+  const blockedMemory = join(root, 'blocked-memory');
+  writeFileSync(blockedMemory, 'not a directory\n');
+  const blockedEnv = { ...env, HARNESS_MEMORY_HOME: blockedMemory };
+  const proposal = json(execute(root, blockedEnv, ['adopt', '--agent', 'codex', '--json']));
+
+  const result = execute(root, blockedEnv, [
+    'adopt',
+    '--agent',
+    'codex',
+    '--proposal',
+    proposal.proposalId,
+    '--yes',
+    '--json',
+  ]);
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(source, 'utf8'), '# original\n');
+  assert.equal(existsSync(join(root, 'codex-home', '.harnessmith', 'install.json')), false);
+  assert.equal(existsSync(join(root, 'personal-harness')), false);
+});

--- a/src/__tests__/args.test.ts
+++ b/src/__tests__/args.test.ts
@@ -81,6 +81,21 @@ test('Commander exposes guided setup through the shared install options', async 
   assert.equal(result.json, true);
 });
 
+test('Commander exposes proposal-bound adopt options', async () => {
+  let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
+  const program = createProgram(async (command, options) => {
+    result = { command, ...options };
+  });
+  await program.parseAsync(
+    ['adopt', '--agent', 'codex', '--proposal', 'sha256:abc', '--yes', '--json'],
+    { from: 'user' },
+  );
+  assert.ok(result);
+  assert.equal(result.command, 'adopt');
+  assert.equal(result.proposal, 'sha256:abc');
+  assert.equal(result.yes, true);
+});
+
 test('Commander exposes adapter capabilities as a read-only command', async () => {
   let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
   const program = createProgram(async (command, options) => {

--- a/src/adopt-command.ts
+++ b/src/adopt-command.ts
@@ -1,0 +1,58 @@
+import type { Readable, Writable } from 'node:stream';
+import { applyAdoptPlan, createAdoptPlan } from './adopt.js';
+import type { Adapter, CliOptions, Io } from './types.js';
+import { HarnessmithError } from './types.js';
+import { confirmAdopt, finishInteractive, printAdoptPlan } from './ui.js';
+
+interface AdoptContext {
+  env: NodeJS.ProcessEnv;
+  io: Io;
+  input: Readable;
+  output: Writable;
+}
+
+export async function executeAdopt(
+  adapters: Adapter[],
+  options: CliOptions,
+  context: AdoptContext,
+  interactive: boolean,
+): Promise<number> {
+  const plan = createAdoptPlan(adapters, context.env);
+  if (!interactive && options.yes && !options.proposal && plan.report.requiresWrite) {
+    throw new HarnessmithError(
+      'CLI_USAGE',
+      'Non-interactive adopt requires --proposal <id> from the exact preview and --yes',
+      2,
+    );
+  }
+  const applyingNonInteractively = Boolean(
+    !interactive && !options.dryRun && options.yes && options.proposal,
+  );
+  if (!applyingNonInteractively || plan.report.blocked.length > 0) {
+    if (options.json || !interactive) context.io.log(JSON.stringify(plan.report));
+    else printAdoptPlan(plan.report, context.io);
+  }
+  if (plan.report.blocked.length > 0) return 3;
+  if (!plan.report.requiresWrite || options.dryRun) return 0;
+
+  let proposal = options.proposal;
+  if (interactive) {
+    if (!(await confirmAdopt(plan.report, { input: context.input, output: context.output }))) {
+      finishInteractive('Adopt cancelled. No files were changed.', context.output);
+      return 0;
+    }
+    proposal = plan.report.proposalId;
+  } else if (!options.yes) {
+    return 0;
+  }
+
+  const result = applyAdoptPlan(adapters, context.env, {
+    proposal,
+    initGlobal: options.initGlobal,
+  });
+  if (options.json) context.io.log(JSON.stringify(result));
+  else context.io.log(`Adopted existing rules into ${result.target.path}`);
+  if (interactive)
+    finishInteractive('Adopt complete. Original Host files were backed up.', context.output);
+  return 0;
+}

--- a/src/adopt-inventory.ts
+++ b/src/adopt-inventory.ts
@@ -1,0 +1,210 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { extname } from 'node:path';
+import { containsAdoptSecret } from './adopt-secret.js';
+import { digestManagedOutput, readInstallRecord } from './records.js';
+import type { Adapter, InstallRecord } from './types.js';
+
+const maxRuleBytes = 256 * 1024;
+
+export interface AdoptInventoryItem {
+  path: string;
+  owner: 'harnessmith' | 'user' | 'host' | 'unknown';
+  classification:
+    | 'managed-compatible'
+    | 'user-owned-overlay'
+    | 'conflict-rule'
+    | 'host-specific-config'
+    | 'not-importable';
+  reasonCode: string;
+  proposal: string;
+  checksum: string | null;
+}
+
+export interface AdoptImportCandidate {
+  path: string;
+  checksum: string;
+  content: string;
+}
+
+export function adoptHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function readAdoptRule(
+  path: string,
+): { ok: true; content: string; checksum: string } | { ok: false; reasonCode: string } {
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink()) return { ok: false, reasonCode: 'SYMLINK_REJECTED' };
+  if (!entry.isFile() || entry.size > maxRuleBytes) {
+    return { ok: false, reasonCode: 'UNKNOWN_FORMAT' };
+  }
+  const bytes = readFileSync(path);
+  if (bytes.includes(0)) return { ok: false, reasonCode: 'UNKNOWN_FORMAT' };
+  let content: string;
+  try {
+    content = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return { ok: false, reasonCode: 'UNKNOWN_FORMAT' };
+  }
+  if (containsAdoptSecret(content)) return { ok: false, reasonCode: 'SECRET_DETECTED' };
+  return { ok: true, content, checksum: adoptHash(content) };
+}
+
+function splitMdc(content: string): { frontmatter: string | null; body: string } {
+  if (!content.startsWith('---\n')) return { frontmatter: null, body: content };
+  const end = content.indexOf('\n---\n', 4);
+  if (end < 0) return { frontmatter: null, body: content };
+  return { frontmatter: content.slice(0, end + 5), body: content.slice(end + 5) };
+}
+
+interface InventoryAccumulator {
+  inventory: AdoptInventoryItem[];
+  imports: AdoptImportCandidate[];
+  blocked: Array<{ path: string; reasonCode: string }>;
+  expectedOutputChecksums: Record<string, string | null>;
+}
+
+function addBlocked(result: InventoryAccumulator, item: AdoptInventoryItem): void {
+  result.inventory.push(item);
+  result.blocked.push({ path: item.path, reasonCode: item.reasonCode });
+}
+
+function inventoryHarness(
+  adapter: Adapter,
+  record: InstallRecord | null,
+  checksum: string | null,
+  result: InventoryAccumulator,
+): void {
+  const entry = lstatSync(adapter.harness);
+  const reasonCode = entry.isSymbolicLink()
+    ? 'SYMLINK_REJECTED'
+    : 'MANAGED_DISTRIBUTION_NOT_IMPORTABLE';
+  const item: AdoptInventoryItem = {
+    path: adapter.harness,
+    owner: record ? 'harnessmith' : 'unknown',
+    classification: record ? 'conflict-rule' : 'not-importable',
+    reasonCode,
+    proposal: entry.isSymbolicLink() ? 'blocked' : 'backup-and-replace',
+    checksum,
+  };
+  if (entry.isSymbolicLink() || record) addBlocked(result, item);
+  else result.inventory.push(item);
+}
+
+function inventoryPortableRule(
+  output: string,
+  checksum: string | null,
+  result: InventoryAccumulator,
+): void {
+  const rule = readAdoptRule(output);
+  if (!rule.ok) {
+    addBlocked(result, {
+      path: output,
+      owner: 'unknown',
+      classification: 'not-importable',
+      reasonCode: rule.reasonCode,
+      proposal: 'blocked',
+      checksum,
+    });
+    return;
+  }
+  if (/managed-by:\s*harnessmith/i.test(rule.content)) {
+    addBlocked(result, {
+      path: output,
+      owner: 'unknown',
+      classification: 'conflict-rule',
+      reasonCode: 'ORPHANED_MANAGED_RULE',
+      proposal: 'inspect-and-resolve-before-adopt',
+      checksum,
+    });
+    return;
+  }
+  const { frontmatter, body } =
+    extname(output) === '.mdc' ? splitMdc(rule.content) : { frontmatter: null, body: rule.content };
+  if (frontmatter) {
+    result.inventory.push({
+      path: output,
+      owner: 'host',
+      classification: 'host-specific-config',
+      reasonCode: 'HOST_FRONTMATTER_EXCLUDED',
+      proposal: 'preserve-in-backup-only',
+      checksum: adoptHash(frontmatter),
+    });
+  }
+  if (body.trim()) {
+    result.inventory.push({
+      path: output,
+      owner: 'user',
+      classification: 'user-owned-overlay',
+      reasonCode: 'PORTABLE_MARKDOWN_RULES',
+      proposal: 'append-to-personal-overlay',
+      checksum: adoptHash(body),
+    });
+    result.imports.push({ path: output, checksum: rule.checksum, content: body });
+  }
+}
+
+function inventoryOutput(
+  adapter: Adapter,
+  record: InstallRecord | null,
+  output: string,
+  result: InventoryAccumulator,
+): void {
+  const checksum = digestManagedOutput(adapter, output);
+  result.expectedOutputChecksums[output] = checksum;
+  if (!existsSync(output)) {
+    result.inventory.push({
+      path: output,
+      owner: 'unknown',
+      classification: 'managed-compatible',
+      reasonCode: 'DESTINATION_MISSING',
+      proposal: 'create-managed-output',
+      checksum,
+    });
+    return;
+  }
+  if (record?.outputs.find(({ path }) => path === output)?.checksum === checksum) {
+    result.inventory.push({
+      path: output,
+      owner: 'harnessmith',
+      classification: 'managed-compatible',
+      reasonCode: 'RECORDED_CHECKSUM_MATCH',
+      proposal: 'no-change',
+      checksum,
+    });
+    return;
+  }
+  if (output === adapter.harness) {
+    inventoryHarness(adapter, record, checksum, result);
+  } else if (record) {
+    addBlocked(result, {
+      path: output,
+      owner: 'harnessmith',
+      classification: 'conflict-rule',
+      reasonCode: 'MANAGED_RULE_MODIFIED',
+      proposal: 'inspect-and-resolve-before-adopt',
+      checksum,
+    });
+  } else inventoryPortableRule(output, checksum, result);
+}
+
+export function collectAdoptInventory(adapters: Adapter[]): InventoryAccumulator {
+  const result: InventoryAccumulator = {
+    inventory: [],
+    imports: [],
+    blocked: [],
+    expectedOutputChecksums: {},
+  };
+  for (const adapter of adapters) {
+    const outputs = [adapter.harness, ...adapter.instructions.map(({ path }) => path)];
+    const hasSymlink = outputs.some(
+      (output) => existsSync(output) && lstatSync(output).isSymbolicLink(),
+    );
+    const record = hasSymlink ? null : readInstallRecord(adapter);
+    for (const output of outputs) {
+      inventoryOutput(adapter, record, output, result);
+    }
+  }
+  return result;
+}

--- a/src/adopt-secret.ts
+++ b/src/adopt-secret.ts
@@ -1,0 +1,11 @@
+const highConfidenceSecretPatterns = [
+  /-----BEGIN (?:(?:(?:RSA|DSA|EC|OPENSSH|ENCRYPTED) )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----/,
+  /\b(?:AKIA[0-9A-Z]{16}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,})\b/,
+  /\b(?:npm_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_-]{20,}|AIza[A-Za-z0-9_-]{35}|sk_live_[A-Za-z0-9]{20,})\b/,
+  /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/i,
+];
+
+export function containsAdoptSecret(value: string): boolean {
+  return highConfidenceSecretPatterns.some((pattern) => pattern.test(value));
+}

--- a/src/adopt.ts
+++ b/src/adopt.ts
@@ -1,0 +1,178 @@
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  type AdoptImportCandidate,
+  adoptHash,
+  collectAdoptInventory,
+  readAdoptRule,
+} from './adopt-inventory.js';
+import { atomicWrite } from './files.js';
+import { installAll } from './install.js';
+import { installationRenderer, installationValues, templateRoot } from './install-template.js';
+import { assertSafePath } from './safe-path.js';
+import type { Adapter, CliOptions } from './types.js';
+import { HarnessmithError } from './types.js';
+
+function appendBlock(
+  current: string,
+  proposalId: string,
+  candidates: AdoptImportCandidate[],
+): string {
+  const imported = candidates
+    .map(
+      ({ path, checksum, content }) =>
+        `<!-- harnessmith-adopt:start ${proposalId.slice(-12)} -->\n` +
+        `<!-- source: ${path}; sha256:${checksum} -->\n${content.trim()}\n` +
+        '<!-- harnessmith-adopt:end -->',
+    )
+    .join('\n\n');
+  return `${current.trimEnd()}${current.trim() ? '\n\n' : ''}${imported}\n`;
+}
+
+function exactDiff(path: string, before: string, after: string): string {
+  const removed = before
+    ? before
+        .replace(/\n$/, '')
+        .split('\n')
+        .map((line) => `-${line}`)
+    : [];
+  const added = after
+    .replace(/\n$/, '')
+    .split('\n')
+    .map((line) => `+${line}`);
+  return [`--- ${path}`, `+++ ${path}`, ...removed, ...added].join('\n');
+}
+
+function personalTemplate(adapter: Adapter, env: NodeJS.ProcessEnv): string {
+  const render = installationRenderer(adapter, env);
+  return render(
+    readFileSync(join(templateRoot, 'agent-harness', 'templates', 'personal', 'AGENTS.md'), 'utf8'),
+  );
+}
+
+function targetState(adapter: Adapter, env: NodeJS.ProcessEnv) {
+  const values = installationValues(adapter, env);
+  const target = join(values.personalHome, 'AGENTS.md');
+  if (existsSync(target) && lstatSync(target).isSymbolicLink()) {
+    return {
+      target,
+      before: '',
+      expectedAfterInit: '',
+      blocked: { path: target, reasonCode: 'SYMLINK_REJECTED' },
+    };
+  }
+  assertSafePath(values.personalHome, target);
+  if (!existsSync(target)) {
+    return { target, before: '', expectedAfterInit: personalTemplate(adapter, env), blocked: null };
+  }
+  const current = readAdoptRule(target);
+  return current.ok
+    ? { target, before: current.content, expectedAfterInit: current.content, blocked: null }
+    : {
+        target,
+        before: '',
+        expectedAfterInit: '',
+        blocked: { path: target, reasonCode: current.reasonCode },
+      };
+}
+
+export function createAdoptPlan(adapters: Adapter[], env: NodeJS.ProcessEnv) {
+  const collected = collectAdoptInventory(adapters);
+  const target = targetState(adapters[0], env);
+  const blocked = [...collected.blocked, ...(target.blocked ? [target.blocked] : [])];
+  const seed = JSON.stringify({
+    adapters: adapters.map(({ name }) => name),
+    inventory: collected.inventory,
+    target: target.target,
+    targetBeforeChecksum: target.before ? adoptHash(target.before) : null,
+  });
+  const proposalHash = adoptHash(seed);
+  const proposalId = `sha256:${proposalHash}`;
+  const finalContent = collected.imports.length
+    ? appendBlock(target.expectedAfterInit, proposalId, collected.imports)
+    : target.expectedAfterInit;
+  const stamp = `adopt-${proposalHash.slice(0, 12)}`;
+  const backups = Object.entries(collected.expectedOutputChecksums)
+    .filter(([, checksum]) => checksum !== null)
+    .map(([source]) => ({ source, path: `${source}.backup-${stamp}` }));
+  const requiresWrite =
+    blocked.length === 0 &&
+    collected.inventory.some(({ proposal }) =>
+      ['append-to-personal-overlay', 'backup-and-replace'].includes(proposal),
+    );
+  const report = {
+    version: 1,
+    command: 'adopt' as const,
+    phase: 'proposal' as const,
+    proposalId,
+    requiresConfirmation: requiresWrite,
+    requiresWrite,
+    blocked,
+    inventory: collected.inventory,
+    target: { path: target.target, owner: 'user-owned-personal-overlay' as const },
+    diff: requiresWrite ? exactDiff(target.target, target.before, finalContent) : null,
+    backups,
+    rollbackPaths: [
+      ...Object.keys(collected.expectedOutputChecksums),
+      target.target,
+      ...backups.map(({ path }) => path),
+    ],
+  };
+  return {
+    report,
+    internal: {
+      expectedOutputChecksums: collected.expectedOutputChecksums,
+      target: target.target,
+      targetExpectedAfterInit: target.expectedAfterInit,
+      finalContent,
+      stamp,
+    },
+  };
+}
+
+export function applyAdoptPlan(
+  adapters: Adapter[],
+  env: NodeJS.ProcessEnv,
+  options: Pick<CliOptions, 'proposal' | 'initGlobal'>,
+) {
+  const plan = createAdoptPlan(adapters, env);
+  if (plan.report.blocked.length > 0) {
+    throw new HarnessmithError('SAFETY_CONFLICT', 'Adopt proposal is blocked', 3);
+  }
+  if (options.proposal !== plan.report.proposalId) {
+    throw new HarnessmithError(
+      'STATE_CONFLICT',
+      'Adopt proposal changed or was not confirmed; run adopt preview again',
+      3,
+    );
+  }
+  if (!plan.report.requiresWrite) {
+    return { ...plan.report, phase: 'complete' as const, result: 'already-adopted' as const };
+  }
+  const installation = installAll(adapters, {
+    env,
+    force: true,
+    noInitGlobal: options.initGlobal === false,
+    stamp: plan.internal.stamp,
+    expectedOutputChecksums: plan.internal.expectedOutputChecksums,
+    afterUserDataInitialize: () => {
+      const current = readAdoptRule(plan.internal.target);
+      if (!current.ok || current.content !== plan.internal.targetExpectedAfterInit) {
+        throw new HarnessmithError(
+          'STATE_CONFLICT',
+          'Personal overlay changed after proposal; adopt stopped before import',
+          3,
+        );
+      }
+      atomicWrite(plan.internal.target, plan.internal.finalContent);
+    },
+  });
+  return {
+    ...plan.report,
+    phase: 'complete' as const,
+    result: 'adopted' as const,
+    installation,
+  };
+}
+
+export type AdoptReport = ReturnType<typeof createAdoptPlan>['report'];

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from 'node:stream';
 import { adapterCapabilities, createAdapter } from './adapters.js';
+import { executeAdopt } from './adopt-command.js';
 import { normalizeAgents } from './agents.js';
 import { installAll } from './install.js';
 import { inspectStatusAll, restoreAll, statusAll, uninstallAll } from './lifecycle.js';
@@ -92,7 +93,7 @@ function previewLifecycle(
 }
 
 function executeLifecycle(
-  command: Exclude<HarnessmithCommand, 'setup' | 'install' | 'capabilities'>,
+  command: Exclude<HarnessmithCommand, 'setup' | 'adopt' | 'install' | 'capabilities'>,
   adapters: Adapter[],
   options: CliOptions,
   context: ExecuteContext,
@@ -237,6 +238,7 @@ export async function executeCommand(
     throw error;
   }
   if (command === 'setup') return executeSetup(adapters, options, context, interactive);
+  if (command === 'adopt') return executeAdopt(adapters, options, context, interactive);
   return command === 'install'
     ? executeInstall(adapters, options, context, interactive)
     : executeLifecycle(command, adapters, options, context, interactive);

--- a/src/install.ts
+++ b/src/install.ts
@@ -40,11 +40,26 @@ function assertInstallable(adapter: Adapter, force: boolean): void {
   }
 }
 
-export function prepareInstall(
+function assertExpectedOutputs(
   adapter: Adapter,
-  { env = process.env, force = false }: InstallOptions = {},
-): PreparedInstall {
+  expected: Record<string, string | null> | undefined,
+): void {
+  if (!expected) return;
+  for (const path of [adapter.harness, ...adapter.instructions.map(({ path }) => path)]) {
+    if (!(path in expected) || digestManagedOutput(adapter, path) !== expected[path]) {
+      throw new HarnessmithError(
+        'STATE_CONFLICT',
+        `Adopt proposal changed before installation: ${path}`,
+        3,
+      );
+    }
+  }
+}
+
+export function prepareInstall(adapter: Adapter, options: InstallOptions = {}): PreparedInstall {
+  const { env = process.env, force = false } = options;
   assertSafeAdapterPaths(adapter);
+  assertExpectedOutputs(adapter, options.expectedOutputChecksums);
   assertInstallable(adapter, force);
   mkdirSync(adapter.home, { recursive: true });
   assertSafeAdapterPaths(adapter);
@@ -183,12 +198,13 @@ export function installAll(adapters: Adapter[], options: InstallOptions = {}): I
     const prepared: PreparedInstall[] = [];
     try {
       for (const adapter of adapters) prepared.push(prepareInstall(adapter, options));
-      const stamp = timestamp();
+      const stamp = options.stamp || timestamp();
       for (const item of prepared) commitInstall(item, stamp);
       const initialization =
         prepared.length > 0
           ? initializeUserData(prepared[0], options.env || process.env, {
               global: !options.noInitGlobal,
+              afterInitialize: options.afterUserDataInitialize,
             })
           : '';
       return prepared.map(({ adapter, backups }) => ({

--- a/src/program.ts
+++ b/src/program.ts
@@ -7,6 +7,7 @@ import type { CliOptions } from './types.js';
 
 export type HarnessmithCommand =
   | 'setup'
+  | 'adopt'
   | 'install'
   | 'status'
   | 'restore'
@@ -63,6 +64,12 @@ export function createProgram(
     .command('setup')
     .description('preview, confirm, install, and verify a first Harness');
   setup.action(() => execute('setup', setup.optsWithGlobals<CliOptions>()));
+
+  const adopt = program
+    .command('adopt')
+    .description('inventory and safely adopt existing Host rules')
+    .option('--proposal <id>', 'confirm the exact proposal id from a prior preview');
+  adopt.action(() => execute('adopt', adopt.optsWithGlobals<CliOptions>()));
 
   const install = program.command('install').description('install or upgrade the harness');
   install.action(() => execute('install', install.optsWithGlobals<CliOptions>()));

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,9 @@ export interface InstallOptions {
   env?: NodeJS.ProcessEnv;
   force?: boolean;
   noInitGlobal?: boolean;
+  stamp?: string;
+  expectedOutputChecksums?: Record<string, string | null>;
+  afterUserDataInitialize?: () => void;
 }
 
 export interface InstallResult extends InstallPlan {
@@ -156,6 +159,7 @@ export interface CliOptions {
   dryRun?: boolean;
   initGlobal?: boolean;
   explain?: boolean;
+  proposal?: string;
 }
 
 export interface RunContext {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from 'node:stream';
 import { confirm, intro, isCancel, log, multiselect, note, outro } from '@clack/prompts';
 import pc from 'picocolors';
+import type { AdoptReport } from './adopt.js';
 import { supportedAgents } from './agents.js';
 import type { SetupGuide, SetupVerification } from './setup.js';
 import type { StatusExplanation } from './status-explanation.js';
@@ -80,6 +81,22 @@ export async function confirmSetup({
   return isCancel(value) ? false : value;
 }
 
+export async function confirmAdopt(
+  report: AdoptReport,
+  {
+    input = process.stdin,
+    output = process.stdout,
+  }: { input?: PromptInput; output?: PromptOutput } = {},
+): Promise<boolean> {
+  const value = await confirm({
+    message: `Apply proposal ${report.proposalId} with ${report.backups.length} exact backup target(s)?`,
+    initialValue: false,
+    input,
+    output,
+  });
+  return isCancel(value) ? false : value;
+}
+
 export function startInteractive(output: PromptOutput): void {
   intro(pc.bgCyan(pc.black(' Harnessmith ')), { output });
 }
@@ -110,6 +127,15 @@ export function printSetupGuide(guide: SetupGuide, io: Io = console): void {
   for (const boundary of guide.willNotChange) io.log(`    - ${boundary}`);
   io.log(`  recovery preview  ${guide.recovery.restore}`);
   io.log(`  real Host behavior  ${guide.hostBehavior.status}`);
+}
+
+export function printAdoptPlan(report: AdoptReport, io: Io = console): void {
+  io.log(`Adopt proposal ${report.proposalId}`);
+  for (const item of report.inventory) {
+    io.log(`  ${item.classification}  ${item.path}  ${item.reasonCode}`);
+  }
+  if (report.diff) io.log(report.diff);
+  for (const backup of report.backups) io.log(`  backup  ${backup.source} -> ${backup.path}`);
 }
 
 export function printSetupVerification(verification: SetupVerification, io: Io = console): void {

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -9,7 +9,7 @@ import { withUserDataCoordinationLocks } from './user-data-lock.js';
 export function initializeUserData(
   prepared: PreparedInstall,
   env: NodeJS.ProcessEnv,
-  { global }: { global: boolean },
+  { global, afterInitialize }: { global: boolean; afterInitialize?: () => void },
 ): string {
   const values = installationValues(prepared.adapter, env);
   const memoryFiles = global
@@ -59,6 +59,7 @@ export function initializeUserData(
           ).stdout.trim(),
         );
       }
+      afterInitialize?.();
       return output.filter(Boolean).join('\n');
     } catch (error) {
       restoreSnapshots(snapshots);


### PR DESCRIPTION
## Summary / 变更说明

- Add a read-only adopt inventory that classifies managed-compatible, user-owned, Host-specific, conflicting, and non-importable content.
- Bind every write to an exact proposal id, preserve portable rules in the personal overlay with provenance, and fail closed on secrets, symlinks, unknown formats, and changed content.
- Reuse the existing preflight, Adapter locks, deterministic backups, user-data locks, and transaction rollback for confirmed global and project-scoped adoption.

## Related Issue / 关联 Issue

Closes #106

## Verification / 验证

- pnpm run preflight — 755 checks; 144 files, 986 passed, 3 skipped.
- pnpm run test:coverage — unit and script coverage gates passed.
- npm pack --dry-run --ignore-scripts — passed; 87 files.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated dist files or include secrets, personal memory, or private paths. / 未修改生成的 dist 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

Host-specific frontmatter remains backup-only, and real Host behavior remains outside deterministic installation evidence.
