### PR TITLE
feat: add explicit memory curation apply

### DIFF
--- a/docs/capability-evidence.yaml
+++ b/docs/capability-evidence.yaml
@@ -150,6 +150,19 @@ claims:
       - template/agent-harness/src/__tests__/memory.test.ts
       - template/agent-harness/src/__tests__/task.test.ts
 
+  - id: explicit-memory-curation-apply
+    status: implemented
+    owner: embedded Harness Memory runtime
+    claim: Keep curation proposal-only by default while explicitly applying bounded, content-bound selections through existing typed lifecycle commands with per-item verification and partial-failure reporting.
+    implementation:
+      - template/agent-harness/src/commands/memory-curation.ts
+      - template/agent-harness/src/program/memory-curation-apply.ts
+      - template/agent-harness/src/lib/memory-curation-contract.ts
+    verification:
+      - template/agent-harness/src/__tests__/memory-curation.test.ts
+      - template/agent-harness/src/__tests__/memory-curation-apply.test.ts
+      - src/__tests__/memory-curation-apply-docs.test.ts
+
   - id: privacy-safe-runtime-audit
     status: implemented
     owner: embedded Harness runtime

--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -92,6 +92,8 @@ node <harness-path>/bin/harness.mjs memory check project --indexed --json
 node <harness-path>/bin/harness.mjs memory relationships /absolute/project/path --json
 node <harness-path>/bin/harness.mjs memory maintain project --json
 node <harness-path>/bin/harness.mjs memory repair project --json
+node <harness-path>/bin/harness.mjs memory curate project --task task-id --json
+node <harness-path>/bin/harness.mjs memory curate project --task task-id --apply-file /tmp/curation-selection.json --yes --json
 ```
 
 `memory relationships` 是项目级只读报告：统一列出 Task、默认 phase/workstream、Memory owner、session 与
@@ -101,6 +103,14 @@ lifecycle role，并报告 orphan task reference 和 cross-workstream binding。
 `memory maintain` 只报告未索引、过期、重复、可归档和替代关系异常，不会自行删除或改写。旧 metadata 通过
 `memory migrate` 先生成 proposal；只有提案状态为 ready 且显式传入 `--apply` 才写入。`supersede` 建立替代关系，
 `archive` 只处理已关闭内容，`promote` 只输出提升到权威事实层的提案。
+
+`memory curate` 默认仍是零写入的 `proposal-only` 报告，Task close 不会自动执行候选。每个 promote、close、supersede
+或 archive 候选包含稳定 `proposalId`、`sourceDigest`、排除 `.agent-docs` 的 workspace digest、`expiresOn`、前置条件和
+精确 verifier。显式执行必须选择 1–16 个 proposal，并传入 `--yes`；需要 replacement 或 promotion 参数时使用项目外的
+有界 `--apply-file`。执行前会重新生成并比对 proposal identity，因此 source、工作区、Task 状态、引用关系或日期变化都会
+fail closed 并要求重新生成。close、supersede 与 archive 只调用既有 typed lifecycle，继续执行 inbound reference、cycle、
+锁和 rollback 门禁；promotion 只调用正式 promotion proposal 流程，不写事实源。批量报告逐项 action、reason、validation、
+recovery path 和 remaining proposals，单项失败只形成 `partial`，不能把整批标为成功。该执行层与 Task acceptance gate 独立。
 
 `memory repair` 默认是零写入诊断，只为 partial initialization、可机械压缩的 core index、损坏或缺失的派生检索索引，
 以及具备完整 owner、proposal、目标与内容 digest 的中断事务分别生成独立 proposal。实际修复必须同时传入上次诊断得到的

--- a/llms.txt
+++ b/llms.txt
@@ -148,6 +148,12 @@ backups, failed sidecars without a typed transaction, and unclassified validatio
 `inconclusive`. A repair must report exact paths, authority, backup/recovery, risk, prerequisites, and an independent
 verifier. Active locks fail closed; stale locks are handled only by the typed lock acquisition contract.
 
+`memory curate <project> --task <id>` is proposal-only by default. Explicit apply selects one to sixteen exact,
+unexpired proposal identities and requires `--yes`; source digest, authoritative workspace, Task, reference, cycle,
+or date drift fails closed. Close, supersede, and archive delegate to typed lifecycle commands. Promotion only emits
+the formal promotion proposal and does not write a source of truth. Batch output is per-item, preserves recovery paths,
+reports remaining proposals, and cannot substitute for the independent Task acceptance gate.
+
 If project-memory need is uncertain, ask the user. Do not initialize `.agent-docs` merely because the command
 exists. Initialization creates `.agent-docs/.gitignore` and `.agent-docs/.ignore` with `*`; it does not modify
 the project-root `.gitignore` or `.ignore`.

--- a/src/__tests__/memory-curation-apply-docs.test.ts
+++ b/src/__tests__/memory-curation-apply-docs.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'vitest';
+
+const root = process.cwd();
+
+test('public curation docs preserve explicit typed apply and acceptance boundaries', () => {
+  const runtime = readFileSync(join(root, 'docs', 'reference', 'runtime-cli.md'), 'utf8');
+  const architecture = readFileSync(
+    join(root, 'template', 'agent-harness', 'docs', 'core', 'harness-cli-architecture.md'),
+    'utf8',
+  );
+  const standard = readFileSync(
+    join(root, 'template', 'agent-harness', 'docs', 'standards', 'project-agent-docs.md'),
+    'utf8',
+  );
+  const manifest = readFileSync(
+    join(root, 'template', 'agent-harness', 'docs', 'manifest.yaml'),
+    'utf8',
+  );
+
+  for (const document of [runtime, architecture, standard]) {
+    assert.match(document, /memory curate/);
+    assert.match(document, /proposalId|proposal identity/i);
+    assert.match(document, /source digest|sourceDigest/i);
+    assert.match(document, /expire|expiresOn|过期/i);
+    assert.match(document, /--yes/);
+    assert.match(document, /partial/i);
+    assert.match(document, /acceptance/i);
+    assert.match(document, /typed lifecycle/i);
+  }
+  assert.match(architecture, /promotion.*proposal/i);
+  assert.match(architecture, /不.*写.*事实源|does not write.*source of truth/i);
+  assert.match(manifest, /curation-apply/);
+  assert.match(manifest, /策展执行/);
+});

--- a/template/agent-harness/docs/core/harness-cli-architecture.md
+++ b/template/agent-harness/docs/core/harness-cli-architecture.md
@@ -148,10 +148,14 @@ validation failure 保留并报告 `inconclusive`。active locks 直接拒绝；
 和未满足条件。proposal 自身永远不构成正式写入授权；只有目标已存在且提供 adoption evidence 时才产生可追踪的
 supersede candidate，仍须 owner 确认并走 typed lifecycle，不能报告为已采纳或已 supersede。
 
-`memory curate <project> --task <id>` 是只读的 task/workstream 策展报告。它只输出 proposal 候选并显式区分
-phase、task、workstream 完成与用户取消；不得嵌入 `task close`，也不得代替 `promote`、`close-input`、
-`supersede` 或 `archive` 的 mutation 与门禁。具有多个 `task:` owner 的共享文档不得因单个 task/workstream
-结束而进入 close 或 archive candidate。
+`memory curate <project> --task <id>` 默认是只读的 task/workstream 策展报告，只输出 proposal 候选并显式区分
+phase、task、workstream 完成与用户取消；`task close` 不会自动 apply。候选用 action、source digest、排除 Memory 的
+workspace digest、Task/workstream/outcome 和 `expiresOn` 计算稳定 `proposalId`。显式执行必须选择有界 proposal 集并同时
+提供 `--yes`；执行前逐项重新生成 identity，任何 source、workspace、Task、引用或日期漂移都 fail closed。close、supersede
+和 archive 只委托既有 typed lifecycle，因此 inbound reference、cycle、lock、exact-state verifier 和 rollback 契约继续生效；
+promotion 只生成正式 promotion proposal，不直接写权威事实源。批量输出逐项 action、reason、validation、recovery path 与
+remaining proposals，partial failure 不得报告整批成功。curation apply 与 Task acceptance gate 独立，不能完成或验证 Task。
+具有多个 `task:` owner 的共享文档不得因单个 task/workstream 结束而进入 close 或 archive candidate。
 
 `memory relationships <project>` 输出 version 1、`report-only` 的关系视图。Task ledger 继续拥有验收状态；
 关系视图只确定性派生默认 workstream 与 current phase，并把 Memory 的 task/workstream/session owner 及

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -23,7 +23,7 @@ entries:
   harness-cli-architecture:
     kind: topic
     path: core/harness-cli-architecture.md
-    conceptAliases: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, memory-migrate, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移]
+    conceptAliases: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, memory-migrate, memory-curate, curation-apply, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移, 记忆策展, 策展执行]
   observability:
     kind: topic
     path: core/observability.md
@@ -68,7 +68,7 @@ entries:
   project-agent-docs:
     kind: standard
     path: standards/project-agent-docs.md
-    conceptAliases: [.agent-docs, project-memory, memory-policy, memory-writeback, high-value-analysis, session, evidence, handoff, acceptance, future-tasks, multi-stage, phase, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, memory-repair, repair-plan, secret-hygiene, host-evals, 项目记忆, 记忆沉淀, 记忆策略, 高价值内容, 只读任务, 会话, 验收, 未来所有任务, 以后所有任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 诊断修复, 修复提案, 凭据卫生]
+    conceptAliases: [.agent-docs, project-memory, memory-policy, memory-writeback, high-value-analysis, session, evidence, handoff, acceptance, future-tasks, multi-stage, phase, verified-phase, phase-handoff, multi-task, compaction, context-budget, close-handoff, memory-autopilot, capture-input, payload-file, memory-list, memory-check, memory-migrate, memory-repair, repair-plan, memory-curate, curation-apply, secret-hygiene, host-evals, 项目记忆, 记忆沉淀, 记忆策略, 高价值内容, 只读任务, 会话, 验收, 未来所有任务, 以后所有任务, 阶段, 多阶段, 多阶段任务, 阶段交接, 阶段已验证仍有后续, 多任务, 压缩, 上下文预算, 上下文预算信号, 自动记忆, 记忆列表, 记忆检查, 记忆迁移, 诊断修复, 修复提案, 记忆策展, 策展执行, 凭据卫生]
   prompt-rule-contract:
     kind: standard
     path: standards/prompt-rule-contract.md

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -196,13 +196,16 @@ proposed 或 blocked 时同时说明原因和所需决策。普通任务仍只�
 未满足条件；输出不会创建或修改目标。目标已承接结论时，只有显式 adoption evidence 才能形成 supersede candidate，
 该 candidate 仍不是已采纳事实，也不能绕过 owner 确认、正式 verifier 或 typed lifecycle mutation。
 
-任务或阶段结束后可运行 `memory curate <project> --task <id> --json` 获取只读、proposal-first 策展报告。
+任务或阶段结束后可运行 `memory curate <project> --task <id> --json` 获取默认只读、proposal-first 策展报告。
 报告把 `phase-complete`、`task-complete`、`workstream-complete` 与 `user-cancel` 分开，并只检查当前
 task/workstream 关联的 Memory；输出 promote、close、supersede、archive、skipped 候选或 `result: none`。
 task complete 不自动表示 workstream complete，不能据此关闭仍有效的 input 或 handoff。报告不证明任务完成，
-不执行 mutation；promotion 仍需 owner、授权与事实源验证，close/supersede/archive 仍走现有 typed lifecycle
-命令及其 inbound reference、状态和 cycle 门禁。多个 `task:` source ref 表示共享 owner；只结束其中一个
-task/workstream 时不得关闭或归档该文档。
+也不会自动 mutation。候选必须包含稳定 proposal identity、source digest、workspace digest、`expiresOn`、前置条件与 verifier。
+只有显式选择有界 proposal 集并提供 `--yes` 才能进入 apply；执行前重新验证 source、Task、引用、cycle、权限和 dirty drift，
+stale、changed 或 expired proposal 必须重新生成。promotion 只调用正式 promotion proposal，不写事实源；close、supersede、
+archive 仍走现有 typed lifecycle 及其 inbound reference、状态、cycle、lock 与 rollback 门禁。输出逐项 action、reason、
+validation、recovery path 和 remaining proposals；partial failure 不冒充整批成功。curation apply 与 acceptance gate 独立。
+多个 `task:` source ref 表示共享 owner；只结束其中一个 task/workstream 时不得关闭或归档该文档。
 
 `memory relationships <project> --json` 只读汇总 Task、默认 phase/workstream、Memory、session 与 owner 关系，
 并报告 orphan task reference 和 cross-workstream binding。关系报告不是新的权威状态层；Task ledger 继续拥有

--- a/template/agent-harness/src/__tests__/memory-curation-apply-lock.test.ts
+++ b/template/agent-harness/src/__tests__/memory-curation-apply-lock.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import lockfile from 'proper-lockfile';
+import { onTestFinished, test } from 'vitest';
+import { initProject } from '../commands/init.js';
+import { curateMemory } from '../commands/memory-curation.js';
+import { captureFinding } from '../commands/memory-finding.js';
+import { captureInput } from '../commands/memory-input.js';
+import { supersedeMemory } from '../commands/memory-lifecycle.js';
+import { initTask } from '../commands/task.js';
+import { applyMemoryCuration, curationApplyLockRoot } from '../program/memory-curation-apply.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+function fixture(taskId = 'curation-apply-lock-task') {
+  const root = mkdtempSync(join(tmpdir(), 'harness-curation-apply-lock-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  initTask(
+    runtime,
+    { project, id: taskId, objective: 'Apply curation', acceptance: ['Independent gate'] },
+    capturedIo(),
+  );
+  return { project, runtime, taskId };
+}
+
+test('curation apply is serialized by a project-scoped lock', () => {
+  const { project, runtime, taskId } = fixture();
+  captureInput(
+    runtime,
+    project,
+    {
+      title: 'Locked input',
+      content: 'Concurrent curation apply must fail closed.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const proposal = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  ).closeCandidates[0];
+  const lockRoot = curationApplyLockRoot(runtime, project);
+  mkdirSync(lockRoot, { recursive: true });
+  assert.equal(
+    createHash('sha256').update(project).digest('hex').startsWith(basename(lockRoot)),
+    true,
+  );
+  const release = lockfile.lockSync(lockRoot, { realpath: false, retries: 0 });
+  try {
+    assert.throws(
+      () =>
+        applyMemoryCuration(
+          runtime,
+          project,
+          { task: taskId, outcome: 'workstream-complete' },
+          [{ proposalId: proposal.proposalId }],
+          capturedIo(),
+        ),
+      /being updated by another process/i,
+    );
+  } finally {
+    release();
+  }
+  assert.equal(existsSync(`${lockRoot}.lock`), false);
+});
+
+test('curation apply rejects duplicate and oversized selections before mutation', () => {
+  const { project, runtime, taskId } = fixture();
+  const proposalId = `sha256:${'a'.repeat(64)}`;
+  assert.throws(
+    () =>
+      applyMemoryCuration(
+        runtime,
+        project,
+        { task: taskId },
+        [{ proposalId }, { proposalId }],
+        capturedIo(),
+      ),
+    /unique/i,
+  );
+  assert.throws(
+    () =>
+      applyMemoryCuration(
+        runtime,
+        project,
+        { task: taskId },
+        Array.from({ length: 17 }, (_, index) => ({
+          proposalId: `sha256:${index.toString(16).padStart(64, '0')}`,
+        })),
+        capturedIo(),
+      ),
+    /between 1 and 16/i,
+  );
+});
+
+test('curation apply preserves typed supersession cycle checks', () => {
+  const { project, runtime, taskId } = fixture();
+  const source = captureFinding(
+    runtime,
+    project,
+    {
+      kind: 'analysis',
+      retention: 'durable',
+      factClass: 'settled-fact',
+      title: 'Cycle source',
+      conclusion: 'This source has an authoritative reference.',
+      rationale: 'Cycle checks remain in the typed lifecycle.',
+      application: 'Reject cyclic replacement selections.',
+      evidence: ['Verified source evidence.'],
+      sourceRefs: [`task:${taskId}`, 'docs/cycle.md'],
+    },
+    capturedIo(),
+  );
+  const replacement = captureFinding(
+    runtime,
+    project,
+    {
+      kind: 'analysis',
+      retention: 'durable',
+      factClass: 'settled-fact',
+      title: 'Cycle replacement',
+      conclusion: 'This replacement points back to the source.',
+      rationale: 'The lifecycle command owns graph validation.',
+      application: 'Keep the graph acyclic.',
+      evidence: ['Verified replacement evidence.'],
+      sourceRefs: [`task:${taskId}`],
+    },
+    capturedIo(),
+  );
+  supersedeMemory(runtime, project, replacement.reference, source.reference, capturedIo());
+  const proposal = curateMemory(runtime, project, { task: taskId }, capturedIo())
+    .supersedeCandidates[0];
+
+  const result = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId },
+    [{ proposalId: proposal.proposalId, replacement: replacement.reference }],
+    capturedIo(),
+  );
+
+  assert.equal(result.status, 'failed');
+  assert.match(result.items[0].reason, /cycle/i);
+  assert.match(readFileSync(source.path, 'utf8'), /status: active/);
+});

--- a/template/agent-harness/src/__tests__/memory-curation-apply.test.ts
+++ b/template/agent-harness/src/__tests__/memory-curation-apply.test.ts
@@ -1,0 +1,398 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { initProject } from '../commands/init.js';
+import { type CurationApplySelection, curateMemory } from '../commands/memory-curation.js';
+import { captureFinding } from '../commands/memory-finding.js';
+import { captureInput } from '../commands/memory-input.js';
+import { initTask } from '../commands/task.js';
+import { digestPath } from '../lib/files.js';
+import { readTask } from '../lib/task-store.js';
+import { applyMemoryCuration, memoryCuration } from '../program/memory-curation-apply.js';
+import { capturedIo, harnessRuntime } from './helpers/harness.js';
+
+function fixture(taskId = 'curation-apply-task') {
+  const root = mkdtempSync(join(tmpdir(), 'harness-curation-apply-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project, { recursive: true });
+  execFileSync('git', ['-C', project, 'init', '-q']);
+  const runtime = harnessRuntime(root);
+  initProject(runtime, project, capturedIo());
+  initTask(
+    runtime,
+    { project, id: taskId, objective: 'Apply curation', acceptance: ['Independent gate'] },
+    capturedIo(),
+  );
+  return { root, project, runtime, taskId, memoryRoot: join(project, '.agent-docs') };
+}
+
+function proposals(report: ReturnType<typeof curateMemory>) {
+  return [
+    ...report.promoteCandidates,
+    ...report.closeCandidates,
+    ...report.supersedeCandidates,
+    ...report.archiveCandidates,
+  ];
+}
+
+test('curation proposals have stable content identity and diagnosis remains read-only', () => {
+  const { project, runtime, taskId, memoryRoot } = fixture();
+  captureInput(
+    runtime,
+    project,
+    {
+      title: 'Bounded input',
+      content: 'Close only after explicit selection.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const before = digestPath(memoryRoot);
+
+  const first = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  );
+  const second = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  );
+
+  assert.equal(digestPath(memoryRoot), before);
+  assert.deepEqual(proposals(first), proposals(second));
+  assert.equal(first.mode, 'proposal-only');
+  assert.match(first.closeCandidates[0].proposalId, /^sha256:[0-9a-f]{64}$/);
+  assert.match(first.closeCandidates[0].sourceDigest, /^sha256:[0-9a-f]{64}$/);
+  assert.match(first.closeCandidates[0].expiresOn, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(first.closeCandidates[0].action, 'close');
+});
+
+test('explicit curation close applies through the typed command and replay fails closed', () => {
+  const { project, runtime, taskId } = fixture();
+  const input = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Selected input',
+      content: 'Close this selected workstream input.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const proposal = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  ).closeCandidates[0];
+
+  const result = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    [{ proposalId: proposal.proposalId }],
+    capturedIo(),
+  );
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.items[0].validation.status, 'passed');
+  assert.match(readFileSync(input.path, 'utf8'), /status: complete/);
+  assert.match(readFileSync(input.path, 'utf8'), /close-reason: workstream-complete/);
+  assert.equal(readTask(project, taskId).value.status, 'in_progress');
+  assert.equal(result.remainingValidation.status, 'passed');
+  assert.ok(
+    !result.remainingProposals.some(({ proposalId }) => proposalId === proposal.proposalId),
+  );
+
+  const replay = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    [{ proposalId: proposal.proposalId }],
+    capturedIo(),
+  );
+  assert.equal(replay.status, 'failed');
+  assert.equal(replay.items[0].validation.status, 'failed');
+  assert.match(replay.items[0].reason, /stale|changed|expired/i);
+});
+
+test('source drift invalidates an exact proposal without overwriting the changed memory', () => {
+  const { project, runtime, taskId } = fixture();
+  const input = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Drifting input',
+      content: 'Original user content.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const proposal = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  ).closeCandidates[0];
+  writeFileSync(input.path, `${readFileSync(input.path, 'utf8')}\nConcurrent user note.\n`);
+
+  const result = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    [{ proposalId: proposal.proposalId }],
+    capturedIo(),
+  );
+
+  assert.equal(result.status, 'failed');
+  assert.match(result.items[0].reason, /stale|changed|expired/i);
+  assert.match(readFileSync(input.path, 'utf8'), /Concurrent user note/);
+  assert.match(readFileSync(input.path, 'utf8'), /status: active/);
+});
+
+test('authoritative workspace drift and proposal expiry both require regeneration', () => {
+  const { root, project, runtime, taskId } = fixture();
+  const input = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Workspace-bound input',
+      content: 'The proposal is bound to the authoritative workspace.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const options = { task: taskId, outcome: 'workstream-complete' as const };
+  const proposal = curateMemory(runtime, project, options, capturedIo()).closeCandidates[0];
+  writeFileSync(join(project, 'README.md'), '# Concurrent authoritative change\n');
+
+  const drifted = applyMemoryCuration(
+    runtime,
+    project,
+    options,
+    [{ proposalId: proposal.proposalId }],
+    capturedIo(),
+  );
+
+  assert.equal(drifted.status, 'failed');
+  assert.match(drifted.items[0].reason, /stale|changed|expired/i);
+  assert.match(readFileSync(input.path, 'utf8'), /status: active/);
+  rmSync(join(project, 'README.md'));
+  const futureRuntime = harnessRuntime(root, {
+    env: { HOME: runtime.home, TZ: 'Pacific/Kiritimati' },
+  });
+  const futureProposal = curateMemory(futureRuntime, project, options, capturedIo())
+    .closeCandidates[0];
+  assert.notEqual(futureProposal.expiresOn, proposal.expiresOn);
+
+  const expired = applyMemoryCuration(
+    runtime,
+    project,
+    options,
+    [{ proposalId: futureProposal.proposalId }],
+    capturedIo(),
+  );
+
+  assert.equal(expired.status, 'failed');
+  assert.match(expired.items[0].reason, /stale|changed|expired/i);
+  assert.match(readFileSync(input.path, 'utf8'), /status: active/);
+});
+
+test('bounded batches report partial failure without undoing independently verified items', () => {
+  const { project, runtime, taskId } = fixture();
+  const input = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Batch input',
+      content: 'This close can complete independently.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  captureFinding(
+    runtime,
+    project,
+    {
+      kind: 'analysis',
+      retention: 'durable',
+      factClass: 'settled-fact',
+      title: 'Settled curation fact',
+      conclusion: 'The formal document already carries this conclusion.',
+      rationale: 'Typed supersession remains explicit.',
+      application: 'Use the authoritative document after owner review.',
+      evidence: ['Verified fixture evidence.'],
+      sourceRefs: [`task:${taskId}`, 'docs/settled.md'],
+    },
+    capturedIo(),
+  );
+  const report = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  );
+  const close = report.closeCandidates[0];
+  const supersede = report.supersedeCandidates[0];
+  const selections: CurationApplySelection[] = [
+    { proposalId: close.proposalId },
+    { proposalId: supersede.proposalId },
+  ];
+
+  const result = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    selections,
+    capturedIo(),
+  );
+
+  assert.equal(result.status, 'partial');
+  assert.equal(result.items[0].validation.status, 'passed');
+  assert.equal(result.items[1].validation.status, 'failed');
+  assert.match(result.items[1].reason, /replacement/i);
+  assert.match(readFileSync(input.path, 'utf8'), /status: complete/);
+  assert.ok(result.remainingProposals.some(({ action }) => action === 'supersede'));
+});
+
+test('promotion selection delegates to the formal proposal flow and never writes its target', () => {
+  const { project, runtime, taskId } = fixture();
+  captureFinding(
+    runtime,
+    project,
+    {
+      kind: 'analysis',
+      retention: 'durable',
+      factClass: 'settled-fact',
+      title: 'Promote this finding',
+      conclusion: 'Promotion remains proposal-first.',
+      rationale: 'Formal writes require separate authorization.',
+      application: 'Review this finding with the documentation owner.',
+      evidence: ['Verified fixture evidence.'],
+      sourceRefs: [`task:${taskId}`],
+    },
+    capturedIo(),
+  );
+  const candidate = curateMemory(runtime, project, { task: taskId }, capturedIo())
+    .promoteCandidates[0];
+  const target = join(project, 'docs', 'promoted.md');
+
+  const result = applyMemoryCuration(
+    runtime,
+    project,
+    { task: taskId },
+    [
+      {
+        proposalId: candidate.proposalId,
+        promotion: {
+          target: 'docs/promoted.md',
+          artifactType: 'docs',
+          owner: 'docs-owner',
+          reason: 'Review durable evidence',
+          verifier: 'pnpm run check:docs',
+        },
+      },
+    ],
+    capturedIo(),
+  );
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.items[0].action, 'promote');
+  assert.equal(result.items[0].validation.status, 'passed');
+  assert.ok(result.items[0].result && 'mode' in result.items[0].result);
+  assert.equal(result.items[0].result.mode, 'proposal-only');
+  assert.equal(digestPath(target), null);
+});
+
+test('curation command requires confirmation and accepts a bounded typed selection file', () => {
+  const { root, project, runtime, taskId } = fixture();
+  const input = captureInput(
+    runtime,
+    project,
+    {
+      title: 'Selection file input',
+      content: 'The selection file identifies this exact proposal.',
+      source: 'chat',
+      mode: 'verbatim',
+      purpose: 'constraint',
+      retention: 'workstream',
+      workstream: taskId,
+    },
+    capturedIo(),
+  );
+  const proposal = curateMemory(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete' },
+    capturedIo(),
+  ).closeCandidates[0];
+  const selectionFile = join(root, 'curation-selection.json');
+  writeFileSync(
+    selectionFile,
+    `${JSON.stringify({ version: 1, selections: [{ proposalId: proposal.proposalId }] })}\n`,
+  );
+  assert.throws(
+    () =>
+      memoryCuration(
+        runtime,
+        project,
+        { task: taskId, outcome: 'workstream-complete', applyFile: selectionFile },
+        capturedIo(),
+      ),
+    /requires explicit --yes/i,
+  );
+  assert.match(readFileSync(input.path, 'utf8'), /status: active/);
+
+  const applied = memoryCuration(
+    runtime,
+    project,
+    { task: taskId, outcome: 'workstream-complete', applyFile: selectionFile, yes: true },
+    capturedIo(),
+  );
+
+  assert.equal(applied.mode, 'applied');
+  assert.match(readFileSync(input.path, 'utf8'), /status: complete/);
+  assert.throws(
+    () =>
+      memoryCuration(
+        runtime,
+        project,
+        {
+          task: taskId,
+          apply: [proposal.proposalId],
+          applyFile: selectionFile,
+          yes: true,
+        },
+        capturedIo(),
+      ),
+    /cannot be combined/i,
+  );
+});

--- a/template/agent-harness/src/__tests__/memory-curation-contract.test.ts
+++ b/template/agent-harness/src/__tests__/memory-curation-contract.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { curationRecoveryPaths, curationWorkspaceDigest } from '../lib/memory-curation-contract.js';
+import { buildCurationProposals } from '../lib/memory-curation-proposals.js';
+import { readCurationSelectionFile } from '../lib/memory-curation-selection.js';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'harness-curation-contract-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const project = join(root, 'project');
+  mkdirSync(project);
+  return { root, project };
+}
+
+test('selection files reject malformed and untyped apply contracts', () => {
+  const { root } = fixture();
+  const cases: Array<[unknown, RegExp]> = [
+    ['{', /invalid JSON/i],
+    [{ version: 2, selections: [] }, /version 1/i],
+    [{ version: 1, selections: [], extra: true }, /unknown key/i],
+    [{ version: 1, selections: [null] }, /proposalId/i],
+    [{ version: 1, selections: [{ proposalId: 'x', extra: true }] }, /unknown key/i],
+    [{ version: 1, selections: [{ proposalId: 'x', replacement: 1 }] }, /replacement/i],
+    [{ version: 1, selections: [{ proposalId: 'x', promotion: [] }] }, /promotion/i],
+  ];
+  for (const [index, [value, expected]] of cases.entries()) {
+    const path = join(root, `selection-${index}.json`);
+    writeFileSync(path, typeof value === 'string' ? value : JSON.stringify(value));
+    assert.throws(() => readCurationSelectionFile(path), expected);
+  }
+});
+
+test('proposal helpers fail closed for unavailable sources and preserve recovery paths', () => {
+  const { root, project } = fixture();
+  assert.throws(() => curationWorkspaceDigest(join(root, 'missing')), /unavailable/i);
+  assert.throws(
+    () =>
+      buildCurationProposals({
+        project,
+        documents: [],
+        candidates: {
+          promote: [{ reference: 'memory:missing', reason: 'missing' }],
+          close: [],
+          supersede: [],
+          archive: [],
+        },
+        expiresOn: '2026-09-01',
+        task: 'task',
+        taskStatus: 'in_progress',
+        workstream: 'task',
+        outcome: 'phase-complete',
+      }),
+    /source disappeared/i,
+  );
+  assert.deepEqual(
+    curationRecoveryPaths(
+      new Error('recovery path: /tmp/one; unresolved paths: /tmp/two\nrecovery path: /tmp/one'),
+    ),
+    ['/tmp/one', '/tmp/two'],
+  );
+  assert.deepEqual(curationRecoveryPaths('no recovery information'), []);
+});

--- a/template/agent-harness/src/commands/memory-curation.ts
+++ b/template/agent-harness/src/commands/memory-curation.ts
@@ -3,6 +3,13 @@ import {
   canonicalMemoryReference,
   loadCurationDocuments,
 } from '../lib/memory-curation-documents.js';
+import { buildCurationProposals } from '../lib/memory-curation-proposals.js';
+import type {
+  CurationCandidate,
+  CurationOptions,
+  CurationOutcome,
+  MemoryCurationReport,
+} from '../lib/memory-curation-types.js';
 import { validateMemoryRoot } from '../lib/memory-validation.js';
 import { assertNoHighConfidenceSecret } from '../lib/secret-hygiene.js';
 import { projectRoot, readTask } from '../lib/task-store.js';
@@ -10,34 +17,12 @@ import { otherTaskOwners, taskReferences } from '../lib/workflow-relations.js';
 import { calendarDate } from '../runtime.js';
 import type { Io, Runtime, TaskStatus } from '../types.js';
 
-type CurationOutcome = 'phase-complete' | 'task-complete' | 'workstream-complete' | 'user-cancel';
+export type { CurationApplySelection } from '../lib/memory-curation-contract.js';
 
-export interface CurationOptions {
-  task: string;
-  workstream?: string;
-  outcome?: CurationOutcome;
-  json?: boolean;
-}
-
-interface CurationCandidate {
-  reference: string;
-  reason: string;
-}
-
-export interface MemoryCurationReport {
-  version: 1;
-  project: string;
-  task: string;
-  taskStatus: TaskStatus;
-  workstream: string;
-  outcome: CurationOutcome;
-  result: 'none' | 'candidates';
-  promoteCandidates: CurationCandidate[];
-  closeCandidates: CurationCandidate[];
-  supersedeCandidates: CurationCandidate[];
-  archiveCandidates: CurationCandidate[];
-  skipped: CurationCandidate[];
-}
+export type {
+  CurationOptions,
+  MemoryCurationReport,
+} from '../lib/memory-curation-types.js';
 
 const outcomes = new Set<CurationOutcome>([
   'phase-complete',
@@ -231,18 +216,29 @@ export function curateMemory(
     0
       ? 'candidates'
       : 'none';
+  const proposals = buildCurationProposals({
+    project: root,
+    documents: all,
+    candidates: buckets,
+    expiresOn: today,
+    task: task.id,
+    taskStatus: task.status,
+    workstream,
+    outcome,
+  });
   const report: MemoryCurationReport = {
     version: 1,
+    mode: 'proposal-only',
     project: root,
     task: task.id,
     taskStatus: task.status,
     workstream,
     outcome,
     result,
-    promoteCandidates: buckets.promote,
-    closeCandidates: buckets.close,
-    supersedeCandidates: buckets.supersede,
-    archiveCandidates: buckets.archive,
+    promoteCandidates: proposals.promote,
+    closeCandidates: proposals.close,
+    supersedeCandidates: proposals.supersede,
+    archiveCandidates: proposals.archive,
     skipped: buckets.skipped,
   };
   outputCuration(report, Boolean(options.json), io);

--- a/template/agent-harness/src/lib/memory-curation-contract.ts
+++ b/template/agent-harness/src/lib/memory-curation-contract.ts
@@ -1,0 +1,157 @@
+import { createHash } from 'node:crypto';
+import { sep } from 'node:path';
+import { digestPath } from './files.js';
+import type {
+  MemoryPromotionOptions,
+  MemoryPromotionProposal,
+} from './memory-promotion-contract.js';
+
+export type CurationAction = 'promote' | 'close' | 'supersede' | 'archive';
+
+export interface CurationProposal {
+  proposalId: string;
+  action: CurationAction;
+  reference: string;
+  reason: string;
+  sourceDigest: string;
+  workspaceDigest: string;
+  expiresOn: string;
+  prerequisites: string[];
+  verifier: { command: string; expected: 'exit 0' };
+}
+
+export interface CurationApplySelection {
+  proposalId: string;
+  replacement?: string;
+  promotion?: MemoryPromotionOptions;
+}
+
+export interface CurationApplyItem {
+  proposalId: string;
+  action: CurationAction | 'unknown';
+  reference: string | null;
+  validation: {
+    status: 'passed' | 'failed' | 'inconclusive';
+    command: string;
+    exitCode: number | null;
+  };
+  reason: string;
+  recoveryPaths: string[];
+  result?: MemoryPromotionProposal | { path: string };
+}
+
+export interface MemoryCurationApplyReport {
+  version: 1;
+  mode: 'applied';
+  project: string;
+  task: string;
+  status: 'passed' | 'partial' | 'failed';
+  items: CurationApplyItem[];
+  remainingProposals: CurationProposal[];
+  remainingValidation: {
+    status: 'passed' | 'inconclusive';
+    reason: string;
+  };
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stable(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function curationWorkspaceDigest(project: string): string {
+  const digest = digestPath(project, {
+    exclude: (path) =>
+      path === '.git' ||
+      path.startsWith(`.git${sep}`) ||
+      path === '.agent-docs' ||
+      path.startsWith(`.agent-docs${sep}`),
+    maxEntries: 100_000,
+    maxBytes: 512 * 1024 * 1024,
+    maxFileBytes: 128 * 1024 * 1024,
+    maxDepth: 64,
+    maxDurationMs: 30_000,
+  });
+  if (!digest) throw new Error(`Curation workspace digest is unavailable: ${project}`);
+  return `sha256:${digest}`;
+}
+
+export function createCurationProposal(input: {
+  action: CurationAction;
+  reference: string;
+  reason: string;
+  sourceDigest: string;
+  workspaceDigest: string;
+  expiresOn: string;
+  task: string;
+  taskStatus: string;
+  workstream: string;
+  outcome: string;
+}): CurationProposal {
+  const prerequisites =
+    input.action === 'promote'
+      ? ['formal-promotion-options-required', 'formal-write-remains-separately-authorized']
+      : input.action === 'supersede'
+        ? ['replacement-memory-required', 'inbound-reference-and-cycle-check-required']
+        : input.action === 'archive'
+          ? ['inbound-reference-check-required']
+          : ['typed-close-contract-required'];
+  const verifier = {
+    command:
+      input.action === 'promote'
+        ? 'harness memory promote <scope> <memory> ... --json'
+        : `harness memory check <scope> --indexed --json`,
+    expected: 'exit 0' as const,
+  };
+  const identity = {
+    version: 1,
+    ...input,
+    prerequisites,
+    verifier,
+  };
+  return {
+    proposalId: `sha256:${createHash('sha256').update(stable(identity)).digest('hex')}`,
+    action: input.action,
+    reference: input.reference,
+    reason: input.reason,
+    sourceDigest: input.sourceDigest,
+    workspaceDigest: input.workspaceDigest,
+    expiresOn: input.expiresOn,
+    prerequisites,
+    verifier,
+  };
+}
+
+export function boundedCurationSelections(
+  selections: CurationApplySelection[],
+): CurationApplySelection[] {
+  if (selections.length < 1 || selections.length > 16) {
+    throw new Error('Curation apply requires between 1 and 16 selected proposals');
+  }
+  const seen = new Set<string>();
+  for (const selection of selections) {
+    if (!/^sha256:[0-9a-f]{64}$/u.test(selection.proposalId)) {
+      throw new Error('Curation selection has an invalid proposal id');
+    }
+    if (seen.has(selection.proposalId)) throw new Error('Curation selections must be unique');
+    seen.add(selection.proposalId);
+  }
+  return selections;
+}
+
+export function curationRecoveryPaths(error: unknown): string[] {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    ...new Set(
+      [...message.matchAll(/(?:recovery path|unresolved paths?):\s+([^;\n]+)/giu)].map((match) =>
+        match[1].trim(),
+      ),
+    ),
+  ];
+}

--- a/template/agent-harness/src/lib/memory-curation-documents.ts
+++ b/template/agent-harness/src/lib/memory-curation-documents.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { parseFrontmatterDocument } from './frontmatter.js';
 import { markdownFiles, memoryReference, readMemoryDocument } from './memory-path.js';
 import {
@@ -19,6 +20,7 @@ export interface CurationDocument {
   taskId?: string;
   sourceRefs: string[];
   references: string[];
+  sourceDigest: string;
 }
 
 export function canonicalMemoryReference(reference: string): string {
@@ -61,6 +63,7 @@ export function loadCurationDocuments(memoryRoot: string): CurationDocument[] {
       references: [...bodyReferences, ...metadataReferences(parsed.metadata)].map(
         canonicalMemoryReference,
       ),
+      sourceDigest: `sha256:${createHash('sha256').update(content).digest('hex')}`,
     };
   });
 }

--- a/template/agent-harness/src/lib/memory-curation-proposals.ts
+++ b/template/agent-harness/src/lib/memory-curation-proposals.ts
@@ -1,0 +1,48 @@
+import type { TaskStatus } from '../types.js';
+import {
+  type CurationAction,
+  createCurationProposal,
+  curationWorkspaceDigest,
+} from './memory-curation-contract.js';
+import type { CurationDocument } from './memory-curation-documents.js';
+
+interface RawCandidate {
+  reference: string;
+  reason: string;
+}
+
+export function buildCurationProposals(input: {
+  project: string;
+  documents: CurationDocument[];
+  candidates: Record<CurationAction, RawCandidate[]>;
+  expiresOn: string;
+  task: string;
+  taskStatus: TaskStatus;
+  workstream: string;
+  outcome: string;
+}) {
+  const workspaceDigest = curationWorkspaceDigest(input.project);
+  const documents = new Map(input.documents.map((document) => [document.reference, document]));
+  const build = (action: CurationAction, item: RawCandidate) => {
+    const document = documents.get(item.reference);
+    if (!document) throw new Error(`Curation candidate source disappeared: ${item.reference}`);
+    return createCurationProposal({
+      action,
+      reference: item.reference,
+      reason: item.reason,
+      sourceDigest: document.sourceDigest,
+      workspaceDigest,
+      expiresOn: input.expiresOn,
+      task: input.task,
+      taskStatus: input.taskStatus,
+      workstream: input.workstream,
+      outcome: input.outcome,
+    });
+  };
+  return {
+    promote: input.candidates.promote.map((item) => build('promote', item)),
+    close: input.candidates.close.map((item) => build('close', item)),
+    supersede: input.candidates.supersede.map((item) => build('supersede', item)),
+    archive: input.candidates.archive.map((item) => build('archive', item)),
+  };
+}

--- a/template/agent-harness/src/lib/memory-curation-selection.ts
+++ b/template/agent-harness/src/lib/memory-curation-selection.ts
@@ -1,0 +1,46 @@
+import { readBoundedRegularFile } from './bounded-file.js';
+import type { CurationApplySelection } from './memory-curation-contract.js';
+
+function plainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function readCurationSelectionFile(path: string): CurationApplySelection[] {
+  const { content } = readBoundedRegularFile(path, {
+    maxBytes: 256 * 1024,
+    subject: 'Curation selection file',
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content) as unknown;
+  } catch (error) {
+    throw new Error('Curation selection file contains invalid JSON', { cause: error });
+  }
+  if (!plainObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.selections)) {
+    throw new Error('Curation selection file must contain version 1 and a selections array');
+  }
+  const unknownRoot = Object.keys(parsed).filter((key) => !['version', 'selections'].includes(key));
+  if (unknownRoot.length > 0) {
+    throw new Error(`Curation selection file has unknown key: ${unknownRoot[0]}`);
+  }
+  return parsed.selections.map((value, index) => {
+    if (!plainObject(value) || typeof value.proposalId !== 'string') {
+      throw new Error(`Curation selection ${index} must contain a proposalId`);
+    }
+    const unknown = Object.keys(value).filter(
+      (key) => !['proposalId', 'replacement', 'promotion'].includes(key),
+    );
+    if (unknown.length > 0) {
+      throw new Error(`Curation selection ${index} has unknown key: ${unknown[0]}`);
+    }
+    if (value.replacement !== undefined && typeof value.replacement !== 'string') {
+      throw new Error(`Curation selection ${index} replacement must be string`);
+    }
+    if (value.promotion !== undefined && !plainObject(value.promotion)) {
+      throw new Error(`Curation selection ${index} promotion must be an object`);
+    }
+    return value as unknown as CurationApplySelection;
+  });
+}

--- a/template/agent-harness/src/lib/memory-curation-types.ts
+++ b/template/agent-harness/src/lib/memory-curation-types.ts
@@ -1,0 +1,42 @@
+import type { TaskStatus } from '../types.js';
+import type { CurationProposal } from './memory-curation-contract.js';
+
+export type CurationOutcome =
+  | 'phase-complete'
+  | 'task-complete'
+  | 'workstream-complete'
+  | 'user-cancel';
+
+export interface CurationOptions {
+  task: string;
+  workstream?: string;
+  outcome?: CurationOutcome;
+  json?: boolean;
+}
+
+export interface CurationCandidate {
+  reference: string;
+  reason: string;
+}
+
+export interface MemoryCurationReport {
+  version: 1;
+  mode: 'proposal-only';
+  project: string;
+  task: string;
+  taskStatus: TaskStatus;
+  workstream: string;
+  outcome: CurationOutcome;
+  result: 'none' | 'candidates';
+  promoteCandidates: CurationProposal[];
+  closeCandidates: CurationProposal[];
+  supersedeCandidates: CurationProposal[];
+  archiveCandidates: CurationProposal[];
+  skipped: CurationCandidate[];
+}
+
+export interface CurationCommandOptions extends CurationOptions {
+  apply?: string[];
+  applyFile?: string;
+  yes?: boolean;
+}

--- a/template/agent-harness/src/program/memory-curation-apply.ts
+++ b/template/agent-harness/src/program/memory-curation-apply.ts
@@ -1,0 +1,242 @@
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { memoryCheck } from '../commands/memory.js';
+import { closeHandoff } from '../commands/memory-autopilot.js';
+import { curateMemory } from '../commands/memory-curation.js';
+import { closeInput } from '../commands/memory-input-close.js';
+import { archiveMemory, supersedeMemory } from '../commands/memory-lifecycle.js';
+import { memoryPromotionProposal } from '../commands/memory-promotion.js';
+import { withExclusiveDirectoryLock } from '../lib/exclusive-lock.js';
+import {
+  boundedCurationSelections,
+  type CurationApplyItem,
+  type CurationApplySelection,
+  curationRecoveryPaths,
+  type MemoryCurationApplyReport,
+} from '../lib/memory-curation-contract.js';
+import { loadCurationDocuments } from '../lib/memory-curation-documents.js';
+import { readCurationSelectionFile } from '../lib/memory-curation-selection.js';
+import type { CurationCommandOptions, CurationOptions } from '../lib/memory-curation-types.js';
+import { resolveMemoryRoot } from '../lib/memory-path.js';
+import { assertSafePath } from '../lib/safe-path.js';
+import { assertRuntimeCanMutate, calendarDate } from '../runtime.js';
+import type { Io, Runtime } from '../types.js';
+
+const quietIo: Io = { log() {}, error() {} };
+
+function allProposals(report: ReturnType<typeof curateMemory>) {
+  return [
+    ...report.promoteCandidates,
+    ...report.closeCandidates,
+    ...report.supersedeCandidates,
+    ...report.archiveCandidates,
+  ];
+}
+
+function referenceName(reference: string): string {
+  return reference.replace(/^memory:/u, '');
+}
+
+function applyProposal(
+  runtime: Runtime,
+  project: string,
+  proposal: ReturnType<typeof allProposals>[number],
+  selection: CurationApplySelection,
+  options: CurationOptions,
+  io: Io,
+) {
+  const memoryRoot = resolveMemoryRoot(runtime, project);
+  const document = loadCurationDocuments(memoryRoot).find(
+    ({ reference }) => reference === proposal.reference,
+  );
+  if (!document || document.sourceDigest !== proposal.sourceDigest) {
+    throw new Error('Curation proposal source changed; regenerate the proposal');
+  }
+  const name = referenceName(proposal.reference);
+  if (proposal.action === 'close') {
+    if (document.kind === 'input') {
+      return closeInput(runtime, project, name, { reason: 'workstream-complete' }, io);
+    }
+    if (document.type === 'session-handoff' && document.session) {
+      return closeHandoff(
+        runtime,
+        project,
+        {
+          session: document.session,
+          outcome: options.outcome === 'user-cancel' ? 'cancelled' : 'completed',
+        },
+        io,
+      );
+    }
+    throw new Error(`Curation close has no typed lifecycle command for ${proposal.reference}`);
+  }
+  if (proposal.action === 'archive') {
+    return archiveMemory(runtime, project, name, { force: document.status === 'active' }, io);
+  }
+  if (proposal.action === 'supersede') {
+    if (!selection.replacement) {
+      throw new Error('Curation supersede selection requires a replacement memory');
+    }
+    return supersedeMemory(runtime, project, name, referenceName(selection.replacement), io);
+  }
+  if (!selection.promotion) {
+    throw new Error('Curation promote selection requires formal promotion options');
+  }
+  return memoryPromotionProposal(runtime, project, name, selection.promotion, io);
+}
+
+function failedItem(
+  selection: CurationApplySelection,
+  proposal: ReturnType<typeof allProposals>[number] | undefined,
+  error: unknown,
+): CurationApplyItem {
+  return {
+    proposalId: selection.proposalId,
+    action: proposal?.action ?? 'unknown',
+    reference: proposal?.reference ?? null,
+    validation: {
+      status: 'failed',
+      command: proposal?.verifier.command ?? 'regenerate curation report',
+      exitCode: 1,
+    },
+    reason: error instanceof Error ? error.message : String(error),
+    recoveryPaths: curationRecoveryPaths(error),
+  };
+}
+
+function passedItem(
+  proposal: ReturnType<typeof allProposals>[number],
+  result: unknown,
+): CurationApplyItem {
+  const normalizedResult =
+    proposal.action === 'promote'
+      ? (result as CurationApplyItem['result'])
+      : typeof result === 'string'
+        ? { path: result }
+        : result && typeof result === 'object' && 'path' in result
+          ? { path: String((result as { path: unknown }).path) }
+          : undefined;
+  return {
+    proposalId: proposal.proposalId,
+    action: proposal.action,
+    reference: proposal.reference,
+    validation: { status: 'passed', command: proposal.verifier.command, exitCode: 0 },
+    reason:
+      proposal.action === 'promote'
+        ? 'formal promotion proposal generated; authoritative write remains separate'
+        : 'typed lifecycle command and independent memory verifier passed',
+    recoveryPaths: [],
+    ...(normalizedResult ? { result: normalizedResult } : {}),
+  };
+}
+
+export function curationApplyLockRoot(runtime: Runtime, project: string): string {
+  const identity = createHash('sha256').update(project).digest('hex').slice(0, 24);
+  const root = join(runtime.installedHarness, 'state', 'curation', identity);
+  assertSafePath(runtime.installedHarness, root);
+  return root;
+}
+
+export function applyMemoryCuration(
+  runtime: Runtime,
+  project: string,
+  options: CurationOptions,
+  requested: CurationApplySelection[],
+  io: Io = console,
+): MemoryCurationApplyReport {
+  assertRuntimeCanMutate(runtime);
+  const selections = boundedCurationSelections(requested);
+  return withExclusiveDirectoryLock(
+    curationApplyLockRoot(runtime, project),
+    'Memory curation apply',
+    () => {
+      const items: CurationApplyItem[] = [];
+      for (const selection of selections) {
+        let current: ReturnType<typeof curateMemory>;
+        try {
+          current = curateMemory(runtime, project, options, quietIo);
+        } catch (error) {
+          items.push(
+            failedItem(
+              selection,
+              undefined,
+              new Error(
+                `Curation proposal is stale, changed, or invalid; regenerate it: ${String(error)}`,
+                { cause: error instanceof Error ? error : undefined },
+              ),
+            ),
+          );
+          continue;
+        }
+        const proposal = allProposals(current).find(
+          ({ proposalId }) => proposalId === selection.proposalId,
+        );
+        if (!proposal || proposal.expiresOn !== calendarDate(runtime)) {
+          items.push(
+            failedItem(
+              selection,
+              proposal,
+              new Error('Curation proposal is stale, changed, or expired; regenerate it'),
+            ),
+          );
+          continue;
+        }
+        try {
+          const result = applyProposal(runtime, project, proposal, selection, options, quietIo);
+          memoryCheck(runtime, project, quietIo, { indexed: true, json: false });
+          items.push(passedItem(proposal, result));
+        } catch (error) {
+          items.push(failedItem(selection, proposal, error));
+        }
+      }
+      let remaining: ReturnType<typeof allProposals> = [];
+      let remainingValidation: MemoryCurationApplyReport['remainingValidation'] = {
+        status: 'passed',
+        reason: 'remaining proposals regenerated from current validated state',
+      };
+      try {
+        remaining = allProposals(curateMemory(runtime, project, options, quietIo));
+      } catch (error) {
+        remainingValidation = {
+          status: 'inconclusive',
+          reason: `remaining proposals could not be regenerated: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+      const passed = items.filter(({ validation }) => validation.status === 'passed').length;
+      const status = passed === items.length ? 'passed' : passed === 0 ? 'failed' : 'partial';
+      const report: MemoryCurationApplyReport = {
+        version: 1,
+        mode: 'applied',
+        project,
+        task: options.task,
+        status,
+        items,
+        remainingProposals: remaining,
+        remainingValidation,
+      };
+      io.log(JSON.stringify(report, null, 2));
+      return report;
+    },
+  );
+}
+
+export function memoryCuration(
+  runtime: Runtime,
+  project: string,
+  options: CurationCommandOptions,
+  io: Io = console,
+) {
+  const applying = options.apply !== undefined || options.applyFile !== undefined;
+  if (!applying) {
+    if (options.yes) throw new Error('Curation --yes requires --apply or --apply-file');
+    return curateMemory(runtime, project, options, io);
+  }
+  if (!options.yes) throw new Error('Curation apply requires explicit --yes confirmation');
+  if (options.apply !== undefined && options.applyFile !== undefined) {
+    throw new Error('Curation --apply cannot be combined with --apply-file');
+  }
+  const selections = options.applyFile
+    ? readCurationSelectionFile(options.applyFile)
+    : (options.apply ?? []).map((proposalId) => ({ proposalId }));
+  return applyMemoryCuration(runtime, project, options, selections, io);
+}

--- a/template/agent-harness/src/program/memory.ts
+++ b/template/agent-harness/src/program/memory.ts
@@ -1,6 +1,5 @@
 import type { Command } from 'commander';
 import { memoryCheck, memoryList, memorySearch } from '../commands/memory.js';
-import { type CurationOptions, curateMemory } from '../commands/memory-curation.js';
 import { archiveMemory, supersedeMemory } from '../commands/memory-lifecycle.js';
 import { memoryMaintenance } from '../commands/memory-maintenance.js';
 import { memoryMigrate } from '../commands/memory-migration.js';
@@ -10,9 +9,11 @@ import {
 } from '../commands/memory-promotion.js';
 import { memoryRepair } from '../commands/memory-repair.js';
 import { workflowRelations } from '../commands/workflow-relations.js';
+import type { CurationCommandOptions } from '../lib/memory-curation-types.js';
 import type { Io, Runtime } from '../types.js';
 import { registerMemoryAutopilotCommands } from './memory-autopilot.js';
 import { registerMemoryCaptureEligibilityCommand } from './memory-capture-eligibility.js';
+import { memoryCuration } from './memory-curation-apply.js';
 import { addSearchOptions, type SearchCommandOptions } from './search-options.js';
 import type { CommandRunner } from './types.js';
 
@@ -60,9 +61,14 @@ export function registerMemoryCommands(
       '--outcome <outcome>',
       'phase-complete, task-complete, workstream-complete, or user-cancel',
     )
+    .option('--apply <proposal...>', 'apply one or more exact proposal ids')
+    .option('--apply-file <path>', 'read bounded typed proposal selections from JSON')
+    .option('--yes', 'confirm the selected typed curation actions')
     .option('--json', 'write a machine-readable curation report')
     .action(
-      run((scope: string, options: CurationOptions) => curateMemory(runtime, scope, options, io)),
+      run((scope: string, options: CurationCommandOptions) =>
+        memoryCuration(runtime, scope, options, io),
+      ),
     );
   memory
     .command('relationships <scope>')


### PR DESCRIPTION
## Summary / 变更说明

- 为只读策展候选增加稳定 proposal identity、source/workspace digest、有效期与有界 typed selection contract。
- 仅在显式选择并确认后调用既有 close、supersede、archive 与 promotion proposal 流程；不直接写权威事实源。
- 逐项报告验证、失败原因、恢复路径与剩余候选，并保持 Task acceptance gate 独立。
- 补齐 stale/drift/expiry、partial failure、cycle、replay、并发锁、输入契约和公开文档测试。

## Related Issue / 关联 Issue

Closes #111

## Verification / 验证

- pnpm run test:coverage
- pnpm run preflight
- npm pack --dry-run
- pre-push: 157 test files passed, 1035 tests passed, 3 skipped

## Checklist / 检查清单

- [x] 默认 memory curate 保持只读
- [x] 未降低测试、覆盖率或 verifier 门槛
- [x] 未执行发布
