### PR TITLE
feat(harness): add explicit documentation intent

### DIFF
--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -29,14 +29,14 @@ node <harness-path>/bin/harness.mjs --help
 
 ## 文档路由与检索
 
-`route` 和 `explain` 根据 manifest 的 `actionAliases` 与 `conceptAliases` 返回命中的文档名称、路径和 alias，
-不加载正文。JSON 报告显式区分 `matched`、`unmatched` 与 `ambiguous`，并只在唯一命中时给出 `top1`；未命中或
-最高优先级动作歧义返回 exit 2，不猜测执行动作。该结构化契约为 version 2。它们适合先确定“这类任务由哪份
-规则负责”：
+`route` 和 `explain` 根据显式 intent、manifest 的 `actionAliases` 与 `conceptAliases` 返回命中的文档名称、路径和
+alias，不加载正文。能够可靠判断动作时使用受限 `--intent`；未提供时只做保守自动推断。JSON 报告显式区分
+`matched`、`unmatched` 与 `ambiguous`，并只在唯一动作时给出 `top1`；未命中或多个真实动作返回 exit 2，
+不按 priority 猜测。该结构化契约为 version 3。路由只负责文档发现，不传递授权：
 
 ```bash
-node <harness-path>/bin/harness.mjs route diagnose payment callback --json
-node <harness-path>/bin/harness.mjs explain release external write
+node <harness-path>/bin/harness.mjs route --intent diagnose payment callback --json
+node <harness-path>/bin/harness.mjs explain --intent release-and-external release external write
 ```
 
 `search` 才会扫描 Harness 文档、项目文档和项目 Memory：

--- a/evals/prompt-route-corpus.v1.json
+++ b/evals/prompt-route-corpus.v1.json
@@ -64,6 +64,24 @@
       "categories": ["en", "quotation", "meta", "false-positive-guard"],
       "query": "The phrase \"implement the fix\" is quoted as an example, not a current instruction.",
       "expected": { "status": "unmatched", "top1": null, "topics": [], "forbiddenPlaybooks": ["change"] }
+    },
+    {
+      "id": "zh-analysis-implementation-noun",
+      "categories": ["zh", "action", "false-positive-guard", "real-request"],
+      "query": "分析当前项目，实现方面是否合理。",
+      "expected": { "status": "matched", "top1": "research-and-design", "topics": [], "forbiddenPlaybooks": ["change"] }
+    },
+    {
+      "id": "zh-review-result-unmatched",
+      "categories": ["zh", "meta", "false-positive-guard", "real-request"],
+      "query": "根据评审结果，形成对应的解决方案。",
+      "expected": { "status": "unmatched", "top1": null, "topics": [], "forbiddenPlaybooks": ["review"] }
+    },
+    {
+      "id": "zh-progressive-implementation",
+      "categories": ["zh", "action", "false-negative-guard", "real-request"],
+      "query": "进行逐个实施。",
+      "expected": { "status": "matched", "top1": "change", "topics": [], "forbiddenPlaybooks": [] }
     }
   ]
 }

--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -75,6 +75,7 @@ test('operating model separates target mutability from managed sidecar eligibili
 });
 
 test('top-level routing uses one primary playbook plus supporting topics without category exceptions', () => {
+  assert.match(agents, /route.*--intent.*用户当前原文/s);
   assert.match(agents, /primaryPlaybook/);
   assert.match(agents, /topics/);
   assert.match(agents, /加载.*primaryPlaybook.*全部.*返回.*topics/s);
@@ -89,6 +90,9 @@ test('top-level routing uses one primary playbook plus supporting topics without
   );
   assert.match(docsIndex, /primaryPlaybook/);
   assert.match(docsIndex, /topics/);
+  assert.match(docsIndex, /显式.*intent.*唯一.*playbook/s);
+  assert.match(docsIndex, /自动推断.*歧义.*unmatched/s);
+  assert.doesNotMatch(docsIndex, /最高优先级.*playbook/);
 });
 
 test('startup rules retain progressive project discovery without copying its command sequence', () => {

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -23,9 +23,9 @@
    recommended 引用只加载命中正文，再核对代码、配置、测试、manifest、lockfile 和脚本等事实源。
    `truncated` 或 `inconclusive` 不能解释为不存在；bootstrap 只读且不能代替事实核对。
 4. 对修改、诊断、评审、设计、发布、工具、安全、Git、长任务或 CLI 请求，先读取
-   `{{HARNESS_HOME}}/agent-harness/docs/README.md` 并运行文档路由。加载至多一个 `primaryPlaybook` 和全部返回的
-   `topics`；若最高优先级 playbook 存在歧义，停止选择并向用户澄清。
-   路由查询保留用户当前原文，不得概括改写而遗漏验收、未来默认、仍有后续或 host-signal 等高损失信号。
+   `{{HARNESS_HOME}}/agent-harness/docs/README.md`；能够可靠判断当前动作时，运行 `route --intent <intent>`；路由查询保留
+   用户当前原文，不得概括改写而遗漏验收、未来默认、仍有后续或 host-signal 等高损失信号。加载至多一个
+   `primaryPlaybook` 和全部返回的 `topics`；无法判断时不传 intent，返回歧义则停止选择并向用户澄清。
    本地 Harness Memory/画像控制不是宿主产品设置；只用 Harness 文档与 CLI，不加载产品文档、skill 或 web。
 5. 不递归读取整个 `docs/`、`.agent-docs/`、archive、历史会话或全部规则；只有缺失信息会改变权限、范围或结果时才询问用户。
 

--- a/template/agent-harness/docs/README.md
+++ b/template/agent-harness/docs/README.md
@@ -45,8 +45,9 @@ updated: 2026-08-28
 
 ## 读取原则
 
-1. 路由返回至多一个 `primaryPlaybook` 和零个或多个 `topics`。先加载 primary playbook，再按任务所需加载 supporting topics。
-2. 最高优先级的 playbook 有多个候选时视为歧义：停止自动选择并向用户澄清，不能靠文档顺序决定。
+1. 能够可靠判断当前动作时显式传入受限 intent 并选择唯一 playbook；Runtime 验证 `--intent` 后返回至多一个
+   `primaryPlaybook` 和零个或多个 `topics`。先加载 primary playbook，再按任务所需加载 supporting topics。
+2. 未传 intent 时只做保守自动推断；多个动作返回歧义，低置信度返回 `unmatched`，不靠 priority 或文档顺序决定。
 3. 项目内存在更具体的 `AGENTS.md`、skill 或文档索引时，优先读取项目事实源。
 4. 检索先返回文件名、标题、元信息或命中段落；只有确认相关后才读取全文。
 5. 本目录保存跨仓、长期、个人级规则和事实导航；单次任务记忆与证据放项目 `.agent-docs/`。
@@ -56,8 +57,7 @@ updated: 2026-08-28
 
 ```bash
 # 使用 manifest 中英 aliases 返回命中文档，不加载正文
-node {{HARNESS_HOME}}/agent-harness/bin/harness.mjs route 评审 permissions --json
-
+node {{HARNESS_HOME}}/agent-harness/bin/harness.mjs route --intent review 评审 permissions --json
 # 在 Harness、项目 docs 与记忆中做有界检索
 node {{HARNESS_HOME}}/agent-harness/bin/harness.mjs search --project /absolute/project/path \
   --limit 20 --max-line-length 300 --json "authentication"

--- a/template/agent-harness/docs/core/operating-model.md
+++ b/template/agent-harness/docs/core/operating-model.md
@@ -46,9 +46,10 @@ updated: 2026-08-28
 
 ## 4. 路由与回复语言
 
-文档路由把用户请求中的动作与涉及概念分开：playbook 只匹配 manifest 的中英文 `actionAliases`，topic 与
-standard 只匹配 `conceptAliases`。CJK 标点和混合语言不改变动作语义；否定、引用、示例和元讨论中的动作词
-不选择 primary playbook。未命中或同优先级真实歧义必须显式返回并停止选择，不靠英文词面或 priority 猜测。
+文档路由把用户请求中的动作与涉及概念分开：调用方能够可靠判断动作时传入受限 intent，Runtime 只验证并映射
+唯一 playbook；topic 与 standard 仍匹配 `conceptAliases`。未传 intent 时，CJK 标点和混合语言不改变动作语义，
+否定、引用、示例、元讨论和名词性动作词不选择 primary playbook。未命中或多个真实动作必须显式返回并停止选择，
+不靠英文词面或 priority 猜测。路由只决定文档发现，不能扩大用户授权。
 
 回复语言优先级是：用户在当前请求中的明确要求 > 带持久证据的当前画像偏好 > 当前请求的自动检测。
 必要的 identifier、命令、路径和错误原文保持原样。翻译、改写、示例目标语言和一次性语言要求只影响当前

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -36,7 +36,7 @@ entries:
     kind: playbook
     priority: 40
     path: playbooks/change.md
-    actionAliases: [change, implement, modify, refactor, build, 变更, 实现, 修改, 重构, 构建]
+    actionAliases: [change, implement, modify, refactor, build, 变更, 实现, 实施, 修改, 重构, 构建]
   diagnose:
     kind: playbook
     priority: 50

--- a/template/agent-harness/src/__tests__/cli.test.ts
+++ b/template/agent-harness/src/__tests__/cli.test.ts
@@ -104,7 +104,7 @@ test('Harness route CLI consumes manifest aliases without loading document bodie
 
   assert.equal(runCli(['route', '--json', 'review', 'permissions'], { runtime, io: output }), 0);
   const report = JSON.parse(output.logs[0]);
-  assert.equal(report.version, 2);
+  assert.equal(report.version, 3);
   assert.equal(report.status, 'matched');
   assert.equal(report.top1.name, 'review');
   assert.ok(report.top1.matchedAliases.includes('review'));
@@ -120,6 +120,23 @@ test('Harness route CLI consumes manifest aliases without loading document bodie
     report.routes.every((route: { content?: string }) => route.content === undefined),
     true,
   );
+});
+
+test('Harness route CLI accepts a validated explicit documentation intent', () => {
+  const { runtime } = installedFixture();
+  const output = capturedIo();
+
+  assert.equal(
+    runCli(
+      ['route', '--json', '--intent', 'research-and-design', '根据评审结果，形成对应的解决方案。'],
+      { runtime, io: output },
+    ),
+    0,
+  );
+  const report = JSON.parse(output.logs[0]);
+  assert.equal(report.intent.source, 'explicit');
+  assert.equal(report.intent.requested, 'research-and-design');
+  assert.equal(report.primaryPlaybook.name, 'research-and-design');
 });
 
 test('Harness route CLI fails closed for unmatched and ambiguous action intent', () => {

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -11,7 +11,7 @@ const docsRoot = join(sourceHarnessRoot, 'docs');
 
 test('documentation routing accepts canonical Chinese task aliases', () => {
   const report = routeDocumentation(docsRoot, ['评审']);
-  assert.equal(report.version, 2);
+  assert.equal(report.version, 3);
   assert.equal(report.status, 'matched');
   assert.deepEqual(
     report.routes.map(({ name }) => name),
@@ -19,6 +19,32 @@ test('documentation routing accepts canonical Chinese task aliases', () => {
   );
   assert.equal(report.primaryPlaybook?.name, 'review');
   assert.deepEqual(report.topics, []);
+});
+
+test('documentation routing maps an explicit intent without re-inferring it from mentioned actions', () => {
+  const report = routeDocumentation(docsRoot, ['通过第一性原理分析当前项目，实现方面是否合理？'], {
+    intent: 'research-and-design',
+  });
+
+  assert.equal(report.version, 3);
+  assert.deepEqual(report.intent, {
+    requested: 'research-and-design',
+    source: 'explicit',
+    mentionedActions: ['change', 'research-and-design'],
+    negatedActions: [],
+  });
+  assert.equal(report.status, 'matched');
+  assert.equal(report.primaryPlaybook?.name, 'research-and-design');
+});
+
+test.each([
+  ['分析当前项目，实现方面是否合理。', 'research-and-design'],
+  ['实现思想是否合理？', null],
+  ['根据评审结果，形成对应的解决方案。', null],
+  ['进行逐个实施。', 'change'],
+])('documentation routing conservatively classifies real request %s', (query, expected) => {
+  const report = routeDocumentation(docsRoot, [query]);
+  assert.equal(report.primaryPlaybook?.name ?? null, expected);
 });
 
 test('documentation routing separates one task playbook from supporting topics', () => {

--- a/template/agent-harness/src/cli.ts
+++ b/template/agent-harness/src/cli.ts
@@ -6,11 +6,11 @@ import { doctor } from './commands/doctor.js';
 import { health } from './commands/health.js';
 import { initGlobal, initPersonal, initProject } from './commands/init.js';
 import { inspectProject } from './commands/project.js';
-import { route } from './commands/route.js';
 import { contextSearch } from './commands/search.js';
 import { validate } from './commands/validate.js';
 import { containsHighConfidenceSecret } from './lib/secret-hygiene.js';
 import { registerAuditCommands } from './program/audit.js';
+import { registerDocumentationCommands } from './program/documentation.js';
 import { registerMemoryCommands } from './program/memory.js';
 import { registerReplayCommands } from './program/replay.js';
 import { registerRepositoryMapCommands } from './program/repository-map.js';
@@ -101,6 +101,7 @@ function registerCoreCommands(
   manifest: HarnessManifest,
 ): void {
   registerBootstrapCommand(program, runtime, io, run);
+  registerDocumentationCommands(program, runtime, io, run);
   program
     .command('version')
     .description('print the Harness version')
@@ -136,21 +137,6 @@ function registerCoreCommands(
     .option('--project <path>', 'project path')
     .option('--json', 'write machine-readable JSON')
     .action(run((options: JsonProjectOptions) => validate(runtime, options, io)));
-  program
-    .command('route <query...>')
-    .description('route task terms to relevant Harness documentation')
-    .option('--json', 'write machine-readable routes without document bodies')
-    .action(
-      run((query: string[], options: { json?: boolean }) => route(runtime, query, options, io)),
-    );
-  program
-    .command('explain <query...>')
-    .description('explain which Harness documents govern a topic without loading their bodies')
-    .option('--json', 'write machine-readable routes without document bodies')
-    .action(
-      run((query: string[], options: { json?: boolean }) => route(runtime, query, options, io)),
-    );
-
   const project = program.command('project').description('inspect project context');
   project
     .command('inspect [path]')

--- a/template/agent-harness/src/commands/route.ts
+++ b/template/agent-harness/src/commands/route.ts
@@ -1,15 +1,15 @@
-import { routeDocumentation } from '../lib/docs-routing.js';
+import { type DocumentationIntent, routeDocumentation } from '../lib/docs-routing.js';
 import { assertNoHighConfidenceSecret } from '../lib/secret-hygiene.js';
 import type { Io, Runtime } from '../types.js';
 
 export function route(
   runtime: Runtime,
   query: string[],
-  { json = false }: { json?: boolean } = {},
+  { json = false, intent }: { json?: boolean; intent?: DocumentationIntent } = {},
   io: Io = console,
 ): number {
   assertNoHighConfidenceSecret(query, 'Documentation route query');
-  const report = routeDocumentation(runtime.docsRoot, query);
+  const report = routeDocumentation(runtime.docsRoot, query, { intent });
   if (json) io.log(JSON.stringify(report, null, 2));
   else if (report.status === 'unmatched') io.log('No matching documentation routes');
   else if (report.status === 'ambiguous') {

--- a/template/agent-harness/src/lib/docs-routing-matching.ts
+++ b/template/agent-harness/src/lib/docs-routing-matching.ts
@@ -1,0 +1,143 @@
+export interface PlaybookAliasEvidence {
+  mentioned: boolean;
+  negated: boolean;
+  requested: boolean;
+}
+
+export function normalizeRoutingText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function routingMatchPositions(candidate: string, term: string): number[] {
+  if (/\p{Script=Han}/u.test(candidate)) {
+    const positions: number[] = [];
+    let offset = 0;
+    while (offset <= term.length - candidate.length) {
+      const position = term.indexOf(candidate, offset);
+      if (position === -1) break;
+      positions.push(position);
+      offset = position + candidate.length;
+    }
+    return positions;
+  }
+  const pattern = new RegExp(
+    `(?:^|[^\\p{L}\\p{N}])(${escapeRegularExpression(candidate)})(?=$|[^\\p{L}\\p{N}])`,
+    'gu',
+  );
+  return [...term.matchAll(pattern)].map(
+    (match) => (match.index ?? 0) + match[0].length - (match[1]?.length ?? 0),
+  );
+}
+
+function routingMatchIsNegated(term: string, position: number): boolean {
+  const clause =
+    term
+      .slice(0, position)
+      .split(/[,.!?;，。！？；]/u)
+      .at(-1) ?? '';
+  return /(?:\b(?:do\s+not|don't|not|never|without|no)\s+(?:\p{L}+\s+){0,2}|(?:不要|无需|不必|别|禁止|避免|不)\s*)$/u.test(
+    clause,
+  );
+}
+
+function routingMatchIsRequestedAction(term: string, position: number): boolean {
+  const clause =
+    term
+      .slice(0, position)
+      .split(/[,.!?;，。！？；]/u)
+      .at(-1) ?? '';
+  const prefix = clause.trim();
+  if (prefix === '') return true;
+  return /^(?:(?:please|can you|could you|would you|i want you to|i need you to|let(?:'s| us)|now|then|also)(?:\s+\p{L}+){0,4}|(?:(?:请你?|帮我|给我|现在|继续|重新|开始|进行|执行|来|需要|要求|希望|想要|逐个|并|只)\s*)+|(?:结合|基于|根据)[\p{L}\p{N} ._-]{0,40}(?:来)?)$/u.test(
+    prefix,
+  );
+}
+
+function routingMatchIsIllustrative(term: string, position: number): boolean {
+  const prefix = term.slice(Math.max(0, position - 48), position);
+  return /(?:\b(?:for example|e\.g\.|such as)\s*,?\s*|(?:例如|比如|譬如)\s*[：:,，]?\s*)$/u.test(
+    prefix,
+  );
+}
+
+function routingMatchIsQuoted(term: string, position: number): boolean {
+  for (const [open, close] of [
+    ['“', '”'],
+    ['‘', '’'],
+    ['「', '」'],
+    ['『', '』'],
+  ] as const) {
+    const opening = term.lastIndexOf(open, position);
+    if (opening !== -1) {
+      const closing = term.indexOf(close, opening + open.length);
+      if (closing >= position) return true;
+    }
+  }
+  for (const quote of ['"', "'"] as const) {
+    const before = term.slice(0, position).split(quote).length - 1;
+    if (before % 2 === 1 && term.indexOf(quote, position) !== -1) return true;
+  }
+  return false;
+}
+
+function routingMatchIsNominalReference(
+  candidate: string,
+  term: string,
+  position: number,
+): boolean {
+  const before =
+    term
+      .slice(0, position)
+      .split(/[,.!?;，。！？；]/u)
+      .at(-1)
+      ?.trim() ?? '';
+  const after = term.slice(position + candidate.length).trimStart();
+  if (/\p{Script=Han}/u.test(candidate)) {
+    if (
+      /^(?:思想|原理|方面|设计|方式|机制|细节|情况|结果|意见|结论|报告|方案|是否|合理)/u.test(after)
+    ) {
+      return true;
+    }
+    return /(?:分析|评价|评审|审查|检查|审视|研究|讨论)\s*$/u.test(before);
+  }
+  return /^(?:result|results|report|reports|feedback|finding|findings)\b/u.test(after);
+}
+
+export function matchesRoutingTerm(trigger: string, term: string): boolean {
+  const candidate = normalizeRoutingText(trigger);
+  if (!candidate) return false;
+  return routingMatchPositions(candidate, term).some(
+    (position) => !routingMatchIsNegated(term, position),
+  );
+}
+
+export function playbookAliasEvidence(trigger: string, term: string): PlaybookAliasEvidence {
+  const candidate = normalizeRoutingText(trigger);
+  const evidence = { mentioned: false, negated: false, requested: false };
+  if (!candidate) return evidence;
+  for (const position of routingMatchPositions(candidate, term)) {
+    if (routingMatchIsQuoted(term, position) || routingMatchIsIllustrative(term, position))
+      continue;
+    evidence.mentioned = true;
+    if (routingMatchIsNegated(term, position)) {
+      evidence.negated = true;
+      continue;
+    }
+    if (
+      routingMatchIsRequestedAction(term, position) &&
+      !routingMatchIsNominalReference(candidate, term, position)
+    ) {
+      evidence.requested = true;
+    }
+  }
+  return evidence;
+}

--- a/template/agent-harness/src/lib/docs-routing.ts
+++ b/template/agent-harness/src/lib/docs-routing.ts
@@ -6,6 +6,11 @@ import {
   type ResponseLanguageDecision,
   resolveResponseLanguage,
 } from './response-language.js';
+import {
+  matchesRoutingTerm,
+  normalizeRoutingText,
+  playbookAliasEvidence,
+} from './docs-routing-matching.js';
 import { isPathInside } from './safe-path.js';
 
 interface ManifestEntry {
@@ -30,8 +35,23 @@ interface DocumentationRoute {
   matchedAliases: string[];
 }
 
+export const documentationIntents = [
+  'change',
+  'diagnose',
+  'review',
+  'research-and-design',
+  'release-and-external',
+] as const;
+
+export type DocumentationIntent = (typeof documentationIntents)[number];
+
+export interface DocumentationRouteOptions {
+  intent?: DocumentationIntent;
+  languageContext?: ResponseLanguageContext;
+}
+
 export interface DocumentationRouteReport {
-  version: 2;
+  version: 3;
   status: 'matched' | 'unmatched' | 'ambiguous';
   query: string[];
   routes: DocumentationRoute[];
@@ -39,6 +59,12 @@ export interface DocumentationRouteReport {
   top1: DocumentationRoute | null;
   ambiguity: string[];
   topics: DocumentationRoute[];
+  intent: {
+    requested: string | null;
+    source: 'explicit' | 'inferred' | 'none';
+    mentionedActions: string[];
+    negatedActions: string[];
+  };
   responseLanguage: ResponseLanguageDecision;
 }
 
@@ -46,111 +72,6 @@ function normalizedTerms(query: string[]): string[] {
   const terms = query.map(normalizeRoutingText).filter(Boolean);
   if (terms.length === 0) throw new Error('At least one routing term is required');
   return [...new Set(terms)];
-}
-
-function normalizeRoutingText(value: string): string {
-  return value
-    .normalize('NFKC')
-    .trim()
-    .toLocaleLowerCase()
-    .replace(/[-_]+/g, ' ')
-    .replace(/\s+/g, ' ');
-}
-
-function escapeRegularExpression(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function routingMatchPositions(candidate: string, term: string): number[] {
-  if (/\p{Script=Han}/u.test(candidate)) {
-    const positions: number[] = [];
-    let offset = 0;
-    while (offset <= term.length - candidate.length) {
-      const position = term.indexOf(candidate, offset);
-      if (position === -1) break;
-      positions.push(position);
-      offset = position + candidate.length;
-    }
-    return positions;
-  }
-  const pattern = new RegExp(
-    `(?:^|[^\\p{L}\\p{N}])(${escapeRegularExpression(candidate)})(?=$|[^\\p{L}\\p{N}])`,
-    'gu',
-  );
-  return [...term.matchAll(pattern)].map(
-    (match) => (match.index ?? 0) + match[0].length - (match[1]?.length ?? 0),
-  );
-}
-
-function routingMatchIsNegated(term: string, position: number): boolean {
-  const clause =
-    term
-      .slice(0, position)
-      .split(/[,.!?;，。！？；]/u)
-      .at(-1) ?? '';
-  return /(?:\b(?:do\s+not|don't|not|never|without|no)\s+(?:\p{L}+\s+){0,2}|(?:不要|无需|不必|别|禁止|避免|不)\s*)$/u.test(
-    clause,
-  );
-}
-
-function routingMatchIsRequestedAction(term: string, position: number): boolean {
-  const clause =
-    term
-      .slice(0, position)
-      .split(/[,.!?;，。！？；]/u)
-      .at(-1) ?? '';
-  const prefix = clause.trim();
-  if (prefix === '') return true;
-  return /^(?:(?:please|can you|could you|would you|i want you to|i need you to|let(?:'s| us)|now|then|also)(?:\s+\p{L}+){0,4}|(?:请|请你|帮我|给我|现在|继续|重新|开始|进行|执行|来|需要|要求|希望|想要|逐个|并|只)|(?:结合|基于|根据)[\p{L}\p{N} ._-]{0,40}(?:来)?)$/u.test(
-    prefix,
-  );
-}
-
-function routingMatchIsIllustrative(term: string, position: number): boolean {
-  const prefix = term.slice(Math.max(0, position - 48), position);
-  return /(?:\b(?:for example|e\.g\.|such as)\s*,?\s*|(?:例如|比如|譬如)\s*[：:,，]?\s*)$/u.test(
-    prefix,
-  );
-}
-
-function routingMatchIsQuoted(term: string, position: number): boolean {
-  for (const [open, close] of [
-    ['“', '”'],
-    ['‘', '’'],
-    ['「', '」'],
-    ['『', '』'],
-  ] as const) {
-    const opening = term.lastIndexOf(open, position);
-    if (opening !== -1) {
-      const closing = term.indexOf(close, opening + open.length);
-      if (closing >= position) return true;
-    }
-  }
-  for (const quote of ['"', "'"] as const) {
-    const before = term.slice(0, position).split(quote).length - 1;
-    if (before % 2 === 1 && term.indexOf(quote, position) !== -1) return true;
-  }
-  return false;
-}
-
-function matchesRoutingTerm(trigger: string, term: string): boolean {
-  const candidate = normalizeRoutingText(trigger);
-  if (!candidate) return false;
-  return routingMatchPositions(candidate, term).some(
-    (position) => !routingMatchIsNegated(term, position),
-  );
-}
-
-function matchesPlaybookIntent(trigger: string, term: string): boolean {
-  const candidate = normalizeRoutingText(trigger);
-  if (!candidate) return false;
-  return routingMatchPositions(candidate, term).some(
-    (position) =>
-      !routingMatchIsNegated(term, position) &&
-      !routingMatchIsQuoted(term, position) &&
-      !routingMatchIsIllustrative(term, position) &&
-      routingMatchIsRequestedAction(term, position),
-  );
 }
 
 function aliasList(entry: ManifestEntry, kind: DocumentationRoute['kind'], name: string): string[] {
@@ -183,60 +104,103 @@ function routedPath(docsRoot: string, path: string): string {
   return target;
 }
 
+function validatedManifestEntry(name: string, rawEntry: ManifestEntry) {
+  if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+    throw new Error(`Documentation manifest entry ${name} must be an object`);
+  }
+  if (typeof rawEntry.path !== 'string' || rawEntry.path.trim() === '') {
+    throw new Error(`Documentation manifest entry ${name} has no valid path`);
+  }
+  if (!['playbook', 'topic', 'standard'].includes(String(rawEntry.kind))) {
+    throw new Error(`Documentation manifest entry ${name} has no valid kind`);
+  }
+  if (
+    rawEntry.priority !== undefined &&
+    (typeof rawEntry.priority !== 'number' || !Number.isInteger(rawEntry.priority))
+  ) {
+    throw new Error(`Documentation manifest entry ${name} has invalid priority`);
+  }
+  return {
+    kind: rawEntry.kind as DocumentationRoute['kind'],
+    path: rawEntry.path,
+    priority: rawEntry.priority ?? 0,
+  };
+}
+
 export function routeDocumentation(
   docsRoot: string,
   query: string[],
-  languageContext: ResponseLanguageContext = {},
+  options: DocumentationRouteOptions = {},
 ): DocumentationRouteReport {
   const terms = normalizedTerms(query);
   const manifestPath = resolve(docsRoot, 'manifest.yaml');
   const manifest = parse(readFileSync(manifestPath, 'utf8')) as DocsManifest;
   const entries = manifestEntries(manifest?.entries);
   const routes: DocumentationRoute[] = [];
+  const playbookEvidence = new Map<
+    string,
+    { route: DocumentationRoute; mentioned: boolean; negated: boolean; requested: boolean }
+  >();
 
   for (const [name, rawEntry] of Object.entries(entries)) {
-    if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
-      throw new Error(`Documentation manifest entry ${name} must be an object`);
-    }
-    if (typeof rawEntry.path !== 'string' || rawEntry.path.trim() === '') {
-      throw new Error(`Documentation manifest entry ${name} has no valid path`);
-    }
-    if (!['playbook', 'topic', 'standard'].includes(String(rawEntry.kind))) {
-      throw new Error(`Documentation manifest entry ${name} has no valid kind`);
-    }
-    if (
-      rawEntry.priority !== undefined &&
-      (typeof rawEntry.priority !== 'number' || !Number.isInteger(rawEntry.priority))
-    ) {
-      throw new Error(`Documentation manifest entry ${name} has invalid priority`);
-    }
-    const kind = rawEntry.kind as DocumentationRoute['kind'];
+    const { kind, path, priority } = validatedManifestEntry(name, rawEntry);
     const aliases = aliasList(rawEntry, kind, name);
+    if (kind === 'playbook') {
+      const evidence = aliases.map((alias) => ({
+        alias,
+        values: terms.map((term) => playbookAliasEvidence(alias, term)),
+      }));
+      const route = {
+        kind,
+        name,
+        path: routedPath(docsRoot, path),
+        priority,
+        matchedAliases: evidence
+          .filter(({ values }) => values.some(({ mentioned }) => mentioned))
+          .map(({ alias }) => alias),
+      };
+      playbookEvidence.set(name, {
+        route,
+        mentioned: evidence.some(({ values }) => values.some(({ mentioned }) => mentioned)),
+        negated: evidence.some(({ values }) => values.some(({ negated }) => negated)),
+        requested: evidence.some(({ values }) => values.some(({ requested }) => requested)),
+      });
+      continue;
+    }
     const matchedAliases = aliases.filter((alias) =>
-      terms.some((term) =>
-        kind === 'playbook' ? matchesPlaybookIntent(alias, term) : matchesRoutingTerm(alias, term),
-      ),
+      terms.some((term) => matchesRoutingTerm(alias, term)),
     );
     if (matchedAliases.length === 0) continue;
     routes.push({
       kind,
       name,
-      path: routedPath(docsRoot, rawEntry.path),
-      priority: rawEntry.priority ?? 0,
+      path: routedPath(docsRoot, path),
+      priority,
       matchedAliases,
     });
   }
 
-  const playbooks = routes
-    .filter(({ kind }) => kind === 'playbook')
-    .sort((left, right) => right.priority - left.priority || left.name.localeCompare(right.name));
-  const highest = playbooks[0]?.priority;
-  const highestRanked = playbooks.filter(({ priority }) => priority === highest);
-  const ambiguity = highestRanked.length > 1 ? highestRanked.map(({ name }) => name) : [];
-  const primaryPlaybook = ambiguity.length === 0 ? (playbooks[0] ?? null) : null;
+  const inferred = [...playbookEvidence.values()].filter(({ requested }) => requested);
+  const explicit = options.intent ? playbookEvidence.get(options.intent) : undefined;
+  if (options.intent && !explicit) {
+    throw new Error(`Documentation intent has no playbook route: ${options.intent}`);
+  }
+  const selected = explicit ? [explicit] : inferred;
+  routes.unshift(...selected.map(({ route }) => route));
+  const ambiguity =
+    !explicit && selected.length > 1
+      ? selected.map(({ route }) => route.name).sort((left, right) => left.localeCompare(right))
+      : [];
+  const primaryPlaybook = ambiguity.length === 0 ? (selected[0]?.route ?? null) : null;
   const status = ambiguity.length > 0 ? 'ambiguous' : routes.length > 0 ? 'matched' : 'unmatched';
+  const mentionedActions = [...playbookEvidence.entries()]
+    .filter(([, { mentioned }]) => mentioned)
+    .map(([name]) => name);
+  const negatedActions = [...playbookEvidence.entries()]
+    .filter(([, { negated }]) => negated)
+    .map(([name]) => name);
   return {
-    version: 2,
+    version: 3,
     status,
     query: terms,
     routes,
@@ -244,6 +208,12 @@ export function routeDocumentation(
     top1: primaryPlaybook,
     ambiguity,
     topics: routes.filter(({ kind }) => kind !== 'playbook'),
-    responseLanguage: resolveResponseLanguage(terms.join(' '), languageContext),
+    intent: {
+      requested: primaryPlaybook?.name ?? null,
+      source: options.intent ? 'explicit' : selected.length > 0 ? 'inferred' : 'none',
+      mentionedActions,
+      negatedActions,
+    },
+    responseLanguage: resolveResponseLanguage(terms.join(' '), options.languageContext),
   };
 }

--- a/template/agent-harness/src/program/documentation.ts
+++ b/template/agent-harness/src/program/documentation.ts
@@ -1,0 +1,32 @@
+import { type Command, Option } from 'commander';
+import { route } from '../commands/route.js';
+import { type DocumentationIntent, documentationIntents } from '../lib/docs-routing.js';
+import type { Io, Runtime } from '../types.js';
+import type { CommandRunner } from './types.js';
+
+export function registerDocumentationCommands(
+  program: Command,
+  runtime: Runtime,
+  io: Io,
+  run: CommandRunner,
+): void {
+  for (const [name, description] of [
+    ['route', 'route task terms to relevant Harness documentation'],
+    ['explain', 'explain which Harness documents govern a topic without loading their bodies'],
+  ] as const) {
+    program
+      .command(`${name} <query...>`)
+      .description(description)
+      .option('--json', 'write machine-readable routes without document bodies')
+      .addOption(
+        new Option('--intent <intent>', 'validated primary documentation intent').choices([
+          ...documentationIntents,
+        ]),
+      )
+      .action(
+        run((query: string[], options: { json?: boolean; intent?: DocumentationIntent }) =>
+          route(runtime, query, options, io),
+        ),
+      );
+  }
+}


### PR DESCRIPTION
## Summary / 变更说明

- add Route v3 with validated explicit documentation intents
- separate requested, mentioned, and negated actions while removing priority-based semantic selection
- conservatively handle nominal Chinese action references and progressive implementation requests
- expand the deterministic corpus from 9 to 12 cases using real user requests
- update the managed Prompt and Runtime CLI documentation without increasing the entrypoint budget

## Related Issue / 关联 Issue

Closes #132

## Verification / 验证

- `pnpm run preflight` — 769 deterministic checks; 157 test files; 1041 passed, 3 skipped
- `pnpm run bench:prompt-route` — 12/12 rule adherence, 9/9 action Top-1, `hostProof: false`
- `git diff --check`

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。
