### PR TITLE
feat: add bounded memory repair

### DIFF
--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -305,6 +305,19 @@ claims:
       - evals/__tests__/registry-verification.test.ts
       - src/__tests__/github-templates.test.ts
 
+  - id: bounded-memory-repair
+    status: implemented
+    owner: embedded Harness Memory lifecycle
+    claim: Diagnose repair candidates without writing, apply one content-bound proposal with exact authority and paths, and retain or roll back unverifiable recovery state.
+    implementation:
+      - template/agent-harness/src/commands/memory-repair.ts
+      - template/agent-harness/src/lib/memory-repair-plan.ts
+      - template/agent-harness/src/lib/memory-repair-apply.ts
+      - template/agent-harness/src/lib/memory-repair-journal.ts
+      - template/agent-harness/src/lib/memory-repair-transaction.ts
+    verification:
+      - template/agent-harness/src/__tests__/memory-repair.test.ts
+
   - id: model-loop-tools-and-permissions
     status: delegated
     owner: host Agent Runtime

--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -91,6 +91,7 @@ node <harness-path>/bin/harness.mjs memory search project "npm cache" --json
 node <harness-path>/bin/harness.mjs memory check project --indexed --json
 node <harness-path>/bin/harness.mjs memory relationships /absolute/project/path --json
 node <harness-path>/bin/harness.mjs memory maintain project --json
+node <harness-path>/bin/harness.mjs memory repair project --json
 ```
 
 `memory relationships` 是项目级只读报告：统一列出 Task、默认 phase/workstream、Memory owner、session 与
@@ -100,6 +101,13 @@ lifecycle role，并报告 orphan task reference 和 cross-workstream binding。
 `memory maintain` 只报告未索引、过期、重复、可归档和替代关系异常，不会自行删除或改写。旧 metadata 通过
 `memory migrate` 先生成 proposal；只有提案状态为 ready 且显式传入 `--apply` 才写入。`supersede` 建立替代关系，
 `archive` 只处理已关闭内容，`promote` 只输出提升到权威事实层的提案。
+
+`memory repair` 默认是零写入诊断，只为 partial initialization、可机械压缩的 core index、损坏或缺失的派生检索索引，
+以及具备完整 owner、proposal、目标与内容 digest 的中断事务分别生成独立 proposal。实际修复必须同时传入上次诊断得到的
+`--proposal <sha256:...> --yes`；任一目标变化都会使 proposal 失效。每项 proposal 都列出 authority、精确影响路径、
+backup/recovery path、前置条件、风险和 verifier。它没有通用 `clean`：unknown files、无 owner identity 的 marker/backup、
+普通 validation failure 与 failed sidecar 只报告 `inconclusive`，不会删除或猜测修复。active locks 会拒绝操作；只有 typed
+lock 获取同一把锁时，底层锁实现才按其 owner/age 契约处理 stale locks，不提供宽泛 lock 清理命令。
 
 ### Memory Autopilot 的窄写入口
 

--- a/llms.txt
+++ b/llms.txt
@@ -138,8 +138,15 @@ unfinished work, or redacted evidence:
 ```bash
 node <harness-path>/bin/harness.mjs init project <absolute-project-path>
 node <harness-path>/bin/harness.mjs memory check <absolute-project-path>
+node <harness-path>/bin/harness.mjs memory repair <absolute-project-path> --json
 node <harness-path>/bin/harness.mjs validate --project <absolute-project-path>
 ```
+
+`memory repair` is diagnose-only by default. Apply exactly one content-bound repair with both
+`--proposal <sha256:...> --yes`; never substitute a generic clean command. Unknown files, ownerless markers or
+backups, failed sidecars without a typed transaction, and unclassified validation failures remain unchanged and
+`inconclusive`. A repair must report exact paths, authority, backup/recovery, risk, prerequisites, and an independent
+verifier. Active locks fail closed; stale locks are handled only by the typed lock acquisition contract.
 
 If project-memory need is uncertain, ask the user. Do not initialize `.agent-docs` merely because the command
 exists. Initialization creates `.agent-docs/.gitignore` and `.agent-docs/.ignore` with `*`; it does not modify

--- a/src/__tests__/memory-repair-docs.test.ts
+++ b/src/__tests__/memory-repair-docs.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'vitest';
+
+const root = process.cwd();
+
+test('public repair guidance preserves proposal, identity, rollback, and verifier boundaries', () => {
+  const runtimeCli = readFileSync(join(root, 'docs/reference/runtime-cli.md'), 'utf8');
+  const architecture = readFileSync(
+    join(root, 'template/agent-harness/docs/core/harness-cli-architecture.md'),
+    'utf8',
+  );
+  const llms = readFileSync(join(root, 'llms.txt'), 'utf8');
+  const combined = [runtimeCli, architecture, llms].join('\n');
+
+  assert.match(
+    combined,
+    /diagnose-only.*content-bound proposal.*explicit apply.*independent verifier/is,
+  );
+  assert.match(combined, /authority.*精确.*路径.*backup.*risk.*verifier/is);
+  assert.match(combined, /--proposal.*--yes/is);
+  assert.match(combined, /unknown files.*ownerless.*inconclusive/is);
+  assert.match(combined, /active locks?.*stale locks?.*typed lock/is);
+  assert.match(
+    combined,
+    /partial initialization.*core.*derived.*orphan marker.*transaction restore/is,
+  );
+  assert.doesNotMatch(combined, /generic clean command is permitted/i);
+});

--- a/template/agent-harness/docs/core/harness-cli-architecture.md
+++ b/template/agent-harness/docs/core/harness-cli-architecture.md
@@ -133,6 +133,15 @@ Memory maintenance 遵循非权威边界：`migrate` 默认只输出 proposal，
 仍被 active index 引用的记忆，`promote` 只输出 proposal。`check --indexed` 要求 active/blocked
 文档可从 index 到达，`maintain` 只读报告候选。Runtime 不得自动写项目正式文档或删除记忆。
 
+`memory repair` 采用 diagnose-only → content-bound proposal → explicit apply → independent verifier。partial
+initialization、core index 压缩、derived search reindex、exact orphan marker 清理和 interrupted transaction restore
+是不同 action，不能由一个通用 clean 混合执行。proposal 声明 authority、精确路径、backup/recovery、前置条件、风险与
+verifier；apply 必须同时提供精确 `--proposal` 与 `--yes`，并复用 runtime identity、SafePath、memory/search lock、
+atomic write 与 rollback。core mutation 先写 owner/proposal/before-after digest 绑定的 journal 和 byte backup；只对完整匹配
+的自有 marker 生成清理或恢复 proposal。unknown files、ownerless backup、身份不完整 marker、failed sidecar 与无法机械归类的
+validation failure 保留并报告 `inconclusive`。active locks 直接拒绝；stale locks 只由同一 typed lock acquisition 按锁契约回收，
+不存在 glob 或宽泛 lock 删除入口。
+
 `memory promote` 输出 version 2 typed proposal，并由
 `schemas/memory-promotion.schema.json` 约束。调用方必须声明 ADR、docs、tests、schema、lint 或 CI
 目标类型、目标 owner、理由与精确 verifier；报告同时给出 source freshness、目标 dirty state、证据、授权缺口

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -68,7 +68,7 @@ entries:
   project-agent-docs:
     kind: standard
     path: standards/project-agent-docs.md
-    conceptAliases: [.agent-docs, project-memory, memory-policy, memory-writeback, high-value-analysis, session, evidence, handoff, acceptance, future-tasks, multi-stage, phase, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, secret-hygiene, host-evals, 项目记忆, 记忆沉淀, 记忆策略, 高价值内容, 只读任务, 会话, 验收, 未来所有任务, 以后所有任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 凭据卫生]
+    conceptAliases: [.agent-docs, project-memory, memory-policy, memory-writeback, high-value-analysis, session, evidence, handoff, acceptance, future-tasks, multi-stage, phase, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, memory-repair, repair-plan, secret-hygiene, host-evals, 项目记忆, 记忆沉淀, 记忆策略, 高价值内容, 只读任务, 会话, 验收, 未来所有任务, 以后所有任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 诊断修复, 修复提案, 凭据卫生]
   prompt-rule-contract:
     kind: standard
     path: standards/prompt-rule-contract.md

--- a/template/agent-harness/src/__tests__/memory-repair-failure.test.ts
+++ b/template/agent-harness/src/__tests__/memory-repair-failure.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { initProject } from '../commands/init.js';
+import { applyMemoryRepair, diagnoseMemoryRepair } from '../commands/memory-repair.js';
+import { repairJournalPaths } from '../lib/memory-repair-journal.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('repair never masks rollback failure and retains changed target plus exact recovery paths', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'harness-memory-repair-failure-'));
+  onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
+  const project = join(fixture, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(fixture);
+  initProject(runtime, project, capturedIo());
+  const memoryRoot = join(project, '.agent-docs');
+  const core = join(memoryRoot, 'core.md');
+  const original = readFileSync(core, 'utf8');
+  const entries: string[] = [];
+  mkdirSync(join(memoryRoot, 'working'), { recursive: true });
+  for (let index = 0; index < 70; index += 1) {
+    const name = `working/failure-${index}`;
+    writeFileSync(
+      join(memoryRoot, `${name}.md`),
+      `---\ntitle: Failure ${index}\ndescription: Repair failure fixture\ntype: working-note\nmemory-kind: working\nstatus: active\nowners: [test-owner]\ncreated: 2026-09-01\nupdated: 2026-09-01\nexpires: 2026-09-30\nproject: project\ntags: [repair]\nscope: []\nsource-refs: []\nsource-of-truth: false\nschema-version: 1\n---\n\n# Failure ${index}\n`,
+    );
+    entries.push(`- ${'long label '.repeat(36)}；memory:${name}`);
+  }
+  writeFileSync(
+    core,
+    original.replace('- <何时读取、能回答什么；创建后补充 memory 引用>', entries.join('\n')),
+  );
+  const proposal = diagnoseMemoryRepair(runtime, project, capturedIo()).proposals.find(
+    ({ action }) => action === 'compact-core-index',
+  );
+  assert.ok(proposal);
+  const journal = repairJournalPaths(runtime, proposal.proposalId);
+
+  assert.throws(
+    () =>
+      applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo(), {
+        beforeVerify: () => {
+          writeFileSync(core, 'concurrent user edit\n');
+          throw new Error('injected concurrent change');
+        },
+      }),
+    /rollback was incomplete.*recovery marker/is,
+  );
+
+  assert.equal(readFileSync(core, 'utf8'), 'concurrent user edit\n');
+  assert.equal(existsSync(journal.marker), true);
+  assert.equal(existsSync(journal.backup), true);
+  const followup = diagnoseMemoryRepair(runtime, project, capturedIo());
+  assert.ok(
+    followup.unresolved.some(
+      ({ fault, reasonCode }) =>
+        fault === 'repair-transaction' && reasonCode === 'REPAIR_TARGET_CHANGED',
+    ),
+  );
+  assert.equal(
+    followup.proposals.some(({ action }) => action === 'restore-interrupted-core-repair'),
+    false,
+  );
+});

--- a/template/agent-harness/src/__tests__/memory-repair-lock.test.ts
+++ b/template/agent-harness/src/__tests__/memory-repair-lock.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import lockfile from 'proper-lockfile';
+import { onTestFinished, test } from 'vitest';
+import { initProject } from '../commands/init.js';
+import { applyMemoryRepair, diagnoseMemoryRepair } from '../commands/memory-repair.js';
+import { canonicalPath } from '../lib/safe-path.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+test('repair rejects an active memory lock and reclaims only the exact stale lock through typed acquisition', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'harness-memory-repair-lock-'));
+  onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
+  const project = join(fixture, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(fixture);
+  initProject(runtime, project, capturedIo());
+  const memoryRoot = canonicalPath(join(project, '.agent-docs'));
+  rmSync(join(memoryRoot, 'README.md'));
+  const proposal = diagnoseMemoryRepair(runtime, project, capturedIo()).proposals.find(
+    ({ action }) => action === 'initialize-missing-memory',
+  );
+  assert.ok(proposal);
+
+  const release = lockfile.lockSync(memoryRoot, { realpath: false, retries: 0 });
+  try {
+    assert.throws(
+      () => applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo()),
+      /being updated by another process/i,
+    );
+  } finally {
+    release();
+  }
+
+  const staleLock = `${memoryRoot}.lock`;
+  mkdirSync(staleLock);
+  const old = new Date(Date.now() - 20 * 60_000);
+  utimesSync(staleLock, old, old);
+  const result = applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo());
+
+  assert.equal(result.verification.status, 'passed');
+  assert.equal(existsSync(staleLock), false);
+});
+
+test('repair bounds journal discovery and leaves oversized unknown state untouched', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'harness-memory-repair-journal-budget-'));
+  onTestFinished(() => rmSync(fixture, { recursive: true, force: true }));
+  const project = join(fixture, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(fixture);
+  initProject(runtime, project, capturedIo());
+  const journalRoot = join(runtime.installedHarness, 'state', 'repair');
+  mkdirSync(journalRoot, { recursive: true });
+  for (let index = 0; index < 257; index += 1) {
+    writeFileSync(join(journalRoot, `${index.toString(16).padStart(64, '0')}.backup`), 'unknown\n');
+  }
+
+  const report = diagnoseMemoryRepair(runtime, project, capturedIo());
+
+  assert.ok(
+    report.unresolved.some(
+      ({ reasonCode }) => reasonCode === 'REPAIR_JOURNAL_ENTRY_BUDGET_EXCEEDED',
+    ),
+  );
+  assert.equal(existsSync(join(journalRoot, `${'0'.repeat(64)}.backup`)), true);
+});

--- a/template/agent-harness/src/__tests__/memory-repair.test.ts
+++ b/template/agent-harness/src/__tests__/memory-repair.test.ts
@@ -1,0 +1,386 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { runCli } from '../cli.js';
+import { initProject } from '../commands/init.js';
+import {
+  applyMemoryRepair,
+  diagnoseMemoryRepair,
+  memoryRepair,
+} from '../commands/memory-repair.js';
+import { memoryCoreBudget } from '../lib/memory-core-budget.js';
+import { compactCoreContent, digest } from '../lib/memory-repair-contract.js';
+import {
+  cleanupRepairJournal,
+  type RepairMarker,
+  repairJournalPaths,
+} from '../lib/memory-repair-journal.js';
+import { canonicalPath } from '../lib/safe-path.js';
+import { searchIndexPath, searchWithIndex } from '../lib/search-index.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  return { root, project, runtime, memoryRoot: join(project, '.agent-docs') };
+}
+
+test('repair diagnosis is read-only and separates partial initialization from derived cache repair', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-plan-');
+  const readme = join(memoryRoot, 'README.md');
+  rmSync(readme);
+  const unknown = join(memoryRoot, 'unknown.txt');
+  writeFileSync(unknown, 'user-owned\n');
+  const before = JSON.stringify({ entries: readdirSync(memoryRoot).sort() });
+
+  const report = diagnoseMemoryRepair(runtime, project, capturedIo());
+
+  assert.equal(report.mode, 'diagnose-only');
+  assert.equal(report.mutation.status, 'unchanged');
+  assert.deepEqual(
+    report.proposals.map(({ action }) => action),
+    ['initialize-missing-memory', 'rebuild-derived-index'],
+  );
+  assert.deepEqual(report.proposals[0].affectedPaths, [canonicalPath(readme)]);
+  assert.equal(report.proposals[0].authority, 'managed-memory-template');
+  assert.equal(report.proposals[0].backup.required, false);
+  assert.equal(readFileSync(unknown, 'utf8'), 'user-owned\n');
+  assert.equal(JSON.stringify({ entries: readdirSync(memoryRoot).sort() }), before);
+  assert.equal(existsSync(readme), false);
+
+  assert.throws(
+    () =>
+      applyMemoryRepair(runtime, project, report.proposals[0].proposalId, capturedIo(), {
+        beforeVerify: () => {
+          throw new Error('injected initialization verifier failure');
+        },
+      }),
+    /injected initialization verifier failure/,
+  );
+  assert.equal(existsSync(readme), false);
+  const unindexed = join(memoryRoot, 'working', 'unindexed.md');
+  mkdirSync(join(memoryRoot, 'working'), { recursive: true });
+  assert.throws(
+    () =>
+      applyMemoryRepair(runtime, project, report.proposals[0].proposalId, capturedIo(), {
+        beforeVerify: () =>
+          writeFileSync(
+            unindexed,
+            '---\ntitle: Unindexed\ndescription: Repair verifier fixture\ntype: working-note\nmemory-kind: working\nstatus: active\nowners: [test-owner]\ncreated: 2026-09-01\nupdated: 2026-09-01\nexpires: 2026-09-30\nproject: project\ntags: [repair]\nscope: []\nsource-refs: []\nsource-of-truth: false\nschema-version: 1\n---\n\n# Unindexed\n',
+          ),
+      }),
+    /unindexed memories/i,
+  );
+  rmSync(unindexed);
+  const applied = applyMemoryRepair(runtime, project, report.proposals[0].proposalId, capturedIo());
+  assert.ok('verification' in applied);
+  assert.equal(applied.verification.status, 'passed');
+  assert.equal(existsSync(readme), true);
+  assert.equal(readFileSync(unknown, 'utf8'), 'user-owned\n');
+});
+
+test('repair CLI defaults to diagnosis and requires proposal plus confirmation for mutation', () => {
+  const { project, runtime } = fixture('harness-memory-repair-cli-');
+  const output = capturedIo();
+  assert.equal(runCli(['memory', 'repair', project, '--json'], { runtime, io: output }), 0);
+  assert.equal(JSON.parse(output.logs[0]).mode, 'diagnose-only');
+  assert.throws(
+    () => runCli(['memory', 'repair', project, '--yes', '--json'], { runtime, io: capturedIo() }),
+    /requires both --proposal.*--yes/i,
+  );
+});
+
+test('repair command renders bounded human-readable diagnosis and apply results', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-output-');
+  rmSync(join(memoryRoot, 'README.md'));
+  const diagnosisOutput = capturedIo();
+
+  const diagnosis = memoryRepair(runtime, project, {}, diagnosisOutput);
+
+  assert.equal(diagnosis.mode, 'diagnose-only');
+  assert.match(diagnosisOutput.logs.join('\n'), /initialize-missing-memory/);
+  assert.match(diagnosisOutput.logs.join('\n'), /target .*README\.md/);
+  assert.match(diagnosisOutput.logs.join('\n'), /verifier harness memory check/);
+  const proposal = diagnosis.proposals.find(({ action }) => action === 'initialize-missing-memory');
+  assert.ok(proposal);
+  const applyOutput = capturedIo();
+
+  const applied = memoryRepair(
+    runtime,
+    project,
+    { proposal: proposal.proposalId, yes: true },
+    applyOutput,
+  );
+
+  assert.ok('verification' in applied);
+  assert.equal(applied.verification.status, 'passed');
+  assert.deepEqual(applyOutput.logs, ['initialize-missing-memory: passed']);
+});
+
+test('repair applies one exact index proposal and independently verifies the rebuilt cache', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-index-');
+  const sources = [
+    {
+      root: memoryRoot,
+      label: 'memory',
+      trust: 'untrusted' as const,
+      excludeDirectories: ['_archive', 'host-evals'],
+    },
+  ];
+  searchWithIndex(runtime, 'memory', sources, { refreshIndex: true });
+  const index = searchIndexPath(runtime, sources);
+  writeFileSync(index, '{broken');
+  const unknown = join(memoryRoot, 'unknown.txt');
+  writeFileSync(unknown, 'preserve me\n');
+  const proposal = diagnoseMemoryRepair(runtime, project, capturedIo()).proposals.find(
+    ({ action }) => action === 'rebuild-derived-index',
+  );
+  assert.ok(proposal);
+
+  const result = applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo());
+
+  assert.equal(result.action, 'rebuild-derived-index');
+  assert.equal(result.verification.status, 'passed');
+  assert.equal(readFileSync(unknown, 'utf8'), 'preserve me\n');
+  assert.doesNotThrow(() => searchWithIndex(runtime, 'memory', sources, { mode: 'fulltext' }));
+  assert.throws(
+    () => applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo()),
+    /proposal.*changed/i,
+  );
+});
+
+test('core repair compacts only canonical index labels and rolls back injected verifier failure', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-core-');
+  const core = join(memoryRoot, 'core.md');
+  const original = readFileSync(core, 'utf8');
+  const entries: string[] = [];
+  for (let index = 0; index < 90; index += 1) {
+    const name = `working/repair-${index}`;
+    mkdirSync(join(memoryRoot, 'working'), { recursive: true });
+    writeFileSync(
+      join(memoryRoot, `${name}.md`),
+      `---\ntitle: Repair ${index}\ndescription: Repair fixture\ntype: working-note\nmemory-kind: working\nstatus: active\nowners: [test-owner]\ncreated: 2026-09-01\nupdated: 2026-09-01\nexpires: 2026-09-30\nproject: project\ntags: [repair]\nscope: []\nsource-refs: []\nsource-of-truth: false\nschema-version: 1\n---\n\n# Repair ${index}\n`,
+    );
+    entries.push(`- ${'bounded label '.repeat(18)}；memory:${name}`);
+  }
+  writeFileSync(
+    core,
+    original.replace('- <何时读取、能回答什么；创建后补充 memory 引用>', entries.join('\n')),
+  );
+  assert.notEqual(memoryCoreBudget(readFileSync(core, 'utf8')).status, 'ok');
+  const proposal = diagnoseMemoryRepair(runtime, project, capturedIo()).proposals.find(
+    ({ action }) => action === 'compact-core-index',
+  );
+  assert.ok(proposal);
+  const oversized = readFileSync(core, 'utf8');
+
+  assert.throws(
+    () =>
+      applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo(), {
+        beforeVerify: () => {
+          throw new Error('injected verifier failure');
+        },
+      }),
+    /injected verifier failure/,
+  );
+  assert.equal(readFileSync(core, 'utf8'), oversized);
+
+  const result = applyMemoryRepair(runtime, project, proposal.proposalId, capturedIo());
+  assert.equal(result.verification.status, 'passed');
+  assert.equal(memoryCoreBudget(readFileSync(core, 'utf8')).status, 'ok');
+  assert.match(readFileSync(core, 'utf8'), /- memory:working\/repair-0/);
+});
+
+test('repair clears only an exact owned orphan marker and retains unverified markers', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-orphan-');
+  const root = canonicalPath(memoryRoot);
+  const target = join(root, 'core.md');
+  const original = readFileSync(target, 'utf8');
+  const proposalId = `sha256:${'a'.repeat(64)}`;
+  const journal = repairJournalPaths(runtime, proposalId);
+  mkdirSync(journal.root, { recursive: true });
+  writeFileSync(journal.backup, original, { mode: 0o600 });
+  writeFileSync(
+    journal.marker,
+    `${JSON.stringify({
+      version: 1,
+      owner: runtime.owner,
+      proposalId,
+      action: 'compact-core-index',
+      stage: 'prepared',
+      root,
+      target,
+      backup: journal.backup,
+      beforeDigest: digest(original),
+      afterDigest: digest(compactCoreContent(original)),
+      mode: 0o644,
+      createdAt: '2026-09-01T00:00:00.000Z',
+    })}\n`,
+  );
+  const unknown = join(journal.root, 'unknown.json');
+  writeFileSync(unknown, '{"owner":"somebody-else"}\n');
+  const ownerlessBackup = join(journal.root, `${'c'.repeat(64)}.backup`);
+  writeFileSync(ownerlessBackup, 'ownerless\n');
+  assert.throws(() => repairJournalPaths(runtime, 'invalid'), /invalid repair proposal id/i);
+  const report = diagnoseMemoryRepair(runtime, project, capturedIo());
+  const cleanup = report.proposals.find(({ action }) => action === 'clear-orphan-repair-marker');
+  assert.ok(cleanup);
+  assert.ok(
+    report.unresolved.some(
+      ({ fault, reasonCode }) =>
+        fault === 'repair-transaction' && reasonCode === 'REPAIR_MARKER_IDENTITY_UNVERIFIED',
+    ),
+  );
+  assert.ok(
+    report.unresolved.some(
+      ({ fault, reasonCode }) =>
+        fault === 'repair-transaction' && reasonCode === 'OWNERLESS_REPAIR_BACKUP_RETAINED',
+    ),
+  );
+
+  const result = applyMemoryRepair(runtime, project, cleanup.proposalId, capturedIo());
+
+  assert.equal(result.verification.status, 'passed');
+  assert.equal(existsSync(journal.marker), false);
+  assert.equal(existsSync(journal.backup), false);
+  assert.equal(readFileSync(target, 'utf8'), original);
+  assert.equal(readFileSync(unknown, 'utf8'), '{"owner":"somebody-else"}\n');
+  assert.equal(readFileSync(ownerlessBackup, 'utf8'), 'ownerless\n');
+});
+
+test('repair retains owned journals when exact path or backup digest verification fails', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-unverified-journal-');
+  const root = canonicalPath(memoryRoot);
+  const target = join(root, 'core.md');
+  const original = readFileSync(target, 'utf8');
+  const createMarker = (identity: string, overrides: Record<string, unknown> = {}) => {
+    const proposalId = `sha256:${identity.repeat(64)}`;
+    const journal = repairJournalPaths(runtime, proposalId);
+    mkdirSync(journal.root, { recursive: true });
+    writeFileSync(journal.backup, original, { mode: 0o600 });
+    writeFileSync(
+      journal.marker,
+      `${JSON.stringify({
+        version: 1,
+        owner: runtime.owner,
+        proposalId,
+        action: 'compact-core-index',
+        stage: 'prepared',
+        root,
+        target,
+        backup: journal.backup,
+        beforeDigest: digest(original),
+        afterDigest: digest(compactCoreContent(original)),
+        mode: 0o644,
+        createdAt: '2026-09-01T00:00:00.000Z',
+        ...overrides,
+      })}\n`,
+    );
+    return journal;
+  };
+  const wrongTarget = createMarker('d', { target: join(root, 'README.md') });
+  const changedBackup = createMarker('e');
+  writeFileSync(changedBackup.backup, 'changed backup\n');
+
+  const report = diagnoseMemoryRepair(runtime, project, capturedIo());
+
+  assert.equal(
+    report.unresolved.filter(({ reasonCode }) => reasonCode === 'REPAIR_MARKER_CONTENT_UNVERIFIED')
+      .length,
+    2,
+  );
+  assert.equal(existsSync(wrongTarget.marker), true);
+  assert.equal(existsSync(wrongTarget.backup), true);
+  assert.equal(existsSync(changedBackup.marker), true);
+  assert.equal(existsSync(changedBackup.backup), true);
+});
+
+test('repair journal cleanup refuses changed recovery evidence', () => {
+  const { runtime, memoryRoot } = fixture('harness-memory-repair-cleanup-evidence-');
+  const root = canonicalPath(memoryRoot);
+  const target = join(root, 'core.md');
+  const original = readFileSync(target, 'utf8');
+  const proposalId = `sha256:${'f'.repeat(64)}`;
+  const journal = repairJournalPaths(runtime, proposalId);
+  mkdirSync(journal.root, { recursive: true });
+  const marker: RepairMarker = {
+    version: 1,
+    owner: runtime.owner,
+    proposalId,
+    action: 'compact-core-index',
+    stage: 'prepared',
+    root,
+    target,
+    backup: journal.backup,
+    beforeDigest: digest(original),
+    afterDigest: digest(compactCoreContent(original)),
+    mode: 0o644,
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+  writeFileSync(journal.backup, 'changed backup\n', { mode: 0o600 });
+  writeFileSync(journal.marker, `${JSON.stringify(marker)}\n`);
+  assert.throws(() => cleanupRepairJournal(marker), /backup changed/i);
+  writeFileSync(journal.backup, original, { mode: 0o600 });
+  writeFileSync(journal.marker, `${JSON.stringify({ ...marker, stage: 'mutated' })}\n`);
+
+  assert.throws(() => cleanupRepairJournal(marker), /marker changed/i);
+  assert.equal(existsSync(journal.marker), true);
+  assert.equal(existsSync(journal.backup), true);
+});
+
+test('repair restores an interrupted core mutation only when marker, backup, and target digests match', () => {
+  const { project, runtime, memoryRoot } = fixture('harness-memory-repair-restore-');
+  const root = canonicalPath(memoryRoot);
+  const target = join(root, 'core.md');
+  const original = readFileSync(target, 'utf8');
+  const mutated = original.replace('# Project Memory Index', '# Project Memory Index\n');
+  writeFileSync(target, mutated);
+  const proposalId = `sha256:${'b'.repeat(64)}`;
+  const journal = repairJournalPaths(runtime, proposalId);
+  mkdirSync(journal.root, { recursive: true });
+  writeFileSync(journal.backup, original, { mode: 0o600 });
+  writeFileSync(
+    journal.marker,
+    `${JSON.stringify({
+      version: 1,
+      owner: runtime.owner,
+      proposalId,
+      action: 'compact-core-index',
+      stage: 'mutated',
+      root,
+      target,
+      backup: journal.backup,
+      beforeDigest: digest(original),
+      afterDigest: digest(mutated),
+      mode: 0o644,
+      createdAt: '2026-09-01T00:00:00.000Z',
+    })}\n`,
+  );
+  const recovery = diagnoseMemoryRepair(runtime, project, capturedIo()).proposals.find(
+    ({ action }) => action === 'restore-interrupted-core-repair',
+  );
+  assert.ok(recovery);
+
+  const result = applyMemoryRepair(runtime, project, recovery.proposalId, capturedIo());
+
+  assert.equal(result.verification.status, 'passed');
+  assert.equal(readFileSync(target, 'utf8'), original);
+  assert.equal(existsSync(journal.marker), false);
+  assert.equal(existsSync(journal.backup), false);
+});

--- a/template/agent-harness/src/commands/memory-repair.ts
+++ b/template/agent-harness/src/commands/memory-repair.ts
@@ -1,0 +1,29 @@
+import { applyMemoryRepair } from '../lib/memory-repair-apply.js';
+import { diagnoseMemoryRepair } from '../lib/memory-repair-plan.js';
+import type { Io, Runtime } from '../types.js';
+
+export { applyMemoryRepair, diagnoseMemoryRepair };
+
+export function memoryRepair(
+  runtime: Runtime,
+  scope: string,
+  options: { proposal?: string; yes?: boolean; json?: boolean },
+  io: Io = console,
+) {
+  if ((options.proposal && !options.yes) || (options.yes && !options.proposal)) {
+    throw new Error('Repair apply requires both --proposal <id> and --yes');
+  }
+  const result =
+    options.proposal && options.yes
+      ? applyMemoryRepair(runtime, scope, options.proposal, io)
+      : diagnoseMemoryRepair(runtime, scope, io);
+  if (options.json) io.log(JSON.stringify(result, null, 2));
+  else if ('proposals' in result) {
+    for (const candidate of result.proposals) {
+      io.log(`${candidate.action} ${candidate.proposalId}`);
+      for (const path of candidate.affectedPaths) io.log(`  target ${path}`);
+      io.log(`  verifier ${candidate.verifier.command}`);
+    }
+  } else io.log(`${result.action}: ${result.verification.status}`);
+  return result;
+}

--- a/template/agent-harness/src/lib/memory-repair-apply.ts
+++ b/template/agent-harness/src/lib/memory-repair-apply.ts
@@ -1,0 +1,73 @@
+import { assertRuntimeCanMutate, calendarDate } from '../runtime.js';
+import type { Io, Runtime } from '../types.js';
+import { withGlobalMemoryTransaction } from './global-memory.js';
+import { memoryMaintenanceReport } from './memory-maintenance.js';
+import { type ApplyOptions, memorySources, repairContext } from './memory-repair-contract.js';
+import { diagnoseMemoryRepair } from './memory-repair-plan.js';
+import {
+  applyCoreRepairTransaction,
+  applyJournalRecovery,
+  discoverRepairJournals,
+} from './memory-repair-transaction.js';
+import { validateMemoryRoot } from './memory-validation.js';
+
+function verifyIndexedMemory(
+  runtime: Runtime,
+  root: string,
+  rootKind: 'global' | 'project',
+  io: Io,
+): void {
+  validateMemoryRoot(root, io, { quietSuccess: true, rootKind });
+  const maintenance = memoryMaintenanceReport(root, calendarDate(runtime));
+  if (maintenance.unindexed.length > 0) {
+    throw new Error(`Repair verifier found ${maintenance.unindexed.length} unindexed memories`);
+  }
+}
+
+import { withProjectMemoryTransaction } from './project-memory.js';
+import { loadCurrentIndex, refreshSearchIndex } from './search-index-store.js';
+
+export function applyMemoryRepair(
+  runtime: Runtime,
+  scope: string,
+  proposalId: string,
+  io: Io = console,
+  options: ApplyOptions = {},
+) {
+  assertRuntimeCanMutate(runtime);
+  const report = diagnoseMemoryRepair(runtime, scope, io);
+  const selected = report.proposals.find((candidate) => candidate.proposalId === proposalId);
+  if (!selected) throw new Error('Repair proposal changed or is no longer applicable');
+  const { rootKind } = repairContext(runtime, scope);
+  if (selected.action === 'initialize-missing-memory') {
+    const verify = () => {
+      options.beforeVerify?.();
+      verifyIndexedMemory(runtime, report.root, rootKind, io);
+    };
+    if (rootKind === 'global') withGlobalMemoryTransaction(runtime, verify);
+    else withProjectMemoryTransaction(runtime, scope, verify);
+  } else if (selected.action === 'rebuild-derived-index') {
+    const sources = memorySources(report.root);
+    refreshSearchIndex(runtime, sources, {});
+    options.beforeVerify?.();
+    loadCurrentIndex(runtime, sources, {});
+  } else if (selected.action === 'compact-core-index') {
+    applyCoreRepairTransaction(runtime, selected, rootKind, io, options);
+  } else {
+    const markerPath = selected.affectedPaths.find((path) => path.endsWith('.json'));
+    const journal = discoverRepairJournals(runtime, report.root).find(
+      ({ marker }) => marker === markerPath,
+    );
+    if (!journal) throw new Error('Repair recovery proposal changed');
+    applyJournalRecovery(runtime, journal, rootKind, io);
+  }
+  return {
+    version: 1 as const,
+    mode: 'applied' as const,
+    proposalId,
+    action: selected.action,
+    affectedPaths: selected.affectedPaths,
+    verification: { status: 'passed' as const, command: selected.verifier.command, exitCode: 0 },
+    recovery: selected.backup,
+  };
+}

--- a/template/agent-harness/src/lib/memory-repair-contract.ts
+++ b/template/agent-harness/src/lib/memory-repair-contract.ts
@@ -1,0 +1,117 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Io, Runtime } from '../types.js';
+import { resolveMemoryRoot } from './memory-path.js';
+import { validateMemoryRoot } from './memory-validation.js';
+import { sameCanonicalPath } from './safe-path.js';
+import type { SearchSource } from './search.js';
+
+export type RepairAction =
+  | 'initialize-missing-memory'
+  | 'compact-core-index'
+  | 'rebuild-derived-index'
+  | 'clear-orphan-repair-marker'
+  | 'restore-interrupted-core-repair';
+
+export interface RepairProposal {
+  proposalId: string;
+  action: RepairAction;
+  authority: string;
+  affectedPaths: string[];
+  backup: { required: boolean; strategy: string; recoveryPaths: string[] };
+  prerequisites: string[];
+  risk: 'low' | 'medium';
+  verifier: { command: string; owner: 'harness'; expected: string };
+  diagnosis: { status: string; reasonCode: string };
+}
+
+export interface MemoryRepairReport {
+  version: 1;
+  mode: 'diagnose-only';
+  scope: string;
+  root: string;
+  mutation: { status: 'unchanged'; reasonCode: 'diagnose-only' };
+  proposals: RepairProposal[];
+  unresolved: Array<{
+    fault: 'memory-validation' | 'repair-transaction';
+    status: 'inconclusive';
+    reasonCode: string;
+    diagnostics: string[];
+  }>;
+}
+
+export interface ApplyOptions {
+  beforeVerify?: () => void;
+}
+
+export function digest(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function fileIdentity(path: string): object {
+  if (!existsSync(path)) return { exists: false };
+  const entry = lstatSync(path);
+  return {
+    exists: true,
+    kind: entry.isFile() && !entry.isSymbolicLink() ? 'file' : 'unsafe',
+    dev: entry.dev,
+    ino: entry.ino,
+    size: entry.size,
+    mtimeMs: entry.mtimeMs,
+    ctimeMs: entry.ctimeMs,
+  };
+}
+
+export function memorySources(root: string): SearchSource[] {
+  return [
+    {
+      root,
+      label: 'memory',
+      trust: 'untrusted',
+      excludeDirectories: ['_archive', 'host-evals'],
+    },
+  ];
+}
+
+export function repairProposal(
+  action: RepairAction,
+  fields: Omit<RepairProposal, 'proposalId' | 'action'>,
+  binding: object,
+): RepairProposal {
+  const proposalId = `sha256:${digest(JSON.stringify({ version: 1, action, fields, binding }))}`;
+  return { proposalId, action, ...fields };
+}
+
+export function repairContext(runtime: Runtime, scope: string) {
+  const root = resolveMemoryRoot(runtime, scope);
+  const rootKind = sameCanonicalPath(root, runtime.memoryHome) ? 'global' : 'project';
+  const required = [
+    join(root, 'README.md'),
+    join(root, 'core.md'),
+    ...(rootKind === 'global' ? [join(root, 'profile.md')] : []),
+  ];
+  return { root, rootKind, required } as const;
+}
+
+export function compactCoreContent(content: string): string {
+  return content
+    .split(/(?<=\n)/u)
+    .map((line) => {
+      const references = [...line.matchAll(/memory:([A-Za-z0-9_./-]+)/g)];
+      if (!line.startsWith('- ') || references.length !== 1) return line;
+      return `- memory:${references[0][1]}${line.endsWith('\n') ? '\n' : ''}`;
+    })
+    .join('');
+}
+
+export function validationDiagnostics(root: string, rootKind: 'global' | 'project', _io: Io) {
+  const diagnostics: string[] = [];
+  const capture = (message: unknown = '') => diagnostics.push(String(message));
+  try {
+    validateMemoryRoot(root, { log: capture, error: capture }, { quietSuccess: true, rootKind });
+    return { valid: true as const, diagnostics };
+  } catch {
+    return { valid: false as const, diagnostics };
+  }
+}

--- a/template/agent-harness/src/lib/memory-repair-journal.ts
+++ b/template/agent-harness/src/lib/memory-repair-journal.ts
@@ -1,0 +1,195 @@
+import { existsSync, lstatSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Runtime } from '../types.js';
+import { atomicWrite } from './files.js';
+import { digest } from './memory-repair-contract.js';
+import { assertSafePath } from './safe-path.js';
+
+export interface RepairMarker {
+  version: 1;
+  owner: string;
+  proposalId: string;
+  action: 'compact-core-index';
+  stage: 'prepared' | 'mutated';
+  root: string;
+  target: string;
+  backup: string;
+  beforeDigest: string;
+  afterDigest: string;
+  mode: number;
+  createdAt: string;
+}
+
+export interface RepairJournalObservation {
+  marker: string;
+  backup: string;
+  status: 'orphan-prepared' | 'interrupted-mutation' | 'inconclusive';
+  reasonCode: string;
+  markerRecord?: RepairMarker;
+}
+
+function validProposalId(value: string): boolean {
+  return /^sha256:[0-9a-f]{64}$/.test(value);
+}
+
+export function repairJournalPaths(runtime: Runtime, proposalId: string) {
+  if (!validProposalId(proposalId)) throw new Error('Invalid repair proposal id');
+  const root = join(runtime.installedHarness, 'state', 'repair');
+  const identity = proposalId.slice('sha256:'.length);
+  const marker = join(root, `${identity}.json`);
+  const backup = join(root, `${identity}.backup`);
+  for (const path of [root, marker, backup]) assertSafePath(runtime.installedHarness, path);
+  return { root, marker, backup };
+}
+
+export function repairMarkerPath(marker: RepairMarker): string {
+  return join(marker.backup, '..', `${marker.proposalId.slice(7)}.json`);
+}
+
+function readRepairMarker(path: string): RepairMarker | null {
+  try {
+    const entry = lstatSync(path);
+    if (!entry.isFile() || entry.isSymbolicLink() || entry.size > 64 * 1024) return null;
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<RepairMarker>;
+    if (
+      value.version !== 1 ||
+      value.action !== 'compact-core-index' ||
+      !['prepared', 'mutated'].includes(value.stage || '') ||
+      typeof value.owner !== 'string' ||
+      typeof value.proposalId !== 'string' ||
+      !validProposalId(value.proposalId) ||
+      typeof value.root !== 'string' ||
+      typeof value.target !== 'string' ||
+      typeof value.backup !== 'string' ||
+      !/^[0-9a-f]{64}$/.test(value.beforeDigest || '') ||
+      !/^[0-9a-f]{64}$/.test(value.afterDigest || '') ||
+      !Number.isInteger(value.mode)
+    ) {
+      return null;
+    }
+    return value as RepairMarker;
+  } catch {
+    return null;
+  }
+}
+
+function regularRepairFileDigest(path: string): string | null {
+  try {
+    const entry = lstatSync(path);
+    if (!entry.isFile() || entry.isSymbolicLink() || entry.size > 2 * 1024 * 1024) return null;
+    return digest(readFileSync(path));
+  } catch {
+    return null;
+  }
+}
+
+function observeMarker(runtime: Runtime, root: string, markerPath: string) {
+  const marker = readRepairMarker(markerPath);
+  if (!marker || marker.owner !== runtime.owner || marker.root !== root) {
+    return {
+      marker: markerPath,
+      backup: marker?.backup || markerPath,
+      status: 'inconclusive' as const,
+      reasonCode: 'REPAIR_MARKER_IDENTITY_UNVERIFIED',
+    };
+  }
+  const paths = repairJournalPaths(runtime, marker.proposalId);
+  const pathsValid =
+    paths.marker === markerPath &&
+    paths.backup === marker.backup &&
+    marker.target === join(root, 'core.md');
+  if (!pathsValid) {
+    return {
+      marker: markerPath,
+      backup: marker.backup,
+      status: 'inconclusive' as const,
+      reasonCode: 'REPAIR_MARKER_CONTENT_UNVERIFIED',
+      markerRecord: marker,
+    };
+  }
+  const targetDigest = regularRepairFileDigest(marker.target);
+  const backupDigest = regularRepairFileDigest(marker.backup);
+  if (backupDigest !== marker.beforeDigest) {
+    return {
+      marker: markerPath,
+      backup: marker.backup,
+      status: 'inconclusive' as const,
+      reasonCode: 'REPAIR_MARKER_CONTENT_UNVERIFIED',
+      markerRecord: marker,
+    };
+  }
+  if (marker.stage === 'prepared' && targetDigest === marker.beforeDigest) {
+    return {
+      marker: markerPath,
+      backup: marker.backup,
+      status: 'orphan-prepared' as const,
+      reasonCode: 'PREPARED_REPAIR_NOT_MUTATED',
+      markerRecord: marker,
+    };
+  }
+  if (marker.stage === 'mutated' && targetDigest === marker.afterDigest) {
+    return {
+      marker: markerPath,
+      backup: marker.backup,
+      status: 'interrupted-mutation' as const,
+      reasonCode: 'MUTATED_REPAIR_NOT_FINALIZED',
+      markerRecord: marker,
+    };
+  }
+  return {
+    marker: markerPath,
+    backup: marker.backup,
+    status: 'inconclusive' as const,
+    reasonCode: 'REPAIR_TARGET_CHANGED',
+    markerRecord: marker,
+  };
+}
+
+export function discoverRepairJournals(runtime: Runtime, root: string): RepairJournalObservation[] {
+  const journalRoot = join(runtime.installedHarness, 'state', 'repair');
+  if (!existsSync(journalRoot)) return [];
+  assertSafePath(runtime.installedHarness, journalRoot);
+  const names = readdirSync(journalRoot).sort();
+  if (names.length > 256) {
+    return [
+      {
+        marker: journalRoot,
+        backup: journalRoot,
+        status: 'inconclusive',
+        reasonCode: 'REPAIR_JOURNAL_ENTRY_BUDGET_EXCEEDED',
+      },
+    ];
+  }
+  const markers = names
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => observeMarker(runtime, root, join(journalRoot, name)));
+  const orphanBackups = names
+    .filter(
+      (name) =>
+        /^[0-9a-f]{64}\.backup$/.test(name) &&
+        !names.includes(`${name.slice(0, -'.backup'.length)}.json`),
+    )
+    .map((name) => ({
+      marker: join(journalRoot, name),
+      backup: join(journalRoot, name),
+      status: 'inconclusive' as const,
+      reasonCode: 'OWNERLESS_REPAIR_BACKUP_RETAINED',
+    }));
+  return [...markers, ...orphanBackups];
+}
+
+export function writeRepairMarker(path: string, marker: RepairMarker): void {
+  atomicWrite(path, `${JSON.stringify(marker, null, 2)}\n`, 0o600);
+}
+
+export function cleanupRepairJournal(marker: RepairMarker): void {
+  if (regularRepairFileDigest(marker.backup) !== marker.beforeDigest) {
+    throw new Error(`Repair backup changed; retained at recovery path ${marker.backup}`);
+  }
+  const current = readRepairMarker(repairMarkerPath(marker));
+  if (!current || JSON.stringify(current) !== JSON.stringify(marker)) {
+    throw new Error('Repair marker changed; retained for inspection');
+  }
+  rmSync(marker.backup);
+  rmSync(repairMarkerPath(marker));
+}

--- a/template/agent-harness/src/lib/memory-repair-plan.ts
+++ b/template/agent-harness/src/lib/memory-repair-plan.ts
@@ -1,0 +1,202 @@
+import { existsSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Io, Runtime } from '../types.js';
+import { memoryCoreBudget } from './memory-core-budget.js';
+import { readMemoryDocument } from './memory-path.js';
+import {
+  compactCoreContent,
+  digest,
+  fileIdentity,
+  type MemoryRepairReport,
+  memorySources,
+  type RepairProposal,
+  repairContext,
+  repairProposal,
+  validationDiagnostics,
+} from './memory-repair-contract.js';
+import {
+  discoverRepairJournals,
+  type RepairJournalObservation,
+} from './memory-repair-transaction.js';
+import { assertSafePath } from './safe-path.js';
+import { searchIndexPath } from './search-index.js';
+import { loadCurrentIndex } from './search-index-store.js';
+
+function initializationProposal(
+  runtime: Runtime,
+  scope: string,
+  required: string[],
+): RepairProposal | null {
+  const missing = required.filter((path) => !existsSync(path));
+  if (missing.length === 0) return null;
+  return repairProposal(
+    'initialize-missing-memory',
+    {
+      authority: 'managed-memory-template',
+      affectedPaths: missing,
+      backup: {
+        required: false,
+        strategy: 'create-missing-only-with-transaction-rollback',
+        recoveryPaths: missing,
+      },
+      prerequisites: ['runtime-identity-valid', 'memory-lock-available'],
+      risk: 'low',
+      verifier: {
+        command: `harness memory check ${scope} --indexed --json`,
+        owner: 'harness',
+        expected: 'exit 0',
+      },
+      diagnosis: { status: 'failed', reasonCode: 'PARTIAL_INITIALIZATION' },
+    },
+    { owner: runtime.owner, paths: required.map((path) => [path, fileIdentity(path)]) },
+  );
+}
+
+function coreProposal(root: string, scope: string): RepairProposal | null {
+  const core = join(root, 'core.md');
+  if (!existsSync(core)) return null;
+  assertSafePath(root, core);
+  const content = readMemoryDocument(core);
+  const budget = memoryCoreBudget(content);
+  const candidate = compactCoreContent(content);
+  if (
+    budget.status === 'ok' ||
+    candidate === content ||
+    memoryCoreBudget(candidate).status !== 'ok'
+  ) {
+    return null;
+  }
+  return repairProposal(
+    'compact-core-index',
+    {
+      authority: 'managed-core-index',
+      affectedPaths: [core],
+      backup: {
+        required: true,
+        strategy: 'exact-byte-and-mode-transaction-snapshot',
+        recoveryPaths: [core],
+      },
+      prerequisites: ['runtime-identity-valid', 'memory-lock-available', 'candidate-valid'],
+      risk: 'medium',
+      verifier: {
+        command: `harness memory check ${scope} --indexed --json`,
+        owner: 'harness',
+        expected: 'exit 0 and core budget ok',
+      },
+      diagnosis: { status: 'failed', reasonCode: `CORE_${budget.status.toUpperCase()}` },
+    },
+    { contentDigest: digest(content), mode: lstatSync(core).mode & 0o777 },
+  );
+}
+
+function indexProposal(runtime: Runtime, root: string, scope: string): RepairProposal | null {
+  const sources = memorySources(root);
+  const index = searchIndexPath(runtime, sources);
+  let status = 'ready';
+  try {
+    loadCurrentIndex(runtime, sources, {});
+  } catch (error) {
+    status =
+      error && typeof error === 'object' && 'status' in error
+        ? String((error as { status: unknown }).status)
+        : 'corrupt';
+  }
+  if (status === 'ready') return null;
+  return repairProposal(
+    'rebuild-derived-index',
+    {
+      authority: 'derived-search-cache',
+      affectedPaths: [index],
+      backup: {
+        required: false,
+        strategy: 'derived-cache-atomic-replacement',
+        recoveryPaths: [],
+      },
+      prerequisites: ['runtime-identity-valid', 'search-index-lock-available'],
+      risk: 'low',
+      verifier: {
+        command: `harness memory search ${scope} __repair_probe__ --mode fulltext --json`,
+        owner: 'harness',
+        expected: 'index loads without fallback',
+      },
+      diagnosis: { status: 'failed', reasonCode: `DERIVED_INDEX_${status.toUpperCase()}` },
+    },
+    { index: fileIdentity(index), root: fileIdentity(root) },
+  );
+}
+
+function journalProposal(observation: RepairJournalObservation): RepairProposal | null {
+  if (observation.status === 'inconclusive') return null;
+  const restoring = observation.status === 'interrupted-mutation';
+  return repairProposal(
+    restoring ? 'restore-interrupted-core-repair' : 'clear-orphan-repair-marker',
+    {
+      authority: 'verified-repair-transaction-marker',
+      affectedPaths: restoring
+        ? [observation.markerRecord?.target || '', observation.marker, observation.backup]
+        : [observation.marker, observation.backup],
+      backup: {
+        required: restoring,
+        strategy: restoring ? 'verified-journal-byte-backup' : 'verified-unmutated-target',
+        recoveryPaths: restoring ? [observation.backup] : [],
+      },
+      prerequisites: ['runtime-owner-match', 'repair-journal-lock-available', 'digest-match'],
+      risk: restoring ? 'medium' : 'low',
+      verifier: {
+        command: 'harness memory check <scope> --indexed --json',
+        owner: 'harness',
+        expected: restoring ? 'exit 0 and original bytes restored' : 'marker and backup absent',
+      },
+      diagnosis: { status: 'failed', reasonCode: observation.reasonCode },
+    },
+    {
+      marker: fileIdentity(observation.marker),
+      backup: fileIdentity(observation.backup),
+      target: observation.markerRecord ? fileIdentity(observation.markerRecord.target) : null,
+    },
+  );
+}
+
+export function diagnoseMemoryRepair(
+  runtime: Runtime,
+  scope = '.',
+  io: Io = console,
+): MemoryRepairReport {
+  const { root, rootKind, required } = repairContext(runtime, scope);
+  const journals = discoverRepairJournals(runtime, root);
+  const proposals = [
+    ...journals.map(journalProposal),
+    initializationProposal(runtime, scope, required),
+    coreProposal(root, scope),
+    indexProposal(runtime, root, scope),
+  ].filter((candidate): candidate is RepairProposal => candidate !== null);
+  const unresolved: MemoryRepairReport['unresolved'] = [];
+  for (const journal of journals.filter(({ status }) => status === 'inconclusive')) {
+    unresolved.push({
+      fault: 'repair-transaction',
+      status: 'inconclusive',
+      reasonCode: journal.reasonCode,
+      diagnostics: [journal.marker],
+    });
+  }
+  if (required.every(existsSync) && existsSync(root)) {
+    const validation = validationDiagnostics(root, rootKind, io);
+    if (!validation.valid) {
+      unresolved.push({
+        fault: 'memory-validation',
+        status: 'inconclusive',
+        reasonCode: 'NO_TYPED_AUTOMATIC_REPAIR',
+        diagnostics: validation.diagnostics,
+      });
+    }
+  }
+  return {
+    version: 1,
+    mode: 'diagnose-only',
+    scope,
+    root,
+    mutation: { status: 'unchanged', reasonCode: 'diagnose-only' },
+    proposals,
+    unresolved,
+  };
+}

--- a/template/agent-harness/src/lib/memory-repair-transaction.ts
+++ b/template/agent-harness/src/lib/memory-repair-transaction.ts
@@ -1,0 +1,193 @@
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { calendarDate } from '../runtime.js';
+import type { Io, Runtime } from '../types.js';
+import { withExclusiveDirectoryLock } from './exclusive-lock.js';
+import { atomicWrite } from './files.js';
+import { memoryCoreBudget } from './memory-core-budget.js';
+import { withMemoryLock } from './memory-lock.js';
+import { memoryMaintenanceReport } from './memory-maintenance.js';
+import { readMemoryDocument } from './memory-path.js';
+import {
+  type ApplyOptions,
+  compactCoreContent,
+  digest,
+  type RepairProposal,
+} from './memory-repair-contract.js';
+import {
+  cleanupRepairJournal,
+  discoverRepairJournals,
+  type RepairJournalObservation,
+  type RepairMarker,
+  repairJournalPaths,
+  repairMarkerPath,
+  writeRepairMarker,
+} from './memory-repair-journal.js';
+import { validateMemoryRoot } from './memory-validation.js';
+import {
+  assertExactFileState,
+  type ExactFileState,
+  exactFileStateMatches,
+  restoreExactFileState,
+} from './memory-write.js';
+import { assertSafePath } from './safe-path.js';
+
+export type { RepairJournalObservation } from './memory-repair-journal.js';
+export { discoverRepairJournals } from './memory-repair-journal.js';
+
+function rollbackCore(
+  root: string,
+  path: string,
+  before: ExactFileState,
+  attempted: ExactFileState,
+  error: unknown,
+  marker: RepairMarker,
+): never {
+  const rollbackError = restoreExactFileState(root, path, before, attempted);
+  if (rollbackError) {
+    throw new Error(
+      `Core repair failed and rollback was incomplete: ${String(error)}; ${rollbackError}; recovery marker ${repairMarkerPath(marker)}`,
+      { cause: error instanceof Error ? error : undefined },
+    );
+  }
+  cleanupRepairJournal(marker);
+  throw error;
+}
+
+function coreMarker(
+  runtime: Runtime,
+  proposal: RepairProposal,
+  root: string,
+  path: string,
+  backup: string,
+  before: ExactFileState,
+  attempted: ExactFileState,
+): RepairMarker {
+  return {
+    version: 1,
+    owner: runtime.owner,
+    proposalId: proposal.proposalId,
+    action: 'compact-core-index',
+    stage: 'prepared',
+    root,
+    target: path,
+    backup,
+    beforeDigest: digest(before.content),
+    afterDigest: digest(attempted.content),
+    mode: before.mode,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function applyCoreRepairTransaction(
+  runtime: Runtime,
+  proposal: RepairProposal,
+  rootKind: 'global' | 'project',
+  io: Io,
+  options: ApplyOptions,
+): void {
+  const path = proposal.affectedPaths[0];
+  const root = dirname(path);
+  const journal = repairJournalPaths(runtime, proposal.proposalId);
+  withExclusiveDirectoryLock(journal.root, 'Repair journal', () =>
+    withMemoryLock(
+      root,
+      () => {
+        assertSafePath(root, path);
+        const entry = lstatSync(path);
+        const before = {
+          exists: true,
+          content: readFileSync(path, 'utf8'),
+          mode: entry.mode & 0o777,
+        } as const;
+        const attempted = {
+          exists: true,
+          content: compactCoreContent(before.content),
+          mode: before.mode,
+        } as const;
+        const marker = coreMarker(runtime, proposal, root, path, journal.backup, before, attempted);
+        if (existsSync(journal.marker) || existsSync(journal.backup)) {
+          throw new Error('Repair journal target already exists; diagnose before retrying');
+        }
+        assertExactFileState(path, before, 'Core repair');
+        atomicWrite(journal.backup, before.content, 0o600);
+        writeRepairMarker(journal.marker, marker);
+        try {
+          atomicWrite(path, attempted.content, attempted.mode);
+          marker.stage = 'mutated';
+          writeRepairMarker(journal.marker, marker);
+          validateMemoryRoot(root, io, { quietSuccess: true, rootKind });
+          options.beforeVerify?.();
+          if (memoryCoreBudget(readMemoryDocument(path)).status !== 'ok') {
+            throw new Error('Core repair verifier failed: budget remains over limit');
+          }
+          if (memoryMaintenanceReport(root, calendarDate(runtime)).unindexed.length > 0) {
+            throw new Error('Core repair verifier failed: active memory remains unindexed');
+          }
+          cleanupRepairJournal(marker);
+        } catch (error) {
+          rollbackCore(root, path, before, attempted, error, marker);
+        }
+      },
+      [],
+      { requireExisting: true },
+    ),
+  );
+}
+
+function restoreInterrupted(marker: RepairMarker, rootKind: 'global' | 'project', io: Io): void {
+  withMemoryLock(
+    marker.root,
+    () => {
+      const before = {
+        exists: true,
+        content: readFileSync(marker.target, 'utf8'),
+        mode: marker.mode,
+      };
+      const restored = {
+        exists: true,
+        content: readFileSync(marker.backup, 'utf8'),
+        mode: marker.mode,
+      };
+      if (!exactFileStateMatches(marker.target, before)) {
+        throw new Error('Interrupted repair target changed; recovery is inconclusive');
+      }
+      try {
+        atomicWrite(marker.target, restored.content, restored.mode);
+        validateMemoryRoot(marker.root, io, { quietSuccess: true, rootKind });
+        cleanupRepairJournal(marker);
+      } catch (error) {
+        const rollbackError = restoreExactFileState(marker.root, marker.target, before, restored);
+        if (rollbackError) {
+          throw new Error(
+            `Repair recovery failed and rollback was incomplete: ${String(error)}; ${rollbackError}`,
+          );
+        }
+        throw error;
+      }
+    },
+    [],
+    { requireExisting: true },
+  );
+}
+
+export function applyJournalRecovery(
+  runtime: Runtime,
+  observation: RepairJournalObservation,
+  rootKind: 'global' | 'project',
+  io: Io,
+): void {
+  const marker = observation.markerRecord;
+  if (!marker) throw new Error('Repair journal identity is not verified');
+  const journal = repairJournalPaths(runtime, marker.proposalId);
+  withExclusiveDirectoryLock(journal.root, 'Repair journal', () => {
+    const current = discoverRepairJournals(runtime, marker.root).find(
+      ({ marker: path }) => path === observation.marker,
+    );
+    if (!current || current.status !== observation.status) {
+      throw new Error('Repair recovery proposal changed');
+    }
+    if (observation.status === 'orphan-prepared') cleanupRepairJournal(marker);
+    else restoreInterrupted(marker, rootKind, io);
+  });
+}

--- a/template/agent-harness/src/program/memory.ts
+++ b/template/agent-harness/src/program/memory.ts
@@ -8,6 +8,7 @@ import {
   type MemoryPromotionOptions,
   memoryPromotionProposal,
 } from '../commands/memory-promotion.js';
+import { memoryRepair } from '../commands/memory-repair.js';
 import { workflowRelations } from '../commands/workflow-relations.js';
 import type { Io, Runtime } from '../types.js';
 import { registerMemoryAutopilotCommands } from './memory-autopilot.js';
@@ -79,6 +80,17 @@ export function registerMemoryCommands(
     .action(
       run((scope: string = '.', options: { json?: boolean }) =>
         memoryMaintenance(runtime, scope, options, io),
+      ),
+    );
+  memory
+    .command('repair [scope]')
+    .description('diagnose bounded repairs or apply one exact proposal')
+    .option('--proposal <id>', 'apply the exact proposal from a prior diagnosis')
+    .option('--yes', 'confirm the selected repair proposal')
+    .option('--json', 'write the repair plan or result as JSON')
+    .action(
+      run((scope: string = '.', options: { proposal?: string; yes?: boolean; json?: boolean }) =>
+        memoryRepair(runtime, scope, options, io),
       ),
     );
   registerMemoryCaptureEligibilityCommand(memory, io, run);


### PR DESCRIPTION
## Summary / 变更说明

- 新增 `harness memory repair` 的只读诊断与精确 proposal 应用流程。
- 将初始化、core 压缩、派生索引重建和 repair journal 恢复分为独立故障类型。
- 为 core 修复提供精确备份、事务回滚、锁保护和独立 verifier；无法确认身份或内容时返回 inconclusive 并保留现场。
- 补充 CLI 契约、架构文档、能力证据以及故障注入、并发锁、回滚和有界扫描测试。

## Related Issue / 关联 Issue

Closes #110

## Verification / 验证

- `pnpm run test:coverage`
- `pnpm run preflight`
- `npm pack --dry-run`
- `git diff --check`
- 结果：153 test files，1022 passed，3 skipped；preflight 762 checks；tarball 100 files。

## Checklist / 检查清单

- [x] 默认诊断零写入，变更要求精确 proposal 与 `--yes`
- [x] 故障类型保持独立，不并入通用 clean
- [x] 失败保留恢复证据且错误不被掩盖
- [x] verifier 明确区分 passed 与 inconclusive
- [x] 未知文件和并发用户修改受到保护
