### PR TITLE
feat(harness): rank bootstrap recommendations

### DIFF
--- a/docs/reference/runtime-cli.md
+++ b/docs/reference/runtime-cli.md
@@ -30,15 +30,19 @@ node <harness-path>/bin/harness.mjs --help
 ## 启动摘要
 
 `bootstrap` 的 version 2 默认输出 `brief`：它仍执行完整的只读 Memory 验证和推荐计算，但只呈现启动决策需要的
-project/Git 状态、Memory state、最多四个 active task、recommended、扫描预算与原因。被有意省略的
-metadata/core/maintenance 和 active task 数量通过 `omitted` 报告，不与“没有数据”混淆。审计或诊断时显式请求完整结构：
+project/Git 状态、Memory state、最多四个 active task、最多八个 recommendations、扫描预算与原因。`recommended`
+保留兼容的引用字符串；`recommendations` 额外提供 `reasonCodes`、`sources`、当前 `status` 与
+`requiresReverification`。推荐按恢复价值稳定排序：blocked/active core 优先于维护候选，过期和已关闭输入不能挤占当前工作。
+被有意省略的 metadata/core/maintenance、active task 和 recommendation 数量通过 `omitted` 报告，不与“没有数据”
+混淆。审计或诊断时显式请求完整结构（最多 32 个 recommendations）：
 
 ```bash
 node <harness-path>/bin/harness.mjs bootstrap --project /path/to/project --detail brief --json
 node <harness-path>/bin/harness.mjs bootstrap --project /path/to/project --detail full --json
 ```
 
-`truncated` 只表示底层有界扫描截断；detail 模式的主动省略只进入 `omitted`。两种模式都不执行修复、归档、迁移或索引写入。
+`truncated` 只表示底层有界扫描或推荐结果截断；detail 模式的主动省略进入 `omitted`。两种模式都不执行修复、归档、
+迁移或索引写入。
 
 ## 文档路由与检索
 

--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -104,7 +104,7 @@ test('startup rules retain progressive project discovery without copying its com
   assert.doesNotMatch(agents, /rg -n -C 12.*输出可见性/);
   assert.match(
     projectMemory,
-    /brief.*metadata.*core.*maintenance.*推荐.*active task.*recommended.*omitted.*full.*完整.*截断/s,
+    /brief.*metadata.*core.*maintenance.*推荐.*active task.*recommendations.*omitted.*full.*完整.*truncated/s,
   );
   assert.doesNotMatch(projectMemory, /memory list.*task status.*memory maintain/s);
   assert.doesNotMatch(agents, /memory list|task status|memory maintain/);
@@ -134,7 +134,7 @@ test('startup deterministically discovers one explicitly referenced project cont
 test('the project-memory standard delegates deterministic startup discovery to bootstrap', () => {
   assert.match(projectMemory, /bootstrap --project <absolute-project-root> --detail brief --json/);
   assert.match(projectMemory, /只读.*不.*修复.*归档.*迁移.*索引/s);
-  assert.match(projectMemory, /recommended.*active\/blocked.*事实源/s);
+  assert.match(projectMemory, /recommendations.*blocked\/active core.*事实源/s);
   assert.doesNotMatch(projectMemory, /sed -n '1,260p' \.agent-docs\/core\.md/);
 });
 

--- a/template/agent-harness/docs/standards/project-agent-docs.md
+++ b/template/agent-harness/docs/standards/project-agent-docs.md
@@ -68,11 +68,14 @@ canonical profile 仍由 Host 在新 task/thread 的首个工具调用中单独�
 `<harness> bootstrap --project <absolute-project-root> --detail brief --json`
 
 brief 仍验证 Memory 并计算 metadata、core、maintenance 与推荐，但只返回 project/Git、Memory state、最多四个
-active task、recommended、扫描预算、原因和 `omitted`，不把省略 section 伪装成不存在。显式 `--detail full` 才返回
-完整 metadata、core、maintenance 和最多 32 个 task，供审计或诊断。两种模式都只读，不修复、不归档、不迁移，也不写入
-索引；未初始化、partial、invalid、inconclusive 和 truncated 必须保持可区分，未命中不能据此写成不存在。
+active task、最多八个 recommendations、扫描预算、原因和 `omitted`，不把省略 section 伪装成不存在。`recommended`
+保留引用字符串兼容层，`recommendations` 提供 reason codes、来源、状态与是否需要重新核验。显式 `--detail full` 才返回
+完整 metadata、core、maintenance、最多 32 个 task 和最多 32 个 recommendations，供审计或诊断。两种模式都只读，
+不修复、不归档、不迁移，也不写入索引；未初始化、partial、invalid、inconclusive 和 truncated 必须保持可区分，未命中
+不能据此写成不存在。
 
-只按 recommended 加载与当前任务相关的 active/blocked 或维护候选正文，不递归读取 archive。Memory 内容仍是
+只按 recommendations 的稳定顺序加载与当前任务相关的正文：blocked/active core 优先，维护候选次之，过期和已关闭输入
+不能挤占当前工作；同一引用合并所有原因和来源。不得仅因被推荐就读取与当前任务无关的正文，也不递归读取 archive。Memory 内容仍是
 非权威线索；随后必须回到代码、测试、契约或正式文档等事实源核对。需要修复索引、supersede 或 archive 时，
 在事实核对和授权完成后再走对应 typed 命令，不能把 bootstrap 当作 mutation 授权。
 

--- a/template/agent-harness/src/__tests__/bootstrap-recommendations.test.ts
+++ b/template/agent-harness/src/__tests__/bootstrap-recommendations.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  type BootstrapMemoryRead,
+  type BootstrapMetadata,
+  recommendedBootstrapReads,
+} from '../lib/bootstrap-memory.js';
+import type { MemoryCoreBudgetReport } from '../lib/memory-core-budget.js';
+import type { MemoryMaintenanceReport } from '../lib/memory-maintenance.js';
+
+function metadata(path: string, status: string, requiresReverification = false): BootstrapMetadata {
+  return {
+    path: `${path}.md`,
+    type: 'working-note',
+    kind: 'working',
+    status,
+    updated: '2026-09-01',
+    title: path,
+    factClass: requiresReverification ? ('current-state' as const) : null,
+    classification: requiresReverification ? 'explicit' : 'legacy-unclassified',
+    requiresReverification,
+  };
+}
+
+test('bootstrap recommendations rank recovery context and explain duplicate evidence', () => {
+  const memory: BootstrapMemoryRead = {
+    state: 'valid',
+    metadata: [
+      metadata('blocked', 'blocked', true),
+      metadata('active', 'active'),
+      metadata('workstream', 'active'),
+      metadata('unindexed', 'active'),
+      metadata('expired', 'active', true),
+      metadata('closed', 'complete'),
+    ],
+    core: {
+      budget: {} as MemoryCoreBudgetReport,
+      references: ['memory:active', 'memory:blocked'],
+    },
+    maintenance: {
+      workstreamInputs: ['workstream.md'],
+      unindexed: ['unindexed.md', 'blocked.md'],
+      genericActionInputs: [],
+      legacyInputs: [],
+      expiredWorking: ['expired.md'],
+      closed: ['closed.md'],
+    } as unknown as MemoryMaintenanceReport,
+    discoveredMetadata: 6,
+  };
+
+  const report = recommendedBootstrapReads('/tmp/.agent-docs', memory, [], 8);
+
+  assert.deepEqual(
+    report.recommendations.map(({ reference }) => reference),
+    [
+      'memory:blocked',
+      'memory:active',
+      'memory:workstream',
+      'memory:unindexed',
+      'memory:expired',
+      'memory:closed',
+    ],
+  );
+  assert.deepEqual(report.recommendations[0], {
+    reference: 'memory:blocked',
+    reasonCodes: ['core-blocked', 'maintenance-unindexed'],
+    sources: ['core', 'maintenance'],
+    status: 'blocked',
+    requiresReverification: true,
+  });
+});
+
+test('bootstrap recommendation limits report omitted candidates without changing ranking', () => {
+  const memory: BootstrapMemoryRead = {
+    state: 'valid',
+    metadata: Array.from({ length: 10 }, (_, index) => metadata(`active-${index}`, 'active')),
+    core: {
+      budget: {} as MemoryCoreBudgetReport,
+      references: Array.from({ length: 10 }, (_, index) => `memory:active-${9 - index}`),
+    },
+    maintenance: null,
+    discoveredMetadata: 10,
+  };
+  const reasons: string[] = [];
+
+  const report = recommendedBootstrapReads('/tmp/.agent-docs', memory, reasons, 8);
+
+  assert.equal(report.discovered, 10);
+  assert.equal(report.recommendations.length, 8);
+  assert.deepEqual(
+    report.recommendations.map(({ reference }) => reference),
+    Array.from({ length: 8 }, (_, index) => `memory:active-${index}`),
+  );
+  assert.ok(reasons.some((reason) => /10 discovered, 8 returned/i.test(reason)));
+});

--- a/template/agent-harness/src/__tests__/bootstrap.test.ts
+++ b/template/agent-harness/src/__tests__/bootstrap.test.ts
@@ -187,6 +187,7 @@ test('bootstrap defaults to a compact brief and preserves full audit detail on r
   assert.deepEqual(brief.omitted, {
     sections: ['memory.metadata', 'memory.core', 'memory.maintenance'],
     activeTasks: 2,
+    recommendations: 0,
   });
 
   assert.equal(full.detail, 'full');
@@ -194,7 +195,7 @@ test('bootstrap defaults to a compact brief and preserves full audit detail on r
   assert.ok(full.memory.core);
   assert.ok(full.memory.maintenance);
   assert.equal(full.tasks.active.length, 6);
-  assert.deepEqual(full.omitted, { sections: [], activeTasks: 0 });
+  assert.deepEqual(full.omitted, { sections: [], activeTasks: 0, recommendations: 0 });
   assert.ok(JSON.stringify(brief).length < JSON.stringify(full).length / 2);
 });
 

--- a/template/agent-harness/src/commands/bootstrap.ts
+++ b/template/agent-harness/src/commands/bootstrap.ts
@@ -1,7 +1,9 @@
 import {
   type BootstrapMemoryRead,
   type BootstrapMetadata,
+  type BootstrapRecommendation,
   type BootstrapState,
+  bootstrapBriefRecommendationLimit,
   bootstrapMetadataLimit,
   bootstrapRecommendationLimit,
   readBootstrapMemory,
@@ -31,10 +33,12 @@ interface BootstrapReportBase {
     maxTasks: number;
     maxBriefTasks: number;
     maxRecommendations: number;
+    maxBriefRecommendations: number;
     discoveredMetadata: number;
     discoveredTasks: number;
+    discoveredRecommendations: number;
   };
-  omitted: { sections: string[]; activeTasks: number };
+  omitted: { sections: string[]; activeTasks: number; recommendations: number };
   truncated: boolean;
   reasons: string[];
 }
@@ -43,6 +47,7 @@ interface BootstrapMemorySummary {
   state: BootstrapState;
   root: string;
   recommended: string[];
+  recommendations: BootstrapRecommendation[];
 }
 
 export interface BootstrapBriefReport extends BootstrapReportBase {
@@ -141,13 +146,21 @@ export function bootstrapProject(
   const reasons: string[] = [];
   const memory = readBootstrapMemory(runtime, snapshot, reasons);
   const tasks = readBootstrapTasks(snapshot, reasons);
-  const recommended = recommendedBootstrapReads(snapshot.memory.root, memory, reasons);
+  const recommendationLimit =
+    detail === 'brief' ? bootstrapBriefRecommendationLimit : bootstrapRecommendationLimit;
+  const recommendationRead = recommendedBootstrapReads(
+    snapshot.memory.root,
+    memory,
+    reasons,
+    recommendationLimit,
+  );
   const activeTaskLimit = detail === 'brief' ? bootstrapBriefTaskLimit : bootstrapTaskLimit;
   const activeTasks = tasks.active.slice(0, activeTaskLimit);
   const memorySummary: BootstrapMemorySummary = {
     state: memory.state,
     root: snapshot.memory.root,
-    recommended,
+    recommended: recommendationRead.recommendations.map(({ reference }) => reference),
+    recommendations: recommendationRead.recommendations,
   };
   const common = {
     version: 2 as const,
@@ -158,12 +171,18 @@ export function bootstrapProject(
       maxTasks: bootstrapTaskLimit,
       maxBriefTasks: bootstrapBriefTaskLimit,
       maxRecommendations: bootstrapRecommendationLimit,
+      maxBriefRecommendations: bootstrapBriefRecommendationLimit,
       discoveredMetadata: memory.discoveredMetadata,
       discoveredTasks: tasks.discovered,
+      discoveredRecommendations: recommendationRead.discovered,
     },
     omitted: {
       sections: detail === 'brief' ? ['memory.metadata', 'memory.core', 'memory.maintenance'] : [],
       activeTasks: Math.max(0, tasks.discovered - activeTasks.length),
+      recommendations: Math.max(
+        0,
+        recommendationRead.discovered - recommendationRead.recommendations.length,
+      ),
     },
     truncated: reasons.some((reason) => /truncated/i.test(reason)),
     reasons,

--- a/template/agent-harness/src/lib/bootstrap-memory.ts
+++ b/template/agent-harness/src/lib/bootstrap-memory.ts
@@ -9,11 +9,17 @@ import {
   type MemoryFactClassification,
 } from './memory-fact-semantics.js';
 import { type MemoryMaintenanceReport, memoryMaintenanceReport } from './memory-maintenance.js';
-import { markdownFiles, memoryReference, readMemoryDocument } from './memory-path.js';
+import { markdownFiles, readMemoryDocument } from './memory-path.js';
 import { validateMemoryRoot } from './memory-validation.js';
 
+export {
+  type BootstrapRecommendation,
+  bootstrapBriefRecommendationLimit,
+  bootstrapRecommendationLimit,
+  recommendedBootstrapReads,
+} from './bootstrap-recommendations.js';
+
 export const bootstrapMetadataLimit = 64;
-export const bootstrapRecommendationLimit = 32;
 
 export type BootstrapState = 'uninitialized' | 'partial' | 'valid' | 'invalid' | 'inconclusive';
 
@@ -147,44 +153,4 @@ export function readBootstrapMemory(
     maintenance,
     discoveredMetadata: metadataResult.discovered,
   };
-}
-
-function candidateReferences(maintenance: MemoryMaintenanceReport | null): string[] {
-  if (!maintenance) return [];
-  const paths = [
-    ...maintenance.unindexed,
-    ...maintenance.expiredWorking,
-    ...maintenance.closed,
-    ...maintenance.legacyInputs,
-    ...maintenance.genericActionInputs,
-    ...maintenance.workstreamInputs,
-  ];
-  return paths.map((path) => `memory:${path.replace(/\.md$/, '')}`);
-}
-
-export function recommendedBootstrapReads(
-  memoryRoot: string,
-  memory: BootstrapMemoryRead,
-  reasons: string[],
-): string[] {
-  const statusByReference = new Map(
-    memory.metadata.map((document) => [
-      `memory:${memoryReference(memoryRoot, join(memoryRoot, document.path))}`,
-      document.status,
-    ]),
-  );
-  const recommended = [
-    ...new Set([
-      ...(memory.core?.references.filter((reference) =>
-        ['active', 'blocked'].includes(statusByReference.get(reference) || ''),
-      ) ?? []),
-      ...candidateReferences(memory.maintenance),
-    ]),
-  ];
-  if (recommended.length > bootstrapRecommendationLimit) {
-    reasons.push(
-      `Recommended reads truncated: ${recommended.length} discovered, ${bootstrapRecommendationLimit} returned`,
-    );
-  }
-  return recommended.slice(0, bootstrapRecommendationLimit);
 }

--- a/template/agent-harness/src/lib/bootstrap-recommendations.ts
+++ b/template/agent-harness/src/lib/bootstrap-recommendations.ts
@@ -1,0 +1,106 @@
+import { join } from 'node:path';
+import type { BootstrapMemoryRead } from './bootstrap-memory.js';
+import type { MemoryMaintenanceReport } from './memory-maintenance.js';
+import { memoryReference } from './memory-path.js';
+
+export const bootstrapRecommendationLimit = 32;
+export const bootstrapBriefRecommendationLimit = 8;
+
+type BootstrapRecommendationReason =
+  | 'core-blocked'
+  | 'core-active'
+  | 'maintenance-workstream-input'
+  | 'maintenance-unindexed'
+  | 'maintenance-generic-action-input'
+  | 'maintenance-legacy-input'
+  | 'maintenance-expired-working'
+  | 'maintenance-closed';
+
+export interface BootstrapRecommendation {
+  reference: string;
+  reasonCodes: BootstrapRecommendationReason[];
+  sources: Array<'core' | 'maintenance'>;
+  status: string | null;
+  requiresReverification: boolean;
+}
+
+interface BootstrapRecommendationRead {
+  recommendations: BootstrapRecommendation[];
+  discovered: number;
+}
+
+interface RankedRecommendation extends BootstrapRecommendation {
+  priority: number;
+}
+
+function maintenanceRecommendationGroups(maintenance: MemoryMaintenanceReport | null) {
+  if (!maintenance) return [];
+  return [
+    { paths: maintenance.workstreamInputs, reason: 'maintenance-workstream-input', priority: 70 },
+    { paths: maintenance.unindexed, reason: 'maintenance-unindexed', priority: 60 },
+    {
+      paths: maintenance.genericActionInputs,
+      reason: 'maintenance-generic-action-input',
+      priority: 50,
+    },
+    { paths: maintenance.legacyInputs, reason: 'maintenance-legacy-input', priority: 40 },
+    { paths: maintenance.expiredWorking, reason: 'maintenance-expired-working', priority: 20 },
+    { paths: maintenance.closed, reason: 'maintenance-closed', priority: 10 },
+  ] as const;
+}
+
+export function recommendedBootstrapReads(
+  memoryRoot: string,
+  memory: BootstrapMemoryRead,
+  reasons: string[],
+  limit = bootstrapRecommendationLimit,
+): BootstrapRecommendationRead {
+  const metadataByReference = new Map(
+    memory.metadata.map((document) => [
+      `memory:${memoryReference(memoryRoot, join(memoryRoot, document.path))}`,
+      document,
+    ]),
+  );
+  const byReference = new Map<string, RankedRecommendation>();
+  const add = (
+    reference: string,
+    reason: BootstrapRecommendationReason,
+    priority: number,
+    source: 'core' | 'maintenance',
+  ) => {
+    const metadata = metadataByReference.get(reference);
+    const existing = byReference.get(reference) ?? {
+      reference,
+      reasonCodes: [],
+      sources: [],
+      status: metadata?.status ?? null,
+      requiresReverification: metadata?.requiresReverification ?? false,
+      priority,
+    };
+    if (!existing.reasonCodes.includes(reason)) existing.reasonCodes.push(reason);
+    if (!existing.sources.includes(source)) existing.sources.push(source);
+    existing.priority = Math.max(existing.priority, priority);
+    byReference.set(reference, existing);
+  };
+  for (const reference of memory.core?.references ?? []) {
+    const status = metadataByReference.get(reference)?.status;
+    if (status === 'blocked') add(reference, 'core-blocked', 100, 'core');
+    if (status === 'active') add(reference, 'core-active', 90, 'core');
+  }
+  for (const group of maintenanceRecommendationGroups(memory.maintenance)) {
+    for (const path of group.paths) {
+      add(`memory:${path.replace(/\.md$/, '')}`, group.reason, group.priority, 'maintenance');
+    }
+  }
+  const ranked = [...byReference.values()].sort(
+    (left, right) =>
+      right.priority - left.priority || left.reference.localeCompare(right.reference),
+  );
+  if (ranked.length > limit) {
+    reasons.push(`Recommended reads truncated: ${ranked.length} discovered, ${limit} returned`);
+  }
+  return {
+    recommendations: ranked.slice(0, limit).map(({ priority: _, ...item }) => item),
+    discovered: ranked.length,
+  };
+}


### PR DESCRIPTION
## Summary / 变更说明

- rank bootstrap recommendations by recovery value so blocked and active core context wins
- preserve the compatible recommended list and add structured reasons, sources, status, and reverification metadata
- cap brief output at 8, full output at 32, and report omitted recommendation counts explicitly

## Related Issue / 关联 Issue

Closes #138

## Verification / 验证

- `pnpm run preflight`
- 770 preflight checks passed
- 159 test files passed; 1047 tests passed; 3 skipped

## Checklist / 检查清单

- [x] Tests added or updated
- [x] Documentation updated
