### PR TITLE
feat: add redacted diagnostics preview

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,9 @@ npx harnessmith uninstall --agent codex
 # Inspect machine-readable Adapter boundaries
 npx harnessmith capabilities --json
 
+# Preview a local redacted diagnostics report; the command neither uploads nor persists it
+npx harnessmith diagnostics --agent codex --json
+
 # Check cross-repository relationships in your personal Repository Map
 node <harness-path>/bin/harness.mjs repository-map check --json
 
@@ -108,12 +111,12 @@ fails closed when the index is unavailable, while `--mode scan` forces scanning.
 
 | State | Harnessmith's contract |
 | --- | --- |
-| Implemented | Adapter distribution, preflight, backups, locks, rollback, non-authoritative Memory, Task gates, and a privacy-safe `audit record` |
+| Implemented | Adapter distribution, preflight, backups, locks, rollback, non-authoritative Memory, Task gates, a privacy-safe `audit record`, and redacted diagnostics previews |
 | Delegated to the Host | Model loops, tool/MCP scheduling, sandboxing, approvals, tokens, and cost |
 | Unsupported | A universal Runtime, Policy Engine, Pack/Registry, multi-agent orchestration, and automatic rule promotion |
 
-Markdown instructions are guidance, not permission enforcement. The audit schema rejects raw prompt content, model output,
-and tool arguments; event authenticity still belongs to the host or external attestation. See
+Markdown instructions are guidance, not permission enforcement. The audit and diagnostics schemas reject raw prompt content,
+model output, tool arguments, file bodies, environment variables, and secrets; event authenticity still belongs to the host or external attestation. See
 [docs/capability-evidence.yaml](./docs/capability-evidence.yaml) for per-capability owners, states, and evidence.
 
 ## Learn more

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ npx harnessmith uninstall --agent codex
 # 查看 Adapter 的机器可读边界
 npx harnessmith capabilities --json
 
+# 预览本地脱敏诊断报告；命令不上传或持久化报告
+npx harnessmith diagnostics --agent codex --json
+
 # 检查个人 Repository Map 中的跨仓库关系
 node <harness-path>/bin/harness.mjs repository-map check --json
 
@@ -105,12 +108,12 @@ node <harness-path>/bin/harness.mjs health --json
 
 | 状态 | Harnessmith 的承诺 |
 | --- | --- |
-| 已实现（Implemented） | Adapter 分发、预检、备份、锁、回滚、非权威 Memory、Task gate 与隐私安全的 `audit record` |
+| 已实现（Implemented） | Adapter 分发、预检、备份、锁、回滚、非权威 Memory、Task gate、隐私安全的 `audit record` 与脱敏诊断预览 |
 | 由宿主负责（Delegated to the Host） | 模型循环、工具/MCP 调度、sandbox、权限批准、token 与成本 |
 | 不支持（Unsupported） | 通用 Runtime、Policy Engine、Pack/Registry、多 Agent 调度和自动规则提升 |
 
-Markdown 规则是行为指导，不是权限强制。审计 schema 拒绝原始 prompt、模型输出和 tool arguments；事件真实性仍由
-宿主或外部 attestation 保证。逐项 owner、状态与证据路径见
+Markdown 规则是行为指导，不是权限强制。审计与诊断 schema 拒绝原始 prompt、模型输出、tool arguments、文件正文、
+环境变量和 secret；事件真实性仍由宿主或外部 attestation 保证。逐项 owner、状态与证据路径见
 [docs/capability-evidence.yaml](./docs/capability-evidence.yaml)。
 
 ## 深入了解

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,9 @@ reproduction without secrets or personal memory content.
 - Install, status, restore, and uninstall serialize each Adapter through a cross-process operation lock. Do
   not delete a live lock to force progress.
 - Backups and installation records remain local.
+- `diagnostics` emits only schema-allowlisted metadata to stdout. It does not persist or upload reports, and it
+  excludes raw prompts, model output, tool arguments, file bodies, environment variables, secrets, local paths,
+  and user identifiers. Review the preview before sharing it.
 - Uninstall does not delete shared or project `.agent-docs` memory.
 - A future custom-template feature must treat templates as executable trusted input because installed
   Harness JavaScript can run with the user's permissions.

--- a/diagnostics/report.schema.json
+++ b/diagnostics/report.schema.json
@@ -1,0 +1,374 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:harnessmith:schema:diagnostics-report:v1",
+  "title": "Harnessmith redacted diagnostics report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "command",
+    "collectionResult",
+    "privacy",
+    "budget",
+    "package",
+    "adapters",
+    "failures",
+    "verification"
+  ],
+  "properties": {
+    "version": {
+      "const": 1,
+      "x-owner": "harnessmith",
+      "x-purpose": "identify the report schema",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "command": {
+      "const": "diagnostics",
+      "x-owner": "harnessmith",
+      "x-purpose": "identify the producing command",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "collectionResult": {
+      "enum": ["complete", "partial", "inconclusive"],
+      "x-owner": "harnessmith diagnostics collector",
+      "x-purpose": "preserve aggregate collection outcome",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "privacy": {
+      "$ref": "#/$defs/privacy",
+      "x-owner": "harnessmith diagnostics collector",
+      "x-purpose": "state upload and persistence behavior",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "budget": {
+      "$ref": "#/$defs/budget",
+      "x-owner": "harnessmith diagnostics collector",
+      "x-purpose": "expose bounded collection limits",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "package": {
+      "$ref": "#/$defs/package",
+      "x-owner": "harnessmith package",
+      "x-purpose": "identify the reporting implementation version",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "adapters": {
+      "type": "array",
+      "maxItems": 5,
+      "items": { "$ref": "#/$defs/adapter" },
+      "x-owner": "outer installer adapters",
+      "x-purpose": "summarize bounded Host-specific evidence",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "failures": {
+      "type": "array",
+      "maxItems": 20,
+      "items": { "$ref": "#/$defs/failure" },
+      "x-owner": "harnessmith diagnostics collector",
+      "x-purpose": "preserve partial collection failures",
+      "x-retention": "user-controlled ephemeral output"
+    },
+    "verification": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": { "type": "string", "maxLength": 256 },
+      "x-owner": "harnesssmith maintainers",
+      "x-purpose": "provide path-redacted reproduction commands",
+      "x-retention": "user-controlled ephemeral output"
+    }
+  },
+  "$defs": {
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uploaded", "persisted", "previewOnly"],
+      "properties": {
+        "uploaded": {
+          "const": false,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "declare that the command performs no upload",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "persisted": {
+          "const": false,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "declare that the command writes no bundle",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "previewOnly": {
+          "const": true,
+          "x-owner": "user",
+          "x-purpose": "require review before any external sharing",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["maxAdapters", "maxCommandBytes", "timeoutMs", "truncated"],
+      "properties": {
+        "maxAdapters": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "bound Adapter fanout",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "maxCommandBytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 262144,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "bound subprocess output reads",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "bound each subprocess duration",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "truncated": {
+          "type": "boolean",
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "distinguish incomplete collection from absence",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+",
+          "x-owner": "harnessmith package",
+          "x-purpose": "correlate diagnostics with implementation version",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "instructionFormat", "nativeRuleActivation"],
+      "properties": {
+        "scope": {
+          "enum": ["global", "project"],
+          "x-owner": "outer installer Adapter",
+          "x-purpose": "identify destination scope without a path",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "instructionFormat": {
+          "enum": ["markdown", "mdc"],
+          "x-owner": "outer installer Adapter",
+          "x-purpose": "identify the instruction contract",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "nativeRuleActivation": {
+          "enum": ["host-default", "always"],
+          "x-owner": "Host Adapter contract",
+          "x-purpose": "identify Host activation ownership",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "outputCounts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["managed", "modified", "missing", "unmanaged"],
+      "properties": {
+        "managed": {
+          "type": "integer",
+          "minimum": 0,
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "count checksum-matching outputs",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "modified": {
+          "type": "integer",
+          "minimum": 0,
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "count checksum-mismatched outputs",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "missing": {
+          "type": "integer",
+          "minimum": 0,
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "count absent outputs",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "unmanaged": {
+          "type": "integer",
+          "minimum": 0,
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "count outputs without ownership evidence",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "installation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasonCode", "outputCounts"],
+      "properties": {
+        "status": {
+          "enum": ["managed", "modified", "partial", "unmanaged", "missing", "inconclusive"],
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "summarize installation ownership",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "reasonCode": {
+          "type": "string",
+          "pattern": "^[A-Z0-9_]+$",
+          "maxLength": 96,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "provide a stable non-content failure class",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "outputCounts": {
+          "$ref": "#/$defs/outputCounts",
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "report aggregate output states without paths",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "runtimeCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status"],
+      "properties": {
+        "id": {
+          "enum": ["runtime", "installation", "global-memory", "project-memory", "audit"],
+          "x-owner": "embedded Harness runtime",
+          "x-purpose": "identify an allowlisted health check",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "status": {
+          "enum": ["passed", "warning", "failed"],
+          "x-owner": "embedded Harness runtime",
+          "x-purpose": "report health without raw messages or details",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "subsystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "reasonCode", "artifactDigest"],
+      "properties": {
+        "id": {
+          "enum": ["memory", "task", "routing", "host"],
+          "x-owner": "Harness or Host boundary",
+          "x-purpose": "identify the diagnosed subsystem",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "status": {
+          "enum": ["passed", "warning", "failed", "inconclusive"],
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "preserve subsystem outcome semantics",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "reasonCode": {
+          "type": "string",
+          "pattern": "^[A-Z0-9_]+$",
+          "maxLength": 96,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "provide a stable non-content classification",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "artifactDigest": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "correlate evidence without retaining raw output",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter", "capability", "installation", "runtimeChecks", "subsystems"],
+      "properties": {
+        "adapter": {
+          "enum": ["codex", "cursor", "claude", "opencode", "kimi"],
+          "x-owner": "outer installer Adapter",
+          "x-purpose": "identify the Host contract without user identifiers",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "capability": {
+          "$ref": "#/$defs/capability",
+          "x-owner": "outer installer Adapter",
+          "x-purpose": "report stable Adapter boundaries",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "installation": {
+          "$ref": "#/$defs/installation",
+          "x-owner": "outer installer lifecycle",
+          "x-purpose": "report redacted installation status",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "runtimeChecks": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/$defs/runtimeCheck" },
+          "x-owner": "embedded Harness runtime",
+          "x-purpose": "report allowlisted health statuses only",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "subsystems": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "$ref": "#/$defs/subsystem" },
+          "x-owner": "Harness and Host boundary owners",
+          "x-purpose": "summarize Memory, Task, routing, and Host evidence",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter", "source", "errorCode", "result"],
+      "properties": {
+        "adapter": {
+          "enum": ["codex", "cursor", "claude", "opencode", "kimi"],
+          "x-owner": "outer installer Adapter",
+          "x-purpose": "attribute collection failure without a path",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "source": {
+          "enum": ["installation", "health", "task", "routing"],
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "identify the failed collection stage",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "errorCode": {
+          "type": "string",
+          "pattern": "^[A-Z0-9_]+$",
+          "maxLength": 96,
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "report a stable classification without raw errors",
+          "x-retention": "user-controlled ephemeral output"
+        },
+        "result": {
+          "const": "inconclusive",
+          "x-owner": "harnessmith diagnostics collector",
+          "x-purpose": "prevent a failed collection from appearing successful",
+          "x-retention": "user-controlled ephemeral output"
+        }
+      }
+    }
+  }
+}

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -161,6 +161,20 @@ claims:
     verification:
       - template/agent-harness/src/__tests__/audit.test.ts
 
+  - id: privacy-safe-diagnostics-preview
+    status: implemented
+    owner: outer diagnostics collector
+    claim: Preview bounded, schema-allowlisted installation and embedded Runtime diagnostics without persisting or uploading raw content, secrets, local paths, environment variables, or user identifiers, while preserving partial failures and Host-dependent conclusions.
+    implementation:
+      - src/diagnostics.ts
+      - src/diagnostics-runtime.ts
+      - src/diagnostics-process.ts
+      - src/diagnostics-command.ts
+      - diagnostics/report.schema.json
+    verification:
+      - src/__tests__/diagnostics.test.ts
+      - src/__tests__/args.test.ts
+
   - id: candidate-bound-host-eval-gate
     status: implemented
     owner: release verification scripts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ owner: maintainers
 | `restore` | 恢复上一安装层 | 是 |
 | `uninstall` | 恢复全部安装层并移除记录 | 是 |
 | `capabilities` | 输出 Adapter 范围、激活和权限边界 | 否 |
+| `diagnostics` | 预览本地脱敏诊断报告 | 否 |
 
 ## 通用选项
 
@@ -88,6 +89,19 @@ npx harnessmith status --agent codex --explain --json
 
 建议动作只作为下一步展示，带有 `automatic: false`、`destructive: false` 和授权要求，不会由 `status` 自动执行。
 
+## 脱敏诊断 `diagnostics`
+
+```bash
+npx harnessmith diagnostics --agent codex --json
+```
+
+报告只包含 allowlist 中的版本、Adapter capability、状态码、计数、SHA-256 摘要、采集预算、失败分类和复核命令。
+原始 prompt、模型输出、tool arguments、文件正文、环境变量、secret、用户标识符和本地路径不能进入报告；未知字段由
+schema 拒绝。命令只将报告预览到 stdout，不写文件也不上传，分享前由用户审阅。
+
+每个子命令最多读取 256 KiB，最长运行 10 秒。超限、超时、无输出和无效 JSON 都保留为稳定失败分类；一个采集步骤
+成功不会覆盖此前失败。未初始化的项目 Memory 和未执行的真实 Host 行为明确标为 `inconclusive`。
+
 ## 示例
 
 ```bash
@@ -109,6 +123,7 @@ npx harnessmith status --agent codex --json
 npx harnessmith status --agent codex --explain --json
 npx harnessmith adopt --agent codex --json
 npx harnessmith capabilities --json
+npx harnessmith diagnostics --agent codex --json
 
 # 回退生命周期
 npx harnessmith restore --agent codex

--- a/llms.txt
+++ b/llms.txt
@@ -151,6 +151,9 @@ the project-root `.gitignore` or `.ignore`.
 - Use `status --explain --json` when ownership alone is insufficient. Preserve `observedState`, `reasonCode`, evidence,
   and action codes. Suggested actions have `automatic: false`; do not execute restore, takeover, or Host changes without
   the user's authorization. Host configuration and real behavior remain `inconclusive` until Host evidence exists.
+- Use `diagnostics --agent <agents> --json` to preview bounded, allowlisted troubleshooting metadata. The command writes
+  only to stdout, never uploads or persists a report, and intentionally excludes raw content, local paths, environment
+  variables, secrets, and user identifiers. Preserve partial and inconclusive classifications when sharing a preview.
 - Lifecycle commands attempt rollback along recorded paths. If rollback is incomplete, preserve stderr and every
   recovery path, report the installation as blocked, and do not claim the previous state was restored.
 - Upgrade by rerunning `npx --yes harnessmith`; use the outer CLI for status, restore, and uninstall:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "template/agent-harness/manifest.json",
     "template/agent-harness/schemas",
     "template/agent-harness/templates",
+    "diagnostics/report.schema.json",
     "evals/scenarios.json",
     "evals/scenarios.schema.json",
     "evals/host-capability-matrix.v1.json",

--- a/src/__tests__/args.test.ts
+++ b/src/__tests__/args.test.ts
@@ -96,6 +96,17 @@ test('Commander exposes proposal-bound adopt options', async () => {
   assert.equal(result.yes, true);
 });
 
+test('Commander exposes read-only diagnostics reports', async () => {
+  let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
+  const program = createProgram(async (command, options) => {
+    result = { command, ...options };
+  });
+  await program.parseAsync(['diagnostics', '--agent', 'codex', '--json'], { from: 'user' });
+  assert.ok(result);
+  assert.equal(result.command, 'diagnostics');
+  assert.equal(result.json, true);
+});
+
 test('Commander exposes adapter capabilities as a read-only command', async () => {
   let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
   const program = createProgram(async (command, options) => {

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter } from '../adapters.js';
+import { executeCommand } from '../command-executor.js';
+import { createDiagnosticsReport } from '../diagnostics.js';
+import { installAll } from '../install.js';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const schema = JSON.parse(
+  readFileSync(join(packageRoot, 'diagnostics', 'report.schema.json'), 'utf8'),
+);
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const env = {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, '用户-codex'),
+    CLAUDE_CONFIG_DIR: join(root, 'claude-home'),
+    HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+    HARNESS_REPOSITORY_ROOT: root,
+    HARNESS_OWNER: '诊断用户',
+  };
+  return { root, env };
+}
+
+test('diagnostics returns only allowlisted metadata and never leaks paths or raw content', () => {
+  const { root, env } = fixture('harnessmith-diagnostics-private-');
+  const adapter = createAdapter('codex', { env });
+  const secret = ['ghp', '_', 'D'.repeat(24)].join('');
+  mkdirSync(dirname(adapter.record), { recursive: true });
+  writeFileSync(
+    adapter.record,
+    JSON.stringify({ prompt: `do not leak ${secret}`, toolArguments: [root], environment: env }),
+  );
+  mkdirSync(dirname(adapter.instructions[0].path), { recursive: true });
+  writeFileSync(adapter.instructions[0].path, `# 私有规则\n${secret}\n`);
+
+  const before = readFileSync(adapter.record, 'utf8');
+  const report = createDiagnosticsReport([adapter], { env, project: root });
+  const serialized = JSON.stringify(report);
+
+  assert.equal(report.collectionResult, 'partial');
+  assert.ok(report.failures.some(({ source }) => source === 'installation'));
+  assert.doesNotMatch(serialized, new RegExp(secret));
+  assert.doesNotMatch(serialized, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.doesNotMatch(serialized, /私有规则|诊断用户|prompt|toolArguments|environment/);
+  assert.equal(readFileSync(adapter.record, 'utf8'), before);
+  assert.equal(report.privacy.uploaded, false);
+  assert.equal(report.privacy.persisted, false);
+});
+
+test('diagnostics summarizes healthy installed runtime checks without returning their messages', () => {
+  const { root, env } = fixture('harnessmith-diagnostics-installed-');
+  const adapter = createAdapter('codex', { env });
+  installAll([adapter], { env, noInitGlobal: false });
+
+  const report = createDiagnosticsReport([adapter], { env, project: root });
+  const item = report.adapters[0];
+  assert.equal(report.collectionResult, 'complete');
+  assert.equal(item.installation.status, 'managed');
+  assert.ok(item.runtimeChecks.some(({ id }) => id === 'installation'));
+  assert.ok(item.subsystems.some(({ id }) => id === 'memory'));
+  assert.ok(item.subsystems.some(({ id }) => id === 'task'));
+  assert.ok(item.subsystems.some(({ id }) => id === 'routing'));
+  assert.ok(item.subsystems.some(({ id, status }) => id === 'host' && status === 'inconclusive'));
+  assert.doesNotMatch(
+    JSON.stringify(report),
+    new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+  );
+});
+
+test('a failed adapter remains visible when another adapter is collected successfully', () => {
+  const { root, env } = fixture('harnessmith-diagnostics-partial-');
+  const codex = createAdapter('codex', { env });
+  const claude = createAdapter('claude', { env });
+  mkdirSync(dirname(codex.record), { recursive: true });
+  writeFileSync(codex.record, '{invalid');
+
+  const report = createDiagnosticsReport([codex, claude], { env, project: root });
+  assert.equal(report.adapters.length, 2);
+  assert.equal(report.collectionResult, 'partial');
+  assert.equal(report.failures.length, 1);
+  assert.equal(report.failures[0].adapter, 'codex');
+  assert.equal(report.adapters[1].adapter, 'claude');
+});
+
+test('diagnostics command previews JSON without persisting a report', async () => {
+  const { root, env } = fixture('harnessmith-diagnostics-command-');
+  const logs: string[] = [];
+  const status = await executeCommand(
+    'diagnostics',
+    { agent: ['codex'], project: root, json: true },
+    {
+      env,
+      io: { log: (value) => logs.push(String(value)) },
+      input: new PassThrough(),
+      output: new PassThrough(),
+    },
+  );
+
+  assert.equal(status, 0);
+  assert.equal(logs.length, 1);
+  assert.equal(JSON.parse(logs[0]).command, 'diagnostics');
+  assert.equal(existsSync(join(root, 'diagnostics.json')), false);
+});
+
+test('diagnostics schema rejects unknown fields and documents owner, purpose, and retention', () => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const { root, env } = fixture('harnessmith-diagnostics-schema-');
+  const report = createDiagnosticsReport([createAdapter('codex', { env })], { env, project: root });
+  assert.equal(ajv.validate(schema, report), true, JSON.stringify(ajv.errors));
+  assert.equal(ajv.validate(schema, { ...report, rawPrompt: 'forbidden' }), false);
+
+  function assertMetadata(node: unknown): void {
+    if (!node || typeof node !== 'object') return;
+    const candidate = node as Record<string, unknown>;
+    if (candidate.properties && typeof candidate.properties === 'object') {
+      for (const value of Object.values(candidate.properties as Record<string, unknown>)) {
+        const field = value as Record<string, unknown>;
+        assert.equal(typeof field['x-owner'], 'string');
+        assert.equal(typeof field['x-purpose'], 'string');
+        assert.equal(typeof field['x-retention'], 'string');
+        assertMetadata(field);
+      }
+    }
+    if (candidate.items) assertMetadata(candidate.items);
+    if (candidate.$defs && typeof candidate.$defs === 'object') {
+      for (const value of Object.values(candidate.$defs as Record<string, unknown>))
+        assertMetadata(value);
+    }
+  }
+  assertMetadata(schema);
+  assert.equal(existsSync(join(root, 'diagnostics.json')), false);
+});

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -2,6 +2,7 @@ import type { Readable, Writable } from 'node:stream';
 import { adapterCapabilities, createAdapter } from './adapters.js';
 import { executeAdopt } from './adopt-command.js';
 import { normalizeAgents } from './agents.js';
+import { executeDiagnostics } from './diagnostics-command.js';
 import { installAll } from './install.js';
 import { inspectStatusAll, restoreAll, statusAll, uninstallAll } from './lifecycle.js';
 import { describeLifecycle } from './lifecycle-plan.js';
@@ -93,7 +94,10 @@ function previewLifecycle(
 }
 
 function executeLifecycle(
-  command: Exclude<HarnessmithCommand, 'setup' | 'adopt' | 'install' | 'capabilities'>,
+  command: Exclude<
+    HarnessmithCommand,
+    'setup' | 'adopt' | 'diagnostics' | 'install' | 'capabilities'
+  >,
   adapters: Adapter[],
   options: CliOptions,
   context: ExecuteContext,
@@ -239,6 +243,7 @@ export async function executeCommand(
   }
   if (command === 'setup') return executeSetup(adapters, options, context, interactive);
   if (command === 'adopt') return executeAdopt(adapters, options, context, interactive);
+  if (command === 'diagnostics') return executeDiagnostics(adapters, options, context);
   return command === 'install'
     ? executeInstall(adapters, options, context, interactive)
     : executeLifecycle(command, adapters, options, context, interactive);

--- a/src/diagnostics-command.ts
+++ b/src/diagnostics-command.ts
@@ -1,0 +1,22 @@
+import { createDiagnosticsReport } from './diagnostics.js';
+import type { Adapter, CliOptions, Io } from './types.js';
+
+export function executeDiagnostics(
+  adapters: Adapter[],
+  options: CliOptions,
+  { env, io }: { env: NodeJS.ProcessEnv; io: Io },
+): number {
+  const report = createDiagnosticsReport(adapters, { env, project: options.project });
+  if (options.json) io.log(JSON.stringify(report));
+  else {
+    io.log(`Diagnostics collection: ${report.collectionResult}`);
+    io.log('No report was uploaded or persisted by Harnessmith.');
+    for (const adapter of report.adapters) {
+      io.log(`  ${adapter.adapter}  installation=${adapter.installation.status}`);
+      for (const subsystem of adapter.subsystems) {
+        io.log(`    ${subsystem.id}  ${subsystem.status}  ${subsystem.reasonCode}`);
+      }
+    }
+  }
+  return report.collectionResult === 'complete' ? 0 : 1;
+}

--- a/src/diagnostics-process.ts
+++ b/src/diagnostics-process.ts
@@ -1,0 +1,72 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import type { Adapter } from './types.js';
+
+export const diagnosticsMaxCommandBytes = 256 * 1024;
+export const diagnosticsCommandTimeoutMs = 10_000;
+
+export interface DiagnosticCommandResult {
+  status: 'collected' | 'inconclusive';
+  reasonCode: string;
+  digest: string | null;
+  value: unknown;
+  truncated: boolean;
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+export function runDiagnosticJson(
+  adapter: Adapter,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  project: string,
+): DiagnosticCommandResult {
+  const result = spawnSync(
+    process.execPath,
+    [join(adapter.harness, 'bin', 'harness.mjs'), ...args],
+    {
+      cwd: project,
+      env,
+      encoding: 'utf8',
+      timeout: diagnosticsCommandTimeoutMs,
+      maxBuffer: diagnosticsMaxCommandBytes,
+      windowsHide: true,
+    },
+  );
+  const output = result.stdout || '';
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  const truncated = errorCode === 'ENOBUFS';
+  if (result.error || !output.trim()) {
+    return {
+      status: 'inconclusive',
+      reasonCode: truncated
+        ? 'COLLECTION_BUDGET_EXCEEDED'
+        : errorCode === 'ETIMEDOUT'
+          ? 'COLLECTION_TIMEOUT'
+          : 'COMMAND_OUTPUT_UNAVAILABLE',
+      digest: output ? digest(output) : null,
+      value: null,
+      truncated,
+    };
+  }
+  try {
+    return {
+      status: 'collected',
+      reasonCode: result.status === 0 ? 'COMMAND_COMPLETED' : 'COMMAND_REPORTED_FAILURE',
+      digest: digest(output),
+      value: JSON.parse(output),
+      truncated,
+    };
+  } catch {
+    return {
+      status: 'inconclusive',
+      reasonCode: 'INVALID_JSON_OUTPUT',
+      digest: digest(output),
+      value: null,
+      truncated,
+    };
+  }
+}

--- a/src/diagnostics-runtime.ts
+++ b/src/diagnostics-runtime.ts
@@ -1,0 +1,220 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  type DiagnosticCommandResult,
+  diagnosticsCommandTimeoutMs,
+  diagnosticsMaxCommandBytes,
+  runDiagnosticJson,
+} from './diagnostics-process.js';
+import { inspectStatusAll } from './status-inspection.js';
+import type { Adapter, AdapterStatusInspection } from './types.js';
+import { HarnessmithError } from './types.js';
+
+export { diagnosticsCommandTimeoutMs, diagnosticsMaxCommandBytes };
+
+const knownHealthChecks = new Set([
+  'runtime',
+  'installation',
+  'global-memory',
+  'project-memory',
+  'audit',
+]);
+
+type DiagnosticStatus = 'passed' | 'warning' | 'failed' | 'inconclusive';
+type DiagnosticSource = 'installation' | 'health' | 'task' | 'routing';
+
+export interface DiagnosticFailure {
+  adapter: string;
+  source: DiagnosticSource;
+  errorCode: string;
+  result: 'inconclusive';
+}
+
+function installationSummary(inspection: AdapterStatusInspection) {
+  const { status, plan } = inspection;
+  const states = status.installed
+    ? status.outputs.map(({ status: value }) => value)
+    : plan.outputs.map(({ state }) => state);
+  const counts = { managed: 0, modified: 0, missing: 0, unmanaged: 0 };
+  for (const state of states) {
+    if (state in counts) counts[state as keyof typeof counts] += 1;
+  }
+  const observed = status.installed
+    ? counts.missing > 0
+      ? 'partial'
+      : counts.modified > 0
+        ? 'modified'
+        : 'managed'
+    : counts.unmanaged > 0
+      ? 'unmanaged'
+      : 'missing';
+  return {
+    status: observed,
+    reasonCode: `INSTALLATION_${observed.toUpperCase()}`,
+    outputCounts: counts,
+  };
+}
+
+function unavailableSubsystems(reasonCode: string) {
+  return ['memory', 'task', 'routing'].map((id) => ({
+    id,
+    status: 'inconclusive' as const,
+    reasonCode,
+    artifactDigest: null,
+  }));
+}
+
+function recordFailures(
+  adapter: Adapter,
+  commands: readonly (readonly [
+    Exclude<DiagnosticSource, 'installation'>,
+    DiagnosticCommandResult,
+  ])[],
+  failures: DiagnosticFailure[],
+): void {
+  for (const [source, result] of commands) {
+    if (
+      result.status === 'inconclusive' &&
+      result.reasonCode !== 'PROJECT_MEMORY_NOT_INITIALIZED'
+    ) {
+      failures.push({
+        adapter: adapter.name,
+        source,
+        errorCode: result.reasonCode,
+        result: 'inconclusive',
+      });
+    }
+  }
+}
+
+function summarizeRuntime(
+  adapter: Adapter,
+  env: NodeJS.ProcessEnv,
+  project: string,
+  failures: DiagnosticFailure[],
+) {
+  const health = runDiagnosticJson(adapter, ['health', '--json'], env, project);
+  const task = existsSync(join(project, '.agent-docs'))
+    ? runDiagnosticJson(adapter, ['task', 'status', '--project', project, '--json'], env, project)
+    : {
+        status: 'inconclusive' as const,
+        reasonCode: 'PROJECT_MEMORY_NOT_INITIALIZED',
+        digest: null,
+        value: null,
+        truncated: false,
+      };
+  const routing = runDiagnosticJson(adapter, ['route', 'diagnose', '--json'], env, project);
+  const commands = [
+    ['health', health],
+    ['task', task],
+    ['routing', routing],
+  ] as const;
+  recordFailures(adapter, commands, failures);
+
+  const rawChecks =
+    health.status === 'collected' &&
+    health.value &&
+    typeof health.value === 'object' &&
+    Array.isArray((health.value as { checks?: unknown }).checks)
+      ? (health.value as { checks: unknown[] }).checks
+      : [];
+  const runtimeChecks = rawChecks.flatMap((value) => {
+    if (!value || typeof value !== 'object') return [];
+    const check = value as { id?: unknown; status?: unknown };
+    if (
+      typeof check.id !== 'string' ||
+      !knownHealthChecks.has(check.id) ||
+      !['passed', 'warning', 'failed'].includes(String(check.status))
+    ) {
+      return [];
+    }
+    return [{ id: check.id, status: check.status as Exclude<DiagnosticStatus, 'inconclusive'> }];
+  });
+  const memoryChecks = runtimeChecks.filter(({ id }) => id.includes('memory'));
+  const memoryStatus: DiagnosticStatus =
+    health.status === 'inconclusive'
+      ? 'inconclusive'
+      : memoryChecks.some(({ status }) => status === 'failed')
+        ? 'failed'
+        : memoryChecks.some(({ status }) => status === 'warning')
+          ? 'warning'
+          : memoryChecks.length > 0
+            ? 'passed'
+            : 'inconclusive';
+  const taskValue = Array.isArray(task.value) ? task.value : null;
+  const routeValue =
+    routing.value && typeof routing.value === 'object'
+      ? (routing.value as { routes?: unknown }).routes
+      : null;
+  return {
+    runtimeChecks,
+    subsystems: [
+      {
+        id: 'memory',
+        status: memoryStatus,
+        reasonCode: health.reasonCode,
+        artifactDigest: health.digest,
+      },
+      {
+        id: 'task',
+        status: taskValue ? ('passed' as const) : ('inconclusive' as const),
+        reasonCode: task.reasonCode,
+        artifactDigest: task.digest,
+      },
+      {
+        id: 'routing',
+        status: Array.isArray(routeValue) ? ('passed' as const) : ('inconclusive' as const),
+        reasonCode: routing.reasonCode,
+        artifactDigest: routing.digest,
+      },
+    ],
+    truncated: commands.some(([, result]) => result.truncated),
+  };
+}
+
+export function collectDiagnosticAdapter(
+  adapter: Adapter,
+  env: NodeJS.ProcessEnv,
+  project: string,
+  failures: DiagnosticFailure[],
+) {
+  const capability = {
+    scope: adapter.capabilities.scope,
+    instructionFormat: adapter.capabilities.instructionFormat,
+    nativeRuleActivation: adapter.capabilities.nativeRuleActivation,
+  };
+  try {
+    const inspection = inspectStatusAll([adapter])[0];
+    const installation = installationSummary(inspection);
+    const canRun =
+      installation.status === 'managed' && existsSync(join(adapter.harness, 'bin', 'harness.mjs'));
+    const runtime = canRun
+      ? summarizeRuntime(adapter, env, project, failures)
+      : {
+          runtimeChecks: [],
+          subsystems: unavailableSubsystems('MANAGED_RUNTIME_UNAVAILABLE'),
+          truncated: false,
+        };
+    return { adapter: adapter.name, capability, installation, ...runtime };
+  } catch (error) {
+    const errorCode = error instanceof HarnessmithError ? error.code : 'INTERNAL_ERROR';
+    failures.push({
+      adapter: adapter.name,
+      source: 'installation',
+      errorCode,
+      result: 'inconclusive',
+    });
+    return {
+      adapter: adapter.name,
+      capability,
+      installation: {
+        status: 'inconclusive' as const,
+        reasonCode: errorCode,
+        outputCounts: { managed: 0, modified: 0, missing: 0, unmanaged: 0 },
+      },
+      runtimeChecks: [],
+      subsystems: unavailableSubsystems('INSTALLATION_INSPECTION_INCONCLUSIVE'),
+      truncated: false,
+    };
+  }
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,60 @@
+import {
+  collectDiagnosticAdapter,
+  type DiagnosticFailure,
+  diagnosticsCommandTimeoutMs,
+  diagnosticsMaxCommandBytes,
+} from './diagnostics-runtime.js';
+import { packageVersion } from './install-template.js';
+import type { Adapter } from './types.js';
+
+export function createDiagnosticsReport(
+  adapters: Adapter[],
+  {
+    env = process.env,
+    project = process.cwd(),
+  }: { env?: NodeJS.ProcessEnv; project?: string } = {},
+) {
+  const failures: DiagnosticFailure[] = [];
+  const collected = adapters.map((adapter) =>
+    collectDiagnosticAdapter(adapter, env, project, failures),
+  );
+  const truncated = collected.some((adapter) => adapter.truncated);
+  const adaptersReport = collected.map(({ truncated: _truncated, ...adapter }) => ({
+    ...adapter,
+    subsystems: [
+      ...adapter.subsystems,
+      {
+        id: 'host',
+        status: 'inconclusive' as const,
+        reasonCode: 'REAL_HOST_NOT_OBSERVED',
+        artifactDigest: null,
+      },
+    ],
+  }));
+  return {
+    version: 1,
+    command: 'diagnostics' as const,
+    collectionResult:
+      failures.length === 0
+        ? ('complete' as const)
+        : adapters.length > 0
+          ? ('partial' as const)
+          : ('inconclusive' as const),
+    privacy: { uploaded: false, persisted: false, previewOnly: true },
+    budget: {
+      maxAdapters: 5,
+      maxCommandBytes: diagnosticsMaxCommandBytes,
+      timeoutMs: diagnosticsCommandTimeoutMs,
+      truncated,
+    },
+    package: { version: packageVersion },
+    adapters: adaptersReport,
+    failures,
+    verification: [
+      'harnessmith diagnostics --agent <agent> --json',
+      'node <harness-path>/bin/harness.mjs health --json',
+    ],
+  };
+}
+
+export type DiagnosticsReport = ReturnType<typeof createDiagnosticsReport>;

--- a/src/program.ts
+++ b/src/program.ts
@@ -8,6 +8,7 @@ import type { CliOptions } from './types.js';
 export type HarnessmithCommand =
   | 'setup'
   | 'adopt'
+  | 'diagnostics'
   | 'install'
   | 'status'
   | 'restore'
@@ -78,6 +79,11 @@ export function createProgram(
     .command('capabilities')
     .description('report adapter scope, activation, ownership, and permission boundaries');
   capabilities.action(() => execute('capabilities', capabilities.optsWithGlobals<CliOptions>()));
+
+  const diagnostics = program
+    .command('diagnostics')
+    .description('preview a redacted, local-only diagnostic report');
+  diagnostics.action(() => execute('diagnostics', diagnostics.optsWithGlobals<CliOptions>()));
 
   for (const [name, description] of [
     ['status', 'inspect installation ownership and integrity'],


### PR DESCRIPTION
## Summary / 变更说明

- add an explicit read-only diagnostics command for local report preview
- emit only schema-allowlisted status, capability, digest, budget, failure, and verification metadata
- preserve partial and inconclusive results while excluding raw content, paths, environment values, secrets, and user identifiers
- document the no-upload and no-persistence boundary and publish the diagnostics schema

## Related Issue / 关联 Issue

Closes #107

## Verification / 验证

- pnpm run preflight (755 checks; 145 test files, 992 passed, 3 skipped)
- pnpm run test:coverage
- npm pack --dry-run (92 files)

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated dist files or include secrets, personal memory, or private paths. / 未修改生成的 dist 文件，且不包含凭据、个人记忆或私有路径。
