### PR TITLE
feat(harness): bound supporting topic routes

### DIFF
--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -32,7 +32,8 @@ node <harness-path>/bin/harness.mjs --help
 `route` 和 `explain` 根据显式 intent、manifest 的 `actionAliases` 与 `conceptAliases` 返回命中的文档名称、路径和
 alias，不加载正文。能够可靠判断动作时使用受限 `--intent`；未提供时只做保守自动推断。JSON 报告显式区分
 `matched`、`unmatched` 与 `ambiguous`，并只在唯一动作时给出 `top1`；未命中或多个真实动作返回 exit 2，
-不按 priority 猜测。该结构化契约为 version 3。路由只负责文档发现，不传递授权：
+不按 priority 猜测。Supporting topics 按匹配 alias 数量稳定排序并最多返回四个，超出的候选进入 `omittedTopics`，
+避免入口上下文无界增长且不把截断伪装成未命中。该结构化契约为 version 3。路由只负责文档发现，不传递授权：
 
 ```bash
 node <harness-path>/bin/harness.mjs route --intent diagnose payment callback --json

--- a/template/agent-harness/docs/README.md
+++ b/template/agent-harness/docs/README.md
@@ -45,8 +45,8 @@ updated: 2026-08-28
 
 ## 读取原则
 
-1. 能够可靠判断当前动作时显式传入受限 intent 并选择唯一 playbook；Runtime 验证 `--intent` 后返回至多一个
-   `primaryPlaybook` 和零个或多个 `topics`。先加载 primary playbook，再按任务所需加载 supporting topics。
+1. 能够可靠判断当前动作时显式传入受限 intent 并选择唯一 playbook；Runtime 验证 `--intent`，返回至多一个 `primaryPlaybook` 和四个按证据强度排序的 `topics`。
+   先加载 primary playbook，再按返回顺序加载 supporting topics；`omittedTopics` 非空表示还有候选因上下文上限未返回，不得解释为不存在。
 2. 未传 intent 时只做保守自动推断；多个动作返回歧义，低置信度返回 `unmatched`，不靠 priority 或文档顺序决定。
 3. 项目内存在更具体的 `AGENTS.md`、skill 或文档索引时，优先读取项目事实源。
 4. 检索先返回文件名、标题、元信息或命中段落；只有确认相关后才读取全文。

--- a/template/agent-harness/docs/manifest.yaml
+++ b/template/agent-harness/docs/manifest.yaml
@@ -23,7 +23,7 @@ entries:
   harness-cli-architecture:
     kind: topic
     path: core/harness-cli-architecture.md
-    conceptAliases: [harness-cli, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, memory-migrate, memory-curate, curation-apply, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移, 记忆策展, 策展执行]
+    conceptAliases: [harness-cli, architecture-design, implementation-architecture, implementation-principle, install, init, memory-command, memory-autopilot, capture-input, close-input, payload-file, handoff, close-handoff, reconcile-profile, forget-profile, profile-autopilot, acceptance, local-harness, harness-profile, profile-autopilot-control, doctor, health, route, memory-migrate, memory-curate, curation-apply, 架构设计, 实现架构, 实现原理, 实现思想, 安装, 初始化, 记忆命令, 自动记忆, 验收, 本地-harness, harness-画像, 画像控制, 健康检查, 路由, 记忆迁移, 记忆策展, 策展执行]
   observability:
     kind: topic
     path: core/observability.md
@@ -72,7 +72,7 @@ entries:
   prompt-rule-contract:
     kind: standard
     path: standards/prompt-rule-contract.md
-    conceptAliases: [prompt-rule, prompt-contract, guarantee-level, confusing-pair, rule-owner, 提示词规则, 提示词契约, 保证等级, 混淆规则, 规则所有者]
+    conceptAliases: [prompt-rule, prompt-contract, prompt-design, prompt-optimization, prompt-设计, prompt-优化, guarantee-level, confusing-pair, rule-owner, 提示词规则, 提示词契约, 提示词设计, 提示词优化, 保证等级, 混淆规则, 规则所有者]
   user-profile-memory:
     kind: standard
     path: standards/user-profile-memory.md

--- a/template/agent-harness/src/__tests__/docs-routing.test.ts
+++ b/template/agent-harness/src/__tests__/docs-routing.test.ts
@@ -75,6 +75,69 @@ test('documentation routing chooses research when the user explicitly asks to an
   assert.equal(report.primaryPlaybook?.name, 'research-and-design');
 });
 
+test('documentation routing maps architecture and prompt design to their exact owners', () => {
+  const report = routeDocumentation(
+    docsRoot,
+    ['通过第一性原理分析当前项目的架构设计、Prompt 设计和实现原理。'],
+    { intent: 'research-and-design' },
+  );
+
+  assert.deepEqual(
+    report.topics.map(({ name }) => name),
+    ['harness-cli-architecture', 'prompt-rule-contract'],
+  );
+  assert.deepEqual(report.omittedTopics, []);
+});
+
+test('documentation routing ranks supporting evidence and reports topics beyond its context bound', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-doc-topic-routes-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  writeFileSync(
+    join(root, 'manifest.yaml'),
+    `version: 1
+entries:
+  change:
+    kind: playbook
+    path: change.md
+    actionAliases: [change]
+  first:
+    kind: topic
+    path: first.md
+    conceptAliases: [shared]
+  exact-owner:
+    kind: standard
+    path: exact-owner.md
+    conceptAliases: [shared, exact concept]
+  third:
+    kind: topic
+    path: third.md
+    conceptAliases: [shared]
+  fourth:
+    kind: topic
+    path: fourth.md
+    conceptAliases: [shared]
+  fifth:
+    kind: topic
+    path: fifth.md
+    conceptAliases: [shared]
+`,
+  );
+
+  const report = routeDocumentation(root, ['change shared exact concept']);
+  assert.deepEqual(
+    report.topics.map(({ name }) => name),
+    ['exact-owner', 'first', 'third', 'fourth'],
+  );
+  assert.deepEqual(
+    report.omittedTopics.map(({ name }) => name),
+    ['fifth'],
+  );
+  assert.deepEqual(
+    report.routes.map(({ name }) => name),
+    ['change', 'exact-owner', 'first', 'third', 'fourth'],
+  );
+});
+
 test.each([
   '这里引用了“review、design、research”三个词，但没有要求执行这些任务。',
   '文档举例包含评审、设计和调研，不代表当前要执行其中任何一项。',
@@ -91,7 +154,7 @@ test('documentation routing keeps Git and safety as topics without giving either
   assert.equal(report.primaryPlaybook?.name, 'review');
   assert.deepEqual(
     report.topics.map(({ name }) => name),
-    ['safety-and-verification', 'git-conventions'],
+    ['git-conventions', 'safety-and-verification'],
   );
 });
 
@@ -253,7 +316,7 @@ test('an exact multi-turn acceptance prompt routes every required autopilot owne
   assert.equal(report.primaryPlaybook?.name, 'change');
   assert.deepEqual(
     report.topics.map(({ name }) => name),
-    ['harness-cli-architecture', 'long-running-tasks', 'project-agent-docs', 'user-profile-memory'],
+    ['project-agent-docs', 'harness-cli-architecture', 'long-running-tasks', 'user-profile-memory'],
   );
 });
 

--- a/template/agent-harness/src/lib/docs-routing.ts
+++ b/template/agent-harness/src/lib/docs-routing.ts
@@ -45,6 +45,8 @@ export const documentationIntents = [
 
 export type DocumentationIntent = (typeof documentationIntents)[number];
 
+const maximumDocumentationTopics = 4;
+
 export interface DocumentationRouteOptions {
   intent?: DocumentationIntent;
   languageContext?: ResponseLanguageContext;
@@ -59,6 +61,7 @@ export interface DocumentationRouteReport {
   top1: DocumentationRoute | null;
   ambiguity: string[];
   topics: DocumentationRoute[];
+  omittedTopics: DocumentationRoute[];
   intent: {
     requested: string | null;
     source: 'explicit' | 'inferred' | 'none';
@@ -127,6 +130,24 @@ function validatedManifestEntry(name: string, rawEntry: ManifestEntry) {
   };
 }
 
+function boundedDocumentationTopics(routes: DocumentationRoute[]): {
+  topics: DocumentationRoute[];
+  omittedTopics: DocumentationRoute[];
+} {
+  const ranked = routes
+    .map((route, index) => ({ index, route }))
+    .sort(
+      (left, right) =>
+        right.route.matchedAliases.length - left.route.matchedAliases.length ||
+        left.index - right.index,
+    )
+    .map(({ route }) => route);
+  return {
+    topics: ranked.slice(0, maximumDocumentationTopics),
+    omittedTopics: ranked.slice(maximumDocumentationTopics),
+  };
+}
+
 export function routeDocumentation(
   docsRoot: string,
   query: string[],
@@ -136,7 +157,7 @@ export function routeDocumentation(
   const manifestPath = resolve(docsRoot, 'manifest.yaml');
   const manifest = parse(readFileSync(manifestPath, 'utf8')) as DocsManifest;
   const entries = manifestEntries(manifest?.entries);
-  const routes: DocumentationRoute[] = [];
+  const supportingRoutes: DocumentationRoute[] = [];
   const playbookEvidence = new Map<
     string,
     { route: DocumentationRoute; mentioned: boolean; negated: boolean; requested: boolean }
@@ -171,7 +192,7 @@ export function routeDocumentation(
       terms.some((term) => matchesRoutingTerm(alias, term)),
     );
     if (matchedAliases.length === 0) continue;
-    routes.push({
+    supportingRoutes.push({
       kind,
       name,
       path: routedPath(docsRoot, path),
@@ -186,12 +207,13 @@ export function routeDocumentation(
     throw new Error(`Documentation intent has no playbook route: ${options.intent}`);
   }
   const selected = explicit ? [explicit] : inferred;
-  routes.unshift(...selected.map(({ route }) => route));
   const ambiguity =
     !explicit && selected.length > 1
       ? selected.map(({ route }) => route.name).sort((left, right) => left.localeCompare(right))
       : [];
   const primaryPlaybook = ambiguity.length === 0 ? (selected[0]?.route ?? null) : null;
+  const { topics, omittedTopics } = boundedDocumentationTopics(supportingRoutes);
+  const routes = [...selected.map(({ route }) => route), ...topics];
   const status = ambiguity.length > 0 ? 'ambiguous' : routes.length > 0 ? 'matched' : 'unmatched';
   const mentionedActions = [...playbookEvidence.entries()]
     .filter(([, { mentioned }]) => mentioned)
@@ -207,7 +229,8 @@ export function routeDocumentation(
     primaryPlaybook,
     top1: primaryPlaybook,
     ambiguity,
-    topics: routes.filter(({ kind }) => kind !== 'playbook'),
+    topics,
+    omittedTopics,
     intent: {
       requested: primaryPlaybook?.name ?? null,
       source: options.intent ? 'explicit' : selected.length > 0 ? 'inferred' : 'none',


### PR DESCRIPTION
## Summary / 变更说明

- 为架构设计、Prompt 设计与实现原理补齐精确的中英文专题 aliases。
- Supporting topics 按匹配 alias 数量稳定排序，最多返回四个。
- 超出上下文上限的候选通过 `omittedTopics` 显式报告，避免静默丢失。
- 保持 Route v3 的 playbook 动作判定与授权边界不变。

## Related Issue / 关联 Issue

Closes #134

## Verification / 验证

- `pnpm run preflight`
- `git diff --check`
- 真实 CLI：架构/Prompt/实现原理请求返回 `harness-cli-architecture` 与 `prompt-rule-contract`

## Checklist / 检查清单

- [x] 新增行为先补失败测试，再实现通过
- [x] 未修改生成目录中的构建产物
