### PR TITLE
refactor(prompt): enforce owner boundaries

### DIFF
--- a/src/__tests__/memory-autopilot-lifecycle-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-lifecycle-prompt.test.ts
@@ -33,6 +33,12 @@ test('payload and profile command contracts have dedicated owners', () => {
   assert.deepEqual(owners(/profile-autopilot pause/), ['user-profile']);
 });
 
+test('entry output summaries route field and host-signal protocols to dedicated owners', () => {
+  assert.deepEqual(owners(/action.*path.*validation/), ['project-memory']);
+  assert.deepEqual(owners(/恢复.*检索.*修复.*归档.*校验/), ['project-memory']);
+  assert.deepEqual(owners(/允许空响应.*agent_message.*强制响应/), ['long-running-tasks']);
+});
+
 test('supporting documents route to owners instead of restating their protocols', () => {
   assert.match(documents.get('project-memory') ?? '', /long-running-tasks\.md/);
   assert.match(documents.get('project-memory') ?? '', /harness-cli-architecture\.md/);

--- a/src/__tests__/memory-autopilot-prompt.test.ts
+++ b/src/__tests__/memory-autopilot-prompt.test.ts
@@ -42,7 +42,7 @@ test('top-level rules preserve only durable trust authorization and delivery bou
 
 test('top-level prompt is a compact bootstrap instead of a Memory CLI manual', () => {
   const lines = agents.trimEnd().split('\n');
-  assert.ok(lines.length <= 60, `template/AGENTS.md has ${lines.length} lines`);
+  assert.ok(lines.length <= 50, `template/AGENTS.md has ${lines.length} lines`);
   assert.ok(Math.max(...lines.map((line) => line.length)) <= 160);
   assert.doesNotMatch(
     agents,
@@ -151,30 +151,27 @@ test('the bounded output-visibility read retains the ordinary-sidecar classifier
 
 test('background sidecars stay quiet while explicit Memory requests remain auditable', () => {
   assert.match(agents, /自动.*sidecar.*静默/s);
-  assert.match(agents, /明确.*Memory.*action.*path.*validation/s);
+  assert.doesNotMatch(agents, /action.*path.*validation/s);
   assert.match(projectMemory, /自动后台.*静默/s);
   assert.match(projectMemory, /用户明确请求.*action.*path.*validation/s);
   assert.match(projectMemory, /字段名.*原样.*action.*path.*validation/s);
   assert.match(projectMemory, /正式结论.*handoff.*不能替代.*path/s);
-  assert.match(agents, /普通任务.*Memory.*恢复.*检索.*修复.*归档.*校验.*不得.*commentary\/final/s);
+  assert.doesNotMatch(agents, /恢复.*检索.*修复.*归档.*校验/s);
   assert.match(
     projectMemory,
     /普通任务.*Memory.*恢复.*检索.*修复.*归档.*校验.*不得.*commentary\/final/s,
   );
-  assert.match(agents, /普通任务.*不得.*action.*path.*validation.*\.agent-docs/s);
+  assert.doesNotMatch(agents, /action.*path.*validation.*\.agent-docs/s);
   assert.match(projectMemory, /普通任务.*不得.*action.*path.*validation.*\.agent-docs/s);
   assert.match(projectMemory, /即使触发自动 sidecar.*不等于索要操作/s);
   assert.match(projectMemory, /prior memory.*preserve expensive finding.*后台 sidecar/s);
   assert.match(projectMemory, /普通任务.*final.*不得.*持久保留.*已保存.*归档.*Memory.*校验/s);
   assert.match(projectMemory, /final.*独立句.*直接陈述.*不.*结论/s);
   assert.match(projectMemory, /final.*事实本身.*主语.*当前架构边界为.*不.*正式文档确认/s);
+  assert.doesNotMatch(agents, /host-signal\/replay|agent_message/);
   assert.match(
-    agents,
+    longRunning,
     /纯 host-signal\/replay.*允许空响应.*不得.*agent_message.*强制响应.*上一用户任务.*验证结果.*不提.*sidecar/s,
-  );
-  assert.match(
-    agents,
-    /commentary.*只描述.*用户任务.*不得.*(?:记录|保存|同步|更新).*(?:偏好|验收约束|Memory|profile|handoff|checkpoint)/s,
   );
   assert.match(
     projectMemory,

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -40,16 +40,9 @@
 
 ## 事实与 Memory
 
-- 冲突时核对用户意图、代码、测试、契约和已接受决策，并注明时间、版本和理由。
-- `docs/`、ADR、代码、测试、schema、lint 和 CI 是事实源；Memory 只保存非权威输入、状态、证据和
-  可追溯提炼。宿主原生 memory 仅作待核对线索。
-- 项目 Memory 的资格、发现、写入、Task/Handoff、画像和 CLI 细节以路由命中的专题文档为准，入口层不复制其协议。
-- 自动捕获必须先得到统一资格结果；未执行判断是 `not-evaluated`，不能冒充 `unchanged` 或已完成写入。
-- 自动后台 sidecar 保持静默；commentary 只描述用户任务，不得说将记录、保存、同步或更新偏好、验收约束、
-  Memory、profile、handoff 或 checkpoint；普通任务中的 Memory 恢复、检索、修复、归档和校验不得出现在 commentary/final。
-- 纯 host-signal/replay turn：宿主允许空响应时不得发送 `agent_message`；强制响应时只陈述上一用户任务的验证结果，不提 sidecar 动作。
-- 普通任务不得输出 `action`、`path`、`validation` 或任何 `.agent-docs` 路径；只有用户明确请求 Memory 审计时例外。
-- 用户明确请求 Memory 操作、交接、状态或审计时，返回最小可核验结果：`action`、`path`、`validation`；proposed 或 blocked 时说明原因。
+- 冲突时核对用户意图、代码、测试、契约和已接受决策；`docs/`、ADR、代码、测试、schema、lint 和 CI 是事实源，Harness Memory 和宿主原生 memory 仅作待核对线索。
+- 项目 Memory、Task/Handoff、画像和 CLI 协议以路由命中的 owner 文档为准；入口层不复制其协议。
+- 自动后台 sidecar 保持静默，commentary/final 只报告用户任务；显式 Memory 操作或审计按 owner 契约返回可核验结果。
 
 ## 安全
 

--- a/template/agent-harness/docs/core/long-running-tasks.md
+++ b/template/agent-harness/docs/core/long-running-tasks.md
@@ -101,6 +101,9 @@ verifier exit 0 且 candidate/workspace digest 与当前状态绑定。重复 si
 采用不同的可见性策略，统一遵循 [project Memory standard](../standards/project-agent-docs.md)；
 host-signal/replay 的执行时机和状态语义仍由本协议定义。
 
+纯 host-signal/replay turn 中，宿主允许空响应时不得发送 `agent_message`；宿主强制响应时只陈述上一用户任务的
+验证结果，不提 sidecar、checkpoint 或 replay 动作。
+
 ## 行为约束
 
 - `task init` 自动把 `working/<task-id>/progress.md` 挂入 `.agent-docs/core.md`；checkpoint 保持入口

--- a/template/agent-harness/docs/standards/prompt-rule-contract.md
+++ b/template/agent-harness/docs/standards/prompt-rule-contract.md
@@ -24,6 +24,9 @@ updated: 2026-08-31
 入口 Prompt 可以保留高损失摘要和 owner 指针，不复制 owner 文档的字段、状态机或命令细节。新增规则前先检查
 现有 ID、owner 和 `confusingWith`，避免用同义规则覆盖同一个失败模式。
 
+入口 Prompt 采用 50 行硬预算，只容纳每次任务都必须看到且遗漏代价高的边界。字段级输出、状态转换、重试和
+Host 事件响应由 owner 文档完整定义；契约测试同时验证入口预算、必要摘要和详细协议的唯一 owner。
+
 ## 保证等级
 
 - `enforced`：代码、schema、validator、锁或事务可机械拒绝违规；必须同时提供实现与 executable verification。


### PR DESCRIPTION
## Summary / 变更说明

- reduce the always-on entry prompt from 57 lines to a 50-line hard budget
- keep high-loss trust, discovery, evidence, and delivery summaries while routing field-level protocols to their owners
- make Project Memory the unique owner of audit/output details and Long-running Tasks the unique owner of host-signal response behavior
- add executable owner-boundary and prompt-budget regression tests

## Related Issue / 关联 Issue

Closes #140

## Verification / 验证

- `pnpm run preflight`
- 770 preflight checks passed
- 159 test files passed; 1048 tests passed; 3 skipped

## Checklist / 检查清单

- [x] Tests added or updated
- [x] Prompt contract documentation updated
