### PR TITLE
feat: add versioned config portability

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,6 +88,11 @@ npx harnessmith capabilities --json
 # Preview a local redacted diagnostics report; the command neither uploads nor persists it
 npx harnessmith diagnostics --agent codex --json
 
+# Export the portable personal overlay, then import it through a content-bound proposal
+npx harnessmith export --output ./harness-config.json --json
+npx harnessmith import --input ./harness-config.json --json
+npx harnessmith import --input ./harness-config.json --proposal <proposalId> --yes --json
+
 # Check cross-repository relationships in your personal Repository Map
 node <harness-path>/bin/harness.mjs repository-map check --json
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ npx harnessmith capabilities --json
 # 预览本地脱敏诊断报告；命令不上传或持久化报告
 npx harnessmith diagnostics --agent codex --json
 
+# 导出可迁移的 personal overlay，再以内容绑定提案导入
+npx harnessmith export --output ./harness-config.json --json
+npx harnessmith import --input ./harness-config.json --json
+npx harnessmith import --input ./harness-config.json --proposal <proposalId> --yes --json
+
 # 检查个人 Repository Map 中的跨仓库关系
 node <harness-path>/bin/harness.mjs repository-map check --json
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,10 @@ reproduction without secrets or personal memory content.
 - `diagnostics` emits only schema-allowlisted metadata to stdout. It does not persist or upload reports, and it
   excludes raw prompts, model output, tool arguments, file bodies, environment variables, secrets, local paths,
   and user identifiers. Review the preview before sharing it.
+- Portable config export is restricted to three personal-overlay files. Managed payloads, mutable state, global
+  and project memory, host credentials, caches, temporary files, and workspace content are excluded. Import
+  validates a versioned closed schema and digests, rejects symlinks and path escapes, and cannot overwrite a
+  different target; a content-bound proposal and explicit confirmation are required before transactional writes.
 - Uninstall does not delete shared or project `.agent-docs` memory.
 - A future custom-template feature must treat templates as executable trusted input because installed
   Harness JavaScript can run with the user's permissions.

--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -175,6 +175,19 @@ claims:
       - src/__tests__/diagnostics.test.ts
       - src/__tests__/args.test.ts
 
+  - id: versioned-portable-config
+    status: implemented
+    owner: outer portable-config transaction
+    claim: Export a minimal versioned personal-overlay bundle and validate, plan, proposal-bind, lock, import, and roll back allowed resources without including managed payloads, state, memory, credentials, caches, temporary files, or workspace content.
+    implementation:
+      - src/portable-config-contract.ts
+      - src/portable-config.ts
+      - src/portable-config-command.ts
+      - portable-config/bundle.schema.json
+    verification:
+      - src/__tests__/portable-config.test.ts
+      - src/__tests__/args.test.ts
+
   - id: candidate-bound-host-eval-gate
     status: implemented
     owner: release verification scripts

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -29,6 +29,15 @@ npx harnessmith adopt --agent codex --proposal <proposalId> --yes --json
 `adopt` 只导入可移植规则正文；Host-specific 配置只保留在原文件备份中。扫描或确认阶段发现 secret、symlink、未知格式、
 路径越界、受管文件被修改，或提案后内容发生变化时都会停止。实际写入与安装共享预检、锁、备份和事务回滚。
 
+## 配置迁移
+
+`export` / `import` 只迁移 user-owned personal overlay，不复制 managed Runtime、state、Memory、credential、cache 或
+workspace 内容。export 可先在 stdout 预览，再用 `--output` 写入新文件；import 首次只返回冲突 plan 和内容绑定的
+`proposalId`，审阅后才以 `--proposal <id> --yes` 提交。
+
+目标已有不同内容时 import 固定拒绝，不能成为静默跨 root 合并或覆盖入口。写入期间持有 personal root lock；失败按
+写前快照回滚。未知版本、篡改 digest、越界路径和 symlink bundle 都会在写入前停止。
+
 ## 只读预览与状态
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,6 +18,8 @@ owner: maintainers
 | `uninstall` | 恢复全部安装层并移除记录 | 是 |
 | `capabilities` | 输出 Adapter 范围、激活和权限边界 | 否 |
 | `diagnostics` | 预览本地脱敏诊断报告 | 否 |
+| `export` | 预览或写入版本化 personal overlay bundle | 仅提供 `--output` 时是 |
+| `import` | 校验并规划或导入 personal overlay bundle | 默认否；确认精确提案后是 |
 
 ## 通用选项
 
@@ -32,6 +34,8 @@ owner: maintainers
 | `--no-init-global` | 跳过共享全局 Memory 初始化 |
 | `--explain` | 仅用于 `status`；解释状态、证据、风险和安全下一步 |
 | `--proposal <id>` | 仅用于 `adopt`；绑定先前只读扫描返回的精确提案 |
+| `--output <file>` | 仅用于 `export`；写入一个不存在的新 bundle 文件 |
+| `--input <file>` | 仅用于 `import`；读取待校验的本地 bundle |
 | `-v, --version` | 输出版本 |
 | `-h, --help` | 输出帮助 |
 
@@ -102,6 +106,28 @@ schema 拒绝。命令只将报告预览到 stdout，不写文件也不上传，
 每个子命令最多读取 256 KiB，最长运行 10 秒。超限、超时、无输出和无效 JSON 都保留为稳定失败分类；一个采集步骤
 成功不会覆盖此前失败。未初始化的项目 Memory 和未执行的真实 Host 行为明确标为 `inconclusive`。
 
+## 版本化导出与导入
+
+```bash
+# 预览并可选写入一个新文件；不会覆盖已有输出
+npx harnessmith export --json
+npx harnessmith export --output ./harness-config.json --json
+
+# 第一步只校验 bundle、digest、目标状态并返回 proposalId
+npx harnessmith import --input ./harness-config.json --json
+
+# 审阅后确认完全相同的 bundle 与目标状态
+npx harnessmith import --input ./harness-config.json --proposal <proposalId> --yes --json
+```
+
+v1 bundle 只允许 personal overlay 的 `AGENTS.md` 和 Repository Map 两种表示；managed distribution、可变 state、
+全局/项目 Memory、Host credential、cache、临时文件和任意 workspace 内容始终排除。allowlist 文件含高置信 secret 或
+超过 256 KiB 时不会进入 bundle，并将导出标记为 `partial`。
+
+import 对未知 schema、未知字段、digest 不一致、路径越界、symlink 和无效 UTF-8 fail closed。目标缺失时可创建，内容
+相同则幂等跳过；任何不同内容均视为 conflict，不能用 import 覆盖，需回到显式 `adopt` 流程。实际写入持有 personal
+root coordination lock，并在失败时按快照回滚；提案后的 bundle 或目标变化会使 `proposalId` 失效。
+
 ## 示例
 
 ```bash
@@ -124,6 +150,8 @@ npx harnessmith status --agent codex --explain --json
 npx harnessmith adopt --agent codex --json
 npx harnessmith capabilities --json
 npx harnessmith diagnostics --agent codex --json
+npx harnessmith export --output ./harness-config.json --json
+npx harnessmith import --input ./harness-config.json --json
 
 # 回退生命周期
 npx harnessmith restore --agent codex

--- a/llms.txt
+++ b/llms.txt
@@ -154,6 +154,9 @@ the project-root `.gitignore` or `.ignore`.
 - Use `diagnostics --agent <agents> --json` to preview bounded, allowlisted troubleshooting metadata. The command writes
   only to stdout, never uploads or persists a report, and intentionally excludes raw content, local paths, environment
   variables, secrets, and user identifiers. Preserve partial and inconclusive classifications when sharing a preview.
+- Use `export --output <new-file> --json` only for the allowlisted personal overlay. Preview `import --input <file> --json`
+  first, then reuse its exact proposal with `--proposal <id> --yes`. Never treat import as permission to merge roots or
+  overwrite different user content; conflicts require the explicit adoption workflow.
 - Lifecycle commands attempt rollback along recorded paths. If rollback is incomplete, preserve stderr and every
   recovery path, report the installation as blocked, and do not claim the previous state was restored.
 - Upgrade by rerunning `npx --yes harnessmith`; use the outer CLI for status, restore, and uninstall:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "template/agent-harness/schemas",
     "template/agent-harness/templates",
     "diagnostics/report.schema.json",
+    "portable-config/bundle.schema.json",
     "evals/scenarios.json",
     "evals/scenarios.schema.json",
     "evals/host-capability-matrix.v1.json",

--- a/portable-config/bundle.schema.json
+++ b/portable-config/bundle.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:harnessmith:schema:portable-config:v1",
+  "title": "Harnessmith portable personal-overlay configuration bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "rootKind",
+    "collectionResult",
+    "resources",
+    "exclusions",
+    "excludedCategories",
+    "bundleDigest"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "harnessmith-portable-config" },
+    "rootKind": { "const": "personal-overlay" },
+    "collectionResult": { "enum": ["complete", "partial"] },
+    "resources": {
+      "type": "array",
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/resource" }
+    },
+    "exclusions": {
+      "type": "array",
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/exclusion" }
+    },
+    "excludedCategories": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "managed-distribution" },
+        { "const": "mutable-state" },
+        { "const": "global-memory" },
+        { "const": "project-memory" },
+        { "const": "host-credentials" },
+        { "const": "cache-and-temporary-files" },
+        { "const": "workspace-content" }
+      ],
+      "items": false,
+      "minItems": 7,
+      "maxItems": 7
+    },
+    "bundleDigest": { "$ref": "#/$defs/digest" }
+  },
+  "$defs": {
+    "path": {
+      "enum": [
+        "AGENTS.md",
+        "projects/repository-map.md",
+        "projects/repository-map.yaml"
+      ]
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "encoding", "digest", "content"],
+      "properties": {
+        "path": { "$ref": "#/$defs/path" },
+        "encoding": { "const": "utf8" },
+        "digest": { "$ref": "#/$defs/digest" },
+        "content": { "type": "string", "maxLength": 262144 }
+      }
+    },
+    "exclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "reasonCode"],
+      "properties": {
+        "path": { "$ref": "#/$defs/path" },
+        "reasonCode": { "enum": ["SECRET_DETECTED", "FILE_BUDGET_EXCEEDED"] }
+      }
+    }
+  }
+}

--- a/src/__tests__/args.test.ts
+++ b/src/__tests__/args.test.ts
@@ -107,6 +107,25 @@ test('Commander exposes read-only diagnostics reports', async () => {
   assert.equal(result.json, true);
 });
 
+test('Commander exposes proposal-bound config export and import', async () => {
+  const calls: Array<CliOptions & { command: HarnessmithCommand }> = [];
+  const program = createProgram(async (command, options) => {
+    calls.push({ command, ...options });
+  });
+  await program.parseAsync(['export', '--output', '/tmp/bundle.json', '--json'], {
+    from: 'user',
+  });
+  await program.parseAsync(
+    ['import', '--input', '/tmp/bundle.json', '--proposal', 'sha256:abc', '--yes', '--json'],
+    { from: 'user' },
+  );
+  assert.equal(calls[0].command, 'export');
+  assert.equal(calls[0].output, '/tmp/bundle.json');
+  assert.equal(calls[1].command, 'import');
+  assert.equal(calls[1].input, '/tmp/bundle.json');
+  assert.equal(calls[1].proposal, 'sha256:abc');
+});
+
 test('Commander exposes adapter capabilities as a read-only command', async () => {
   let result: (CliOptions & { command: HarnessmithCommand }) | undefined;
   const program = createProgram(async (command, options) => {

--- a/src/__tests__/fixtures/portable-config/unsupported-v2.json
+++ b/src/__tests__/fixtures/portable-config/unsupported-v2.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 2,
+  "kind": "harnessmith-portable-config",
+  "rootKind": "personal-overlay",
+  "collectionResult": "complete",
+  "resources": [],
+  "exclusions": [],
+  "excludedCategories": [
+    "managed-distribution",
+    "mutable-state",
+    "global-memory",
+    "project-memory",
+    "host-credentials",
+    "cache-and-temporary-files",
+    "workspace-content"
+  ],
+  "bundleDigest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/src/__tests__/fixtures/portable-config/v1.json
+++ b/src/__tests__/fixtures/portable-config/v1.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "kind": "harnessmith-portable-config",
+  "rootKind": "personal-overlay",
+  "collectionResult": "complete",
+  "resources": [
+    {
+      "path": "AGENTS.md",
+      "encoding": "utf8",
+      "digest": "sha256:faa5b4816800b8cbe1595e5533fe36c53f396c0c26a3a876dd3e4085232348a1",
+      "content": "# fixture\n"
+    }
+  ],
+  "exclusions": [],
+  "excludedCategories": [
+    "managed-distribution",
+    "mutable-state",
+    "global-memory",
+    "project-memory",
+    "host-credentials",
+    "cache-and-temporary-files",
+    "workspace-content"
+  ],
+  "bundleDigest": "sha256:c7490623d4b10a8ea2338570a3df361e6ac493c6f7c467d257330141e535965d"
+}

--- a/src/__tests__/portable-config.test.ts
+++ b/src/__tests__/portable-config.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { onTestFinished, test } from 'vitest';
+import {
+  applyPortableConfigImport,
+  createPortableConfigBundle,
+  planPortableConfigImport,
+  writePortableConfigBundle,
+} from '../portable-config.js';
+import {
+  executePortableConfigExport,
+  executePortableConfigImport,
+} from '../portable-config-command.js';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const schema = JSON.parse(
+  readFileSync(join(packageRoot, 'portable-config', 'bundle.schema.json'), 'utf8'),
+);
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  return {
+    root,
+    env: {
+      ...process.env,
+      HOME: root,
+      HARNESS_PERSONAL_HOME: join(root, '个人-harness'),
+    },
+  };
+}
+
+function write(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+test('export includes only allowlisted personal overlay files and excludes secrets', () => {
+  const { root, env } = fixture('harnessmith-portable-export-');
+  const personal = env.HARNESS_PERSONAL_HOME;
+  const secret = ['ghp', '_', 'E'.repeat(24)].join('');
+  write(join(personal, 'AGENTS.md'), '# 我的规则\n');
+  write(join(personal, 'projects', 'repository-map.yaml'), 'version: 1\nrepositories: []\n');
+  write(join(personal, 'projects', 'repository-map.md'), `private ${secret}\n`);
+  write(join(personal, 'state', 'cache.json'), `{"secret":"${secret}"}\n`);
+  write(join(root, 'workspace.txt'), 'arbitrary workspace content\n');
+
+  const bundle = createPortableConfigBundle({ env });
+  const serialized = JSON.stringify(bundle);
+
+  assert.deepEqual(
+    bundle.resources.map(({ path }) => path),
+    ['AGENTS.md', 'projects/repository-map.yaml'],
+  );
+  assert.ok(
+    bundle.exclusions.some(
+      ({ path, reasonCode }) =>
+        path === 'projects/repository-map.md' && reasonCode === 'SECRET_DETECTED',
+    ),
+  );
+  assert.doesNotMatch(serialized, new RegExp(secret));
+  assert.doesNotMatch(serialized, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.doesNotMatch(serialized, /cache\.json|workspace\.txt/);
+  assert.deepEqual(bundle.excludedCategories, [
+    'managed-distribution',
+    'mutable-state',
+    'global-memory',
+    'project-memory',
+    'host-credentials',
+    'cache-and-temporary-files',
+    'workspace-content',
+  ]);
+});
+
+test('export and import round-trip allowed data through a proposal-bound transaction', () => {
+  const source = fixture('harnessmith-portable-source-');
+  const target = fixture('harnessmith-portable-target-');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# 可迁移规则\n中文内容\n');
+  write(
+    join(source.env.HARNESS_PERSONAL_HOME, 'projects', 'repository-map.yaml'),
+    'version: 1\nrepositories: []\n',
+  );
+  const bundle = createPortableConfigBundle({ env: source.env });
+  const bundlePath = join(source.root, 'bundle.json');
+  writePortableConfigBundle(bundlePath, bundle);
+
+  const plan = planPortableConfigImport(bundlePath, { env: target.env });
+  assert.equal(plan.applied, false);
+  assert.ok(plan.changes.every(({ action }) => action === 'create'));
+  const result = applyPortableConfigImport(bundlePath, plan.proposalId, { env: target.env });
+
+  assert.equal(result.applied, true);
+  assert.equal(
+    readFileSync(join(target.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), 'utf8'),
+    '# 可迁移规则\n中文内容\n',
+  );
+  assert.equal(
+    readFileSync(join(target.env.HARNESS_PERSONAL_HOME, 'projects', 'repository-map.yaml'), 'utf8'),
+    'version: 1\nrepositories: []\n',
+  );
+});
+
+test('import refuses changed targets and stale proposals without overwriting user content', () => {
+  const source = fixture('harnessmith-portable-conflict-source-');
+  const target = fixture('harnessmith-portable-conflict-target-');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# imported\n');
+  const bundlePath = join(source.root, 'bundle.json');
+  writePortableConfigBundle(bundlePath, createPortableConfigBundle({ env: source.env }));
+  const plan = planPortableConfigImport(bundlePath, { env: target.env });
+  const destination = join(target.env.HARNESS_PERSONAL_HOME, 'AGENTS.md');
+  write(destination, '# local edit\n');
+
+  assert.throws(
+    () => applyPortableConfigImport(bundlePath, plan.proposalId, { env: target.env }),
+    /proposal changed/,
+  );
+  assert.equal(readFileSync(destination, 'utf8'), '# local edit\n');
+  const conflict = planPortableConfigImport(bundlePath, { env: target.env });
+  assert.equal(conflict.changes[0].action, 'conflict');
+  assert.throws(
+    () => applyPortableConfigImport(bundlePath, conflict.proposalId, { env: target.env }),
+    /adopt flow/,
+  );
+});
+
+test('import rejects unknown schema, tampering, traversal, and symlink input', () => {
+  const source = fixture('harnessmith-portable-invalid-source-');
+  const target = fixture('harnessmith-portable-invalid-target-');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# safe\n');
+  const bundle = createPortableConfigBundle({ env: source.env });
+  const bundlePath = join(source.root, 'bundle.json');
+
+  write(bundlePath, `${JSON.stringify({ ...bundle, schemaVersion: 2 })}\n`);
+  assert.throws(() => planPortableConfigImport(bundlePath, { env: target.env }), /schema version/);
+
+  write(bundlePath, `${JSON.stringify({ ...bundle, bundleDigest: 'sha256:bad' })}\n`);
+  assert.throws(() => planPortableConfigImport(bundlePath, { env: target.env }), /digest/);
+
+  const traversal = {
+    ...bundle,
+    resources: [{ ...bundle.resources[0], path: '../escape.md' }],
+  };
+  write(bundlePath, `${JSON.stringify(traversal)}\n`);
+  assert.throws(() => planPortableConfigImport(bundlePath, { env: target.env }), /resource path/);
+
+  const realPath = join(source.root, 'real-bundle.json');
+  write(realPath, `${JSON.stringify(bundle)}\n`);
+  const linkPath = join(source.root, 'linked-bundle.json');
+  symlinkSync(realPath, linkPath);
+  assert.throws(() => planPortableConfigImport(linkPath, { env: target.env }), /symbolic link/);
+
+  const outside = join(target.root, 'outside.md');
+  write(outside, '# outside\n');
+  const linkedTarget = join(target.env.HARNESS_PERSONAL_HOME, 'AGENTS.md');
+  mkdirSync(dirname(linkedTarget), { recursive: true });
+  symlinkSync(outside, linkedTarget);
+  assert.throws(() => planPortableConfigImport(realPath, { env: target.env }), /symbolic link/);
+});
+
+test('import rolls back all created files when a transaction fails', () => {
+  const source = fixture('harnessmith-portable-rollback-source-');
+  const target = fixture('harnessmith-portable-rollback-target-');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# first\n');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'projects', 'repository-map.yaml'), 'version: 1\n');
+  const bundlePath = join(source.root, 'bundle.json');
+  writePortableConfigBundle(bundlePath, createPortableConfigBundle({ env: source.env }));
+  const plan = planPortableConfigImport(bundlePath, { env: target.env });
+
+  assert.throws(
+    () =>
+      applyPortableConfigImport(bundlePath, plan.proposalId, {
+        env: target.env,
+        afterWrite: ({ index }) => {
+          if (index === 0) throw new Error('injected failure');
+        },
+      }),
+    /injected failure/,
+  );
+  assert.equal(existsSync(join(target.env.HARNESS_PERSONAL_HOME, 'AGENTS.md')), false);
+  assert.equal(
+    existsSync(join(target.env.HARNESS_PERSONAL_HOME, 'projects', 'repository-map.yaml')),
+    false,
+  );
+});
+
+test('portable config bundle matches its closed versioned schema', () => {
+  const { env } = fixture('harnessmith-portable-schema-');
+  write(join(env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# schema\n');
+  const bundle = createPortableConfigBundle({ env });
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+
+  assert.equal(ajv.validate(schema, bundle), true, JSON.stringify(ajv.errors));
+  assert.equal(ajv.validate(schema, { ...bundle, credential: 'forbidden' }), false);
+});
+
+test('version fixtures preserve v1 compatibility and fail closed on unsupported versions', () => {
+  const target = fixture('harnessmith-portable-version-target-');
+  const fixtureRoot = join(packageRoot, 'src', '__tests__', 'fixtures', 'portable-config');
+
+  const plan = planPortableConfigImport(join(fixtureRoot, 'v1.json'), { env: target.env });
+  assert.equal(plan.schemaVersion, 1);
+  assert.equal(plan.changes[0].action, 'create');
+  assert.throws(
+    () => planPortableConfigImport(join(fixtureRoot, 'unsupported-v2.json'), { env: target.env }),
+    /schema version/,
+  );
+});
+
+test('CLI handlers preview export and require an exact proposal before import', () => {
+  const source = fixture('harnessmith-portable-command-source-');
+  const target = fixture('harnessmith-portable-command-target-');
+  write(join(source.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), '# command\n');
+  const bundlePath = join(source.root, 'bundle.json');
+  const exportLogs: string[] = [];
+  assert.equal(
+    executePortableConfigExport(
+      { agent: [], project: source.root, output: bundlePath, json: true },
+      { env: source.env, io: { log: (value) => exportLogs.push(String(value)) } },
+    ),
+    0,
+  );
+  assert.equal(JSON.parse(exportLogs[0]).kind, 'harnessmith-portable-config');
+
+  const previewLogs: string[] = [];
+  assert.equal(
+    executePortableConfigImport(
+      { agent: [], project: target.root, input: bundlePath, json: true },
+      { env: target.env, io: { log: (value) => previewLogs.push(String(value)) } },
+    ),
+    0,
+  );
+  const proposalId = JSON.parse(previewLogs[0]).proposalId;
+  assert.throws(
+    () =>
+      executePortableConfigImport(
+        { agent: [], project: target.root, input: bundlePath, yes: true },
+        { env: target.env, io: { log: () => undefined } },
+      ),
+    /requires --proposal/,
+  );
+  assert.equal(
+    executePortableConfigImport(
+      { agent: [], project: target.root, input: bundlePath, proposal: proposalId, yes: true },
+      { env: target.env, io: { log: () => undefined } },
+    ),
+    0,
+  );
+  assert.equal(
+    readFileSync(join(target.env.HARNESS_PERSONAL_HOME, 'AGENTS.md'), 'utf8'),
+    '# command\n',
+  );
+});

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -1,4 +1,3 @@
-import type { Readable, Writable } from 'node:stream';
 import { adapterCapabilities, createAdapter } from './adapters.js';
 import { executeAdopt } from './adopt-command.js';
 import { normalizeAgents } from './agents.js';
@@ -6,11 +5,15 @@ import { executeDiagnostics } from './diagnostics-command.js';
 import { installAll } from './install.js';
 import { inspectStatusAll, restoreAll, statusAll, uninstallAll } from './lifecycle.js';
 import { describeLifecycle } from './lifecycle-plan.js';
+import {
+  executePortableConfigExport,
+  executePortableConfigImport,
+} from './portable-config-command.js';
 import type { HarnessmithCommand } from './program.js';
 import { assertNonOverlappingAdapters, describeInstall } from './records.js';
 import { executeSetup } from './setup-command.js';
 import { explainStatus, explainUnsupportedStatus } from './status-explanation.js';
-import type { Adapter, CliOptions, Io, LifecycleCommand, LifecyclePlan } from './types.js';
+import type { Adapter, CliOptions, ExecuteContext, LifecycleCommand } from './types.js';
 import { HarnessmithError } from './types.js';
 import {
   confirmConflicts,
@@ -23,14 +26,7 @@ import {
   startInteractive,
 } from './ui.js';
 
-interface ExecuteContext {
-  env: NodeJS.ProcessEnv;
-  io: Io;
-  input: Readable;
-  output: Writable;
-}
-
-function isTty(stream: Readable | Writable): boolean {
+function isTty(stream: ExecuteContext['input'] | ExecuteContext['output']): boolean {
   return 'isTTY' in stream && stream.isTTY === true;
 }
 
@@ -57,7 +53,7 @@ async function resolveAdapters(options: CliOptions, context: ExecuteContext): Pr
 }
 
 function printLifecyclePlans(
-  plans: LifecyclePlan[],
+  plans: Array<ReturnType<typeof describeLifecycle>>,
   context: ExecuteContext,
   machineReadable: boolean,
 ): void {
@@ -96,7 +92,7 @@ function previewLifecycle(
 function executeLifecycle(
   command: Exclude<
     HarnessmithCommand,
-    'setup' | 'adopt' | 'diagnostics' | 'install' | 'capabilities'
+    'setup' | 'adopt' | 'diagnostics' | 'export' | 'import' | 'install' | 'capabilities'
   >,
   adapters: Adapter[],
   options: CliOptions,
@@ -223,6 +219,8 @@ export async function executeCommand(
     !options.yes && isTty(context.input) && isTty(context.output) && !options.json;
   if (interactive) startInteractive(context.output);
   if (command === 'capabilities') return executeCapabilities(options, context);
+  if (command === 'export') return executePortableConfigExport(options, context);
+  if (command === 'import') return executePortableConfigImport(options, context);
   let adapters: Adapter[];
   try {
     adapters = await resolveAdapters(options, context);

--- a/src/portable-config-command.ts
+++ b/src/portable-config-command.ts
@@ -1,0 +1,53 @@
+import {
+  applyPortableConfigImport,
+  createPortableConfigBundle,
+  planPortableConfigImport,
+  writePortableConfigBundle,
+} from './portable-config.js';
+import type { CliOptions, Io } from './types.js';
+import { HarnessmithError } from './types.js';
+
+export function executePortableConfigExport(
+  options: CliOptions,
+  { env, io }: { env: NodeJS.ProcessEnv; io: Io },
+): number {
+  const bundle = createPortableConfigBundle({ env });
+  if (options.output) writePortableConfigBundle(options.output, bundle);
+  if (options.json) io.log(JSON.stringify(bundle));
+  else {
+    io.log(`Portable config export: ${bundle.collectionResult}`);
+    io.log(`Bundle digest: ${bundle.bundleDigest}`);
+    io.log(`Persisted: ${options.output ? 'yes' : 'no (preview only)'}`);
+    for (const resource of bundle.resources) io.log(`  include ${resource.path}`);
+    for (const exclusion of bundle.exclusions) {
+      io.log(`  exclude ${exclusion.path}  ${exclusion.reasonCode}`);
+    }
+  }
+  return bundle.collectionResult === 'complete' ? 0 : 1;
+}
+
+export function executePortableConfigImport(
+  options: CliOptions,
+  { env, io }: { env: NodeJS.ProcessEnv; io: Io },
+): number {
+  if (!options.input) {
+    throw new HarnessmithError('CLI_USAGE', 'import requires --input <file>', 2);
+  }
+  if (options.yes !== true && options.proposal) {
+    throw new HarnessmithError('CLI_USAGE', 'import --proposal requires --yes', 2);
+  }
+  if (options.yes === true && !options.proposal) {
+    throw new HarnessmithError('CLI_USAGE', 'import --yes requires --proposal <id>', 2);
+  }
+  const plan =
+    options.yes === true && options.proposal
+      ? applyPortableConfigImport(options.input, options.proposal, { env })
+      : planPortableConfigImport(options.input, { env });
+  if (options.json) io.log(JSON.stringify(plan));
+  else {
+    io.log(`Portable config import: ${plan.applied ? 'applied' : 'preview'}`);
+    io.log(`Proposal: ${plan.proposalId}`);
+    for (const change of plan.changes) io.log(`  ${change.action}  ${change.path}`);
+  }
+  return plan.changes.some(({ action }) => action === 'conflict') ? 1 : 0;
+}

--- a/src/portable-config-contract.ts
+++ b/src/portable-config-contract.ts
@@ -1,0 +1,162 @@
+import { createHash } from 'node:crypto';
+import { containsAdoptSecret } from './adopt-secret.js';
+import { HarnessmithError } from './types.js';
+
+export const portableConfigPaths = [
+  'AGENTS.md',
+  'projects/repository-map.md',
+  'projects/repository-map.yaml',
+] as const;
+
+export const portableConfigExcludedCategories = [
+  'managed-distribution',
+  'mutable-state',
+  'global-memory',
+  'project-memory',
+  'host-credentials',
+  'cache-and-temporary-files',
+  'workspace-content',
+] as const;
+
+export interface PortableConfigResource {
+  path: (typeof portableConfigPaths)[number];
+  encoding: 'utf8';
+  digest: string;
+  content: string;
+}
+
+export interface PortableConfigExclusion {
+  path: (typeof portableConfigPaths)[number];
+  reasonCode: 'SECRET_DETECTED' | 'FILE_BUDGET_EXCEEDED';
+}
+
+export interface PortableConfigBundle {
+  schemaVersion: 1;
+  kind: 'harnessmith-portable-config';
+  rootKind: 'personal-overlay';
+  collectionResult: 'complete' | 'partial';
+  resources: PortableConfigResource[];
+  exclusions: PortableConfigExclusion[];
+  excludedCategories: typeof portableConfigExcludedCategories;
+  bundleDigest: string;
+}
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+
+export function portableDigest(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+export function portableBundleDigest(bundle: Omit<PortableConfigBundle, 'bundleDigest'>): string {
+  return portableDigest(JSON.stringify(bundle));
+}
+
+function integrity(message: string): never {
+  throw new HarnessmithError('INTEGRITY_ERROR', message, 3);
+}
+
+function object(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return integrity(`Invalid portable config ${name}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: string[], name: string): void {
+  const actual = Object.keys(value).sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    integrity(`Invalid portable config ${name} fields`);
+  }
+}
+
+function parseResource(value: unknown): PortableConfigResource {
+  const item = object(value, 'resource');
+  exactKeys(item, ['content', 'digest', 'encoding', 'path'], 'resource');
+  if (!portableConfigPaths.includes(item.path as PortableConfigResource['path'])) {
+    integrity('Invalid portable config resource path');
+  }
+  if (item.encoding !== 'utf8' || typeof item.content !== 'string') {
+    integrity('Invalid portable config resource encoding');
+  }
+  if (Buffer.byteLength(item.content, 'utf8') > 256 * 1024) {
+    integrity('Portable config resource exceeds byte budget');
+  }
+  if (containsAdoptSecret(item.content)) integrity('Portable config resource contains a secret');
+  if (typeof item.digest !== 'string' || !digestPattern.test(item.digest)) {
+    integrity('Invalid portable config resource digest');
+  }
+  if (portableDigest(item.content) !== item.digest)
+    integrity('Portable config resource digest mismatch');
+  return item as unknown as PortableConfigResource;
+}
+
+function parseExclusion(value: unknown): PortableConfigExclusion {
+  const item = object(value, 'exclusion');
+  exactKeys(item, ['path', 'reasonCode'], 'exclusion');
+  if (!portableConfigPaths.includes(item.path as PortableConfigExclusion['path'])) {
+    integrity('Invalid portable config exclusion path');
+  }
+  if (!['SECRET_DETECTED', 'FILE_BUDGET_EXCEEDED'].includes(String(item.reasonCode))) {
+    integrity('Invalid portable config exclusion reason');
+  }
+  return item as unknown as PortableConfigExclusion;
+}
+
+export function parsePortableConfigBundle(value: unknown): PortableConfigBundle {
+  const bundle = object(value, 'bundle');
+  exactKeys(
+    bundle,
+    [
+      'bundleDigest',
+      'collectionResult',
+      'excludedCategories',
+      'exclusions',
+      'kind',
+      'resources',
+      'rootKind',
+      'schemaVersion',
+    ],
+    'bundle',
+  );
+  if (bundle.schemaVersion !== 1) integrity('Unsupported portable config schema version');
+  if (bundle.kind !== 'harnessmith-portable-config' || bundle.rootKind !== 'personal-overlay') {
+    integrity('Invalid portable config kind');
+  }
+  if (!Array.isArray(bundle.resources) || !Array.isArray(bundle.exclusions)) {
+    integrity('Invalid portable config resource lists');
+  }
+  const resources = bundle.resources.map(parseResource);
+  const exclusions = bundle.exclusions.map(parseExclusion);
+  const resourcePaths = resources.map(({ path }) => path);
+  const exclusionPaths = exclusions.map(({ path }) => path);
+  if (
+    new Set([...resourcePaths, ...exclusionPaths]).size !==
+    resources.length + exclusions.length
+  ) {
+    integrity('Duplicate portable config resource path');
+  }
+  if (
+    !Array.isArray(bundle.excludedCategories) ||
+    JSON.stringify(bundle.excludedCategories) !== JSON.stringify(portableConfigExcludedCategories)
+  ) {
+    integrity('Invalid portable config excluded categories');
+  }
+  const expectedResult = exclusions.length > 0 ? 'partial' : 'complete';
+  if (bundle.collectionResult !== expectedResult) integrity('Invalid portable config result');
+  if (typeof bundle.bundleDigest !== 'string' || !digestPattern.test(bundle.bundleDigest)) {
+    integrity('Invalid portable config bundle digest');
+  }
+  const normalized = {
+    schemaVersion: 1,
+    kind: 'harnessmith-portable-config',
+    rootKind: 'personal-overlay',
+    collectionResult: expectedResult,
+    resources,
+    exclusions,
+    excludedCategories: portableConfigExcludedCategories,
+  } as const;
+  if (portableBundleDigest(normalized) !== bundle.bundleDigest) {
+    integrity('Portable config bundle digest mismatch');
+  }
+  return { ...normalized, bundleDigest: bundle.bundleDigest };
+}

--- a/src/portable-config.ts
+++ b/src/portable-config.ts
@@ -1,0 +1,227 @@
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { containsAdoptSecret } from './adopt-secret.js';
+import { atomicWrite } from './files.js';
+import {
+  type PortableConfigBundle,
+  type PortableConfigExclusion,
+  type PortableConfigResource,
+  parsePortableConfigBundle,
+  portableBundleDigest,
+  portableConfigExcludedCategories,
+  portableConfigPaths,
+  portableDigest,
+} from './portable-config-contract.js';
+import { restoreSnapshots, snapshotFiles } from './records.js';
+import { assertSafePath, canonicalPath } from './safe-path.js';
+import { errorMessage, HarnessmithError } from './types.js';
+import { withUserDataCoordinationLocks } from './user-data-lock.js';
+
+export interface PortableConfigImportChange {
+  path: (typeof portableConfigPaths)[number];
+  action: 'create' | 'already-present' | 'conflict';
+  sourceDigest: string;
+  targetDigest: string | null;
+}
+
+export interface PortableConfigImportPlan {
+  version: 1;
+  action: 'import';
+  schemaVersion: 1;
+  rootKind: 'personal-overlay';
+  proposalId: string;
+  applied: boolean;
+  rollback: 'snapshot-restore';
+  changes: PortableConfigImportChange[];
+}
+
+function personalRoot(env: NodeJS.ProcessEnv): string {
+  return canonicalPath(env.HARNESS_PERSONAL_HOME || join(env.HOME || homedir(), '.agent-harness'));
+}
+
+function regularFile(path: string, context: string) {
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink()) {
+    throw new HarnessmithError('UNSAFE_PATH', `${context} is a symbolic link`, 3);
+  }
+  if (!entry.isFile()) throw new HarnessmithError('INTEGRITY_ERROR', `${context} is not a file`, 3);
+  return entry;
+}
+
+function readUtf8(path: string): string {
+  const buffer = readFileSync(path);
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch (error) {
+    throw new HarnessmithError('INTEGRITY_ERROR', 'Portable config file is not valid UTF-8', 3, {
+      cause: error,
+    });
+  }
+}
+
+export function createPortableConfigBundle({
+  env = process.env,
+}: {
+  env?: NodeJS.ProcessEnv;
+} = {}) {
+  const root = personalRoot(env);
+  const resources: PortableConfigResource[] = [];
+  const exclusions: PortableConfigExclusion[] = [];
+  for (const relative of portableConfigPaths) {
+    const path = join(root, relative);
+    if (!existsSync(path)) continue;
+    assertSafePath(root, path);
+    const entry = regularFile(path, 'Portable config source');
+    if (entry.size > 256 * 1024) {
+      exclusions.push({ path: relative, reasonCode: 'FILE_BUDGET_EXCEEDED' });
+      continue;
+    }
+    const content = readUtf8(path);
+    if (containsAdoptSecret(content)) {
+      exclusions.push({ path: relative, reasonCode: 'SECRET_DETECTED' });
+      continue;
+    }
+    resources.push({ path: relative, encoding: 'utf8', digest: portableDigest(content), content });
+  }
+  const body = {
+    schemaVersion: 1,
+    kind: 'harnessmith-portable-config',
+    rootKind: 'personal-overlay',
+    collectionResult: exclusions.length > 0 ? ('partial' as const) : ('complete' as const),
+    resources,
+    exclusions,
+    excludedCategories: portableConfigExcludedCategories,
+  } as const;
+  return { ...body, bundleDigest: portableBundleDigest(body) };
+}
+
+export function writePortableConfigBundle(path: string, bundle: PortableConfigBundle): void {
+  parsePortableConfigBundle(bundle);
+  const target = resolve(path);
+  if (existsSync(target)) {
+    regularFile(target, 'Portable config output');
+    throw new HarnessmithError('SAFETY_CONFLICT', 'Portable config output already exists', 3);
+  }
+  atomicWrite(target, `${JSON.stringify(bundle, null, 2)}\n`, 0o600);
+}
+
+function readBundle(path: string): PortableConfigBundle {
+  const input = resolve(path);
+  const entry = regularFile(input, 'Portable config input');
+  if (entry.size > 1024 * 1024) {
+    throw new HarnessmithError('INTEGRITY_ERROR', 'Portable config input exceeds byte budget', 3);
+  }
+  try {
+    return parsePortableConfigBundle(JSON.parse(readUtf8(input)));
+  } catch (error) {
+    if (error instanceof HarnessmithError) throw error;
+    throw new HarnessmithError('INTEGRITY_ERROR', 'Portable config input is not valid JSON', 3, {
+      cause: error,
+    });
+  }
+}
+
+function importPlan(
+  bundle: PortableConfigBundle,
+  env: NodeJS.ProcessEnv,
+): PortableConfigImportPlan {
+  const root = personalRoot(env);
+  const changes = bundle.resources.map((resource) => {
+    const target = join(root, resource.path);
+    assertSafePath(root, target);
+    if (!existsSync(target)) {
+      return {
+        path: resource.path,
+        action: 'create' as const,
+        sourceDigest: resource.digest,
+        targetDigest: null,
+      };
+    }
+    const entry = regularFile(target, 'Portable config target');
+    if (entry.size > 256 * 1024) {
+      return {
+        path: resource.path,
+        action: 'conflict' as const,
+        sourceDigest: resource.digest,
+        targetDigest: null,
+      };
+    }
+    const targetDigest = portableDigest(readUtf8(target));
+    return {
+      path: resource.path,
+      action:
+        targetDigest === resource.digest ? ('already-present' as const) : ('conflict' as const),
+      sourceDigest: resource.digest,
+      targetDigest,
+    };
+  });
+  const proposalId = portableDigest(JSON.stringify({ bundleDigest: bundle.bundleDigest, changes }));
+  return {
+    version: 1,
+    action: 'import',
+    schemaVersion: bundle.schemaVersion,
+    rootKind: bundle.rootKind,
+    proposalId,
+    applied: false,
+    rollback: 'snapshot-restore',
+    changes,
+  };
+}
+
+export function planPortableConfigImport(
+  bundlePath: string,
+  { env = process.env }: { env?: NodeJS.ProcessEnv } = {},
+): PortableConfigImportPlan {
+  return importPlan(readBundle(bundlePath), env);
+}
+
+export function applyPortableConfigImport(
+  bundlePath: string,
+  proposalId: string,
+  {
+    env = process.env,
+    afterWrite,
+  }: {
+    env?: NodeJS.ProcessEnv;
+    afterWrite?: (event: { index: number; path: string }) => void;
+  } = {},
+): PortableConfigImportPlan {
+  const bundle = readBundle(bundlePath);
+  const root = personalRoot(env);
+  return withUserDataCoordinationLocks([root], () => {
+    const plan = importPlan(bundle, env);
+    if (plan.proposalId !== proposalId) {
+      throw new HarnessmithError('STATE_CONFLICT', 'Portable config import proposal changed', 3);
+    }
+    if (plan.changes.some(({ action }) => action === 'conflict')) {
+      throw new HarnessmithError(
+        'SAFETY_CONFLICT',
+        'Portable config target conflict requires the explicit adopt flow',
+        3,
+      );
+    }
+    const paths = bundle.resources.map(({ path }) => join(root, path));
+    const snapshots = snapshotFiles(paths.map((path) => ({ path })));
+    try {
+      bundle.resources.forEach((resource, index) => {
+        if (plan.changes[index]?.action === 'already-present') return;
+        const target = paths[index];
+        assertSafePath(root, target);
+        atomicWrite(target, resource.content);
+        afterWrite?.({ index, path: resource.path });
+      });
+      return { ...plan, applied: true };
+    } catch (error) {
+      try {
+        restoreSnapshots(snapshots);
+      } catch (rollbackError) {
+        throw new Error(
+          `Portable config import failed and rollback was incomplete: ${errorMessage(error)}; rollback: ${errorMessage(rollbackError)}`,
+          { cause: error instanceof Error ? error : undefined },
+        );
+      }
+      throw error;
+    }
+  });
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -9,6 +9,8 @@ export type HarnessmithCommand =
   | 'setup'
   | 'adopt'
   | 'diagnostics'
+  | 'export'
+  | 'import'
   | 'install'
   | 'status'
   | 'restore'
@@ -84,6 +86,19 @@ export function createProgram(
     .command('diagnostics')
     .description('preview a redacted, local-only diagnostic report');
   diagnostics.action(() => execute('diagnostics', diagnostics.optsWithGlobals<CliOptions>()));
+
+  const exportCommand = program
+    .command('export')
+    .description('preview or write a versioned personal-overlay bundle')
+    .option('--output <file>', 'write the reviewed bundle to a new local file');
+  exportCommand.action(() => execute('export', exportCommand.optsWithGlobals<CliOptions>()));
+
+  const importCommand = program
+    .command('import')
+    .description('validate and plan or apply a versioned personal-overlay bundle')
+    .requiredOption('--input <file>', 'read a local portable-config bundle')
+    .option('--proposal <id>', 'confirm the exact proposal id from a prior preview');
+  importCommand.action(() => execute('import', importCommand.optsWithGlobals<CliOptions>()));
 
   for (const [name, description] of [
     ['status', 'inspect installation ownership and integrity'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,13 @@ export interface Io {
   error?(message?: unknown, ...optional: unknown[]): void;
 }
 
+export interface ExecuteContext {
+  env: NodeJS.ProcessEnv;
+  io: Io;
+  input: Readable;
+  output: Writable;
+}
+
 export interface Instruction {
   path: string;
   render(content: string): string;
@@ -160,6 +167,8 @@ export interface CliOptions {
   initGlobal?: boolean;
   explain?: boolean;
   proposal?: string;
+  output?: string;
+  input?: string;
 }
 
 export interface RunContext {


### PR DESCRIPTION
## Summary / 变更说明

- add a v1 closed-schema bundle for the allowlisted user-owned personal overlay
- exclude managed distribution, state, memory, credentials, caches, temporary files, workspace content, and secret-bearing files
- validate digests, versions, paths, UTF-8, symlinks, and target state before import
- bind import confirmation to an exact proposal and apply under a coordination lock with snapshot rollback

## Related Issue / 关联 Issue

Closes #108

## Verification / 验证

- pnpm run preflight (755 checks; 146 test files, 1001 passed, 3 skipped)
- pnpm run test:coverage
- npm pack --dry-run (96 files)

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated dist files or include secrets, personal memory, or private paths. / 未修改生成的 dist 文件，且不包含凭据、个人记忆或私有路径。
