### PR TITLE
feat(status): expose content fingerprints

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,9 +91,14 @@ npx harnessmith status --agent codex --explain --json
 ```
 
 解释输出使用稳定的 `observedState`、`reasonCode` 和 action `code`，逐项列出安装记录、受管理输出与备份证据。
+`status --json` 与 `--explain` 还返回 `contentFingerprint`：`recorded` 绑定安装时实际渲染的受管理内容，`current`
+绑定当前内容；二者一致为 `matched`，差异为 `drifted`，旧记录或未接管目标为 `unrecorded`。计算按逻辑输出角色排序，
+并把安装时展开的绝对路径还原为占位符，因此同一 Adapter 的等价安装可以跨主目录比较。
 本地状态可判定为 `managed`、`modified`、`unmanaged`、`partial` 或 `missing`；`unsupported` 表示没有 Adapter
 契约并在路径解析前停止。Harness capability、Host configuration 和真实 Host behavior 分开报告，无法从本地证明的 Host
 结论固定为 `inconclusive` / `host-dependent`，不会误报为 healthy。
+
+内容指纹只证明 Harnessmith 受管理 Prompt/配置的内容身份，不证明 Host 已加载这些文件，也不证明模型行为、权限或认证状态。
 
 `status` 的 First Value 投影只把 `managed` 映射为 `installed: passed`；因为该命令不运行 Runtime health，`healthy`
 仍为 `not-checked`。managed 状态的统一下一步是 `diagnostics --agent <agent> --json`。

--- a/src/__tests__/status-content-fingerprint.test.ts
+++ b/src/__tests__/status-content-fingerprint.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter } from '../adapters.js';
+import { installAll } from '../install.js';
+import { inspectStatusAll, statusAll } from '../lifecycle.js';
+import { explainStatus } from '../status-explanation.js';
+
+function fixture(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const env = {
+    ...process.env,
+    HOME: root,
+    CODEX_HOME: join(root, 'codex-home'),
+    HARNESS_MEMORY_HOME: join(root, 'agent-docs'),
+    HARNESS_PERSONAL_HOME: join(root, 'personal-harness'),
+    HARNESS_REPOSITORY_ROOT: join(root, 'repositories'),
+    HARNESS_OWNER: 'fingerprint-test',
+  };
+  return { root, env, adapter: createAdapter('codex', { env }) };
+}
+
+test('effective content fingerprints are stable across absolute installation homes', () => {
+  const left = fixture('harnessmith-fingerprint-left-');
+  const right = fixture('harnessmith-fingerprint-right-');
+  installAll([left.adapter], { env: left.env, noInitGlobal: true });
+  installAll([right.adapter], { env: right.env, noInitGlobal: true });
+
+  const leftStatus = statusAll([left.adapter])[0];
+  const rightStatus = statusAll([right.adapter])[0];
+
+  assert.equal(leftStatus.contentFingerprint.state, 'matched');
+  assert.equal(leftStatus.contentFingerprint.recorded, leftStatus.contentFingerprint.current);
+  assert.match(leftStatus.contentFingerprint.current, /^sha256:[a-f0-9]{64}$/);
+  assert.deepEqual(leftStatus.contentFingerprint, rightStatus.contentFingerprint);
+});
+
+test('effective content fingerprints expose drift and status explanation evidence', () => {
+  const { env, adapter } = fixture('harnessmith-fingerprint-drift-');
+  installAll([adapter], { env, noInitGlobal: true });
+  const before = statusAll([adapter])[0].contentFingerprint;
+
+  writeFileSync(adapter.instructions[0].path, 'modified instructions\n');
+  const after = statusAll([adapter])[0].contentFingerprint;
+
+  assert.equal(after.state, 'drifted');
+  assert.equal(after.recorded, before.recorded);
+  assert.notEqual(after.current, before.current);
+  assert.deepEqual(
+    explainStatus(inspectStatusAll([adapter])[0]).evidence.contentFingerprint,
+    after,
+  );
+
+  rmSync(adapter.harness, { recursive: true });
+  const missing = statusAll([adapter])[0].contentFingerprint;
+  assert.equal(missing.state, 'drifted');
+  assert.notEqual(missing.current, after.current);
+});
+
+test('unmanaged content has a current fingerprint without a recorded identity', () => {
+  const { adapter } = fixture('harnessmith-fingerprint-unmanaged-');
+  mkdirSync(adapter.home, { recursive: true });
+  writeFileSync(adapter.instructions[0].path, 'unmanaged instructions\n');
+
+  const status = statusAll([adapter])[0];
+
+  assert.equal(status.installed, false);
+  assert.deepEqual(status.contentFingerprint, {
+    version: 1,
+    algorithm: 'sha256',
+    state: 'unrecorded',
+    recorded: null,
+    current: status.contentFingerprint.current,
+  });
+  assert.match(status.contentFingerprint.current, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('legacy installation records remain readable and report an unrecorded fingerprint', () => {
+  const { env, adapter } = fixture('harnessmith-fingerprint-legacy-');
+  installAll([adapter], { env, noInitGlobal: true });
+  const record = JSON.parse(readFileSync(adapter.record, 'utf8'));
+  delete record.contentFingerprint;
+  writeFileSync(adapter.record, `${JSON.stringify(record, null, 2)}\n`);
+
+  const status = statusAll([adapter])[0];
+
+  assert.equal(status.installed, true);
+  assert.ok(status.outputs.every(({ status: value }) => value === 'managed'));
+  assert.equal(status.contentFingerprint.state, 'unrecorded');
+  assert.equal(status.contentFingerprint.recorded, null);
+});
+
+test('a malformed install context is reported as drift instead of breaking status', () => {
+  const { env, adapter } = fixture('harnessmith-fingerprint-context-');
+  installAll([adapter], { env, noInitGlobal: true });
+  writeFileSync(join(adapter.harness, 'install-context.json'), '{invalid json\n');
+
+  const status = statusAll([adapter])[0];
+
+  assert.equal(status.contentFingerprint.state, 'drifted');
+  assert.ok(status.outputs.some(({ status: value }) => value === 'modified'));
+});

--- a/src/__tests__/status-content-fingerprint.test.ts
+++ b/src/__tests__/status-content-fingerprint.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { onTestFinished, test } from 'vitest';
 import { createAdapter } from '../adapters.js';
+import { effectiveContentFingerprint } from '../effective-content-fingerprint.js';
 import { installAll } from '../install.js';
 import { inspectStatusAll, statusAll } from '../lifecycle.js';
 import { explainStatus } from '../status-explanation.js';
@@ -102,4 +103,40 @@ test('a malformed install context is reported as drift instead of breaking statu
 
   assert.equal(status.contentFingerprint.state, 'drifted');
   assert.ok(status.outputs.some(({ status: value }) => value === 'modified'));
+});
+
+test('fingerprint normalization handles JSON-escaped Windows paths', () => {
+  const left = fixture('harnessmith-fingerprint-windows-left-');
+  const right = fixture('harnessmith-fingerprint-windows-right-');
+  for (const [fixtureValue, root] of [
+    [left, 'C:\\Users\\left'],
+    [right, 'C:\\Users\\right'],
+  ] as const) {
+    mkdirSync(fixtureValue.adapter.harness, { recursive: true });
+    const harnessHome = `${root}\\.codex`;
+    const instruction = `${harnessHome}\\AGENTS.md`;
+    writeFileSync(
+      join(fixtureValue.adapter.harness, 'install-context.json'),
+      `${JSON.stringify(
+        {
+          version: 1,
+          adapter: 'codex',
+          harnessHome,
+          instructionFiles: [instruction],
+          memoryHome: `${root}\\.agent-docs`,
+          personalHome: `${root}\\.agent-harness`,
+          repositoryRoot: `${root}\\git-repo`,
+          owner: 'fingerprint-test',
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFileSync(fixtureValue.adapter.instructions[0].path, `Read ${harnessHome}\\docs\n`);
+  }
+
+  assert.equal(
+    effectiveContentFingerprint(left.adapter),
+    effectiveContentFingerprint(right.adapter),
+  );
 });

--- a/src/content-fingerprint-types.ts
+++ b/src/content-fingerprint-types.ts
@@ -1,0 +1,7 @@
+export interface ManagedContentFingerprint {
+  version: 1;
+  algorithm: 'sha256';
+  state: 'matched' | 'drifted' | 'unrecorded';
+  recorded: string | null;
+  current: string;
+}

--- a/src/effective-content-fingerprint.ts
+++ b/src/effective-content-fingerprint.ts
@@ -1,0 +1,151 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import type { Adapter } from './types.js';
+
+interface FingerprintBudget {
+  entries: number;
+  bytes: number;
+  deadline: number;
+}
+
+interface Replacement {
+  value: string;
+  token: string;
+  contextOnly: boolean;
+}
+
+const fingerprintLimits = {
+  maxEntries: 100_000,
+  maxBytes: 512 * 1024 * 1024,
+  maxFileBytes: 128 * 1024 * 1024,
+  maxDepth: 64,
+  maxDurationMs: 30_000,
+};
+
+function portable(path: string): string {
+  return path.replaceAll(sep, '/');
+}
+
+function replacements(adapter: Adapter): Replacement[] {
+  const contextPath = join(adapter.harness, 'install-context.json');
+  if (!existsSync(contextPath)) return [];
+  let context: Record<string, unknown>;
+  try {
+    context = JSON.parse(readFileSync(contextPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+  const values: Replacement[] = [];
+  for (const [key, token] of [
+    ['harnessHome', '{{HARNESS_HOME}}'],
+    ['memoryHome', '{{HARNESS_MEMORY_HOME}}'],
+    ['personalHome', '{{HARNESS_PERSONAL_HOME}}'],
+    ['repositoryRoot', '{{HARNESS_REPOSITORY_ROOT}}'],
+  ] as const) {
+    const value = context[key];
+    if (typeof value === 'string' && value) values.push({ value, token, contextOnly: false });
+  }
+  const instructionFiles = context.instructionFiles;
+  if (Array.isArray(instructionFiles)) {
+    instructionFiles.forEach((value, index) => {
+      if (typeof value === 'string' && value) {
+        values.push({ value, token: `{{INSTRUCTION_FILE_${index}}}`, contextOnly: true });
+      }
+    });
+  }
+  if (typeof context.owner === 'string' && context.owner) {
+    values.push({ value: context.owner, token: '{{HARNESS_OWNER}}', contextOnly: true });
+  }
+  return values.sort((left, right) => right.value.length - left.value.length);
+}
+
+function normalizedContent(
+  content: Buffer,
+  relative: string,
+  substitutions: Replacement[],
+): Buffer | string {
+  const text = content.toString('utf8');
+  if (!Buffer.from(text, 'utf8').equals(content)) return content;
+  const isContext = portable(relative) === 'install-context.json';
+  return substitutions.reduce(
+    (value, replacement) =>
+      replacement.contextOnly && !isContext
+        ? value
+        : value.replaceAll(replacement.value, replacement.token),
+    text,
+  );
+}
+
+function reserve(budget: FingerprintBudget, path: string, depth: number, bytes = 0): void {
+  if (Date.now() > budget.deadline) throw new Error(`Fingerprint time budget exceeded: ${path}`);
+  if (depth > fingerprintLimits.maxDepth)
+    throw new Error(`Fingerprint depth budget exceeded: ${path}`);
+  budget.entries += 1;
+  if (budget.entries > fingerprintLimits.maxEntries)
+    throw new Error(`Fingerprint entry budget exceeded: ${path}`);
+  if (bytes > fingerprintLimits.maxFileBytes)
+    throw new Error(`Fingerprint file byte budget exceeded: ${path}`);
+  budget.bytes += bytes;
+  if (budget.bytes > fingerprintLimits.maxBytes)
+    throw new Error(`Fingerprint total byte budget exceeded: ${path}`);
+}
+
+function hashOutput(
+  hash: ReturnType<typeof createHash>,
+  root: string,
+  role: string,
+  substitutions: Replacement[],
+  budget: FingerprintBudget,
+): void {
+  if (!existsSync(root)) {
+    hash.update(`missing:${role}\n`);
+    return;
+  }
+  const pending = [{ path: root, relative: '', depth: 0 }];
+  while (pending.length > 0) {
+    const item = pending.pop();
+    if (!item) continue;
+    const stat = lstatSync(item.path);
+    const identity = `${role}/${portable(item.relative)}`;
+    if (stat.isDirectory()) {
+      reserve(budget, item.path, item.depth);
+      hash.update(`directory:${identity}\n`);
+      const children = readdirSync(item.path)
+        .filter((name) => !(role === 'harness' && !item.relative && name === 'state'))
+        .sort((left, right) => right.localeCompare(left))
+        .map((name) => ({
+          path: join(item.path, name),
+          relative: item.relative ? join(item.relative, name) : name,
+          depth: item.depth + 1,
+        }));
+      pending.push(...children);
+    } else if (stat.isFile()) {
+      reserve(budget, item.path, item.depth, stat.size);
+      hash.update(`file:${identity}\n`);
+      hash.update(normalizedContent(readFileSync(item.path), item.relative, substitutions));
+    } else if (stat.isSymbolicLink()) {
+      reserve(budget, item.path, item.depth);
+      hash.update(`symlink:${identity}:${readlinkSync(item.path)}\n`);
+    } else {
+      reserve(budget, item.path, item.depth);
+      hash.update(`special:${identity}\n`);
+    }
+  }
+}
+
+export function effectiveContentFingerprint(adapter: Adapter): string {
+  const hash = createHash('sha256');
+  const substitutions = replacements(adapter);
+  const budget = {
+    entries: 0,
+    bytes: 0,
+    deadline: Date.now() + fingerprintLimits.maxDurationMs,
+  };
+  hash.update(`adapter:${adapter.name}\n`);
+  hashOutput(hash, adapter.harness, 'harness', substitutions, budget);
+  adapter.instructions.forEach(({ path }, index) => {
+    hashOutput(hash, path, `instruction:${index}`, substitutions, budget);
+  });
+  return `sha256:${hash.digest('hex')}`;
+}

--- a/src/effective-content-fingerprint.ts
+++ b/src/effective-content-fingerprint.ts
@@ -68,13 +68,35 @@ function normalizedContent(
   const text = content.toString('utf8');
   if (!Buffer.from(text, 'utf8').equals(content)) return content;
   const isContext = portable(relative) === 'install-context.json';
-  return substitutions.reduce(
-    (value, replacement) =>
-      replacement.contextOnly && !isContext
-        ? value
-        : value.replaceAll(replacement.value, replacement.token),
-    text,
-  );
+  const normalize = (value: string, context: boolean) =>
+    substitutions.reduce(
+      (result, replacement) =>
+        replacement.contextOnly && !context
+          ? result
+          : result.replaceAll(replacement.value, replacement.token),
+      value,
+    );
+  if (isContext) {
+    try {
+      const normalizeJson = (value: unknown): unknown => {
+        if (typeof value === 'string') return normalize(value, true);
+        if (Array.isArray(value)) return value.map(normalizeJson);
+        if (value && typeof value === 'object') {
+          return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+              key,
+              normalizeJson(item),
+            ]),
+          );
+        }
+        return value;
+      };
+      return JSON.stringify(normalizeJson(JSON.parse(text)));
+    } catch {
+      return text;
+    }
+  }
+  return normalize(text, false);
 }
 
 function reserve(budget: FingerprintBudget, path: string, depth: number, bytes = 0): void {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,5 +1,6 @@
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
+import { effectiveContentFingerprint } from './effective-content-fingerprint.js';
 import {
   atomicWrite,
   copyRenderedTree,
@@ -148,6 +149,7 @@ export function commitInstall(prepared: PreparedInstall, stamp = timestamp()): P
     packageVersion,
     adapter: prepared.adapter.name,
     installedAt: new Date().toISOString(),
+    contentFingerprint: effectiveContentFingerprint(prepared.adapter),
     outputs: prepared.outputs.map(({ destination }) => ({
       path: destination,
       checksum: digestManagedOutput(prepared.adapter, destination),

--- a/src/records.ts
+++ b/src/records.ts
@@ -77,6 +77,12 @@ export function readInstallRecordAt(adapter: Adapter, recordPath: string): Insta
         assertSafePath(adapter.home, output.backup);
       }
     }
+    if (
+      record.contentFingerprint !== undefined &&
+      !/^sha256:[a-f0-9]{64}$/.test(record.contentFingerprint)
+    ) {
+      throw new Error('invalid content fingerprint');
+    }
     if (record.recordBackup) {
       const validRecordBackup =
         resolve(record.recordBackup) === record.recordBackup &&

--- a/src/status-explanation.ts
+++ b/src/status-explanation.ts
@@ -96,6 +96,7 @@ export function explainStatus({ adapter, status, record, plan }: AdapterStatusIn
           : ('requires-review' as const),
     evidence: {
       record: { path: adapter.record, state: record ? ('present' as const) : ('missing' as const) },
+      contentFingerprint: status.contentFingerprint,
       outputs: status.installed
         ? status.outputs
         : plan.outputs.map(({ path, state: outputState }) => ({ path, status: outputState })),

--- a/src/status-inspection.ts
+++ b/src/status-inspection.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { effectiveContentFingerprint } from './effective-content-fingerprint.js';
 import { assertLifecyclePaths } from './lifecycle-plan.js';
 import { withAdapterLocks } from './operation-lock.js';
 import {
@@ -12,6 +13,8 @@ import type { Adapter, AdapterStatus, AdapterStatusInspection } from './types.js
 function inspectAdapterStatus(adapter: Adapter): AdapterStatusInspection {
   assertLifecyclePaths(adapter);
   const record = readInstallRecord(adapter);
+  const currentFingerprint = effectiveContentFingerprint(adapter);
+  const recordedFingerprint = record?.contentFingerprint ?? null;
   if (record) assertLifecyclePaths(adapter, [{ path: adapter.record, record }]);
   return {
     adapter,
@@ -24,6 +27,18 @@ function inspectAdapterStatus(adapter: Adapter): AdapterStatusInspection {
       capabilities: adapter.capabilities,
       packageVersion: record?.packageVersion || null,
       installedAt: record?.installedAt || null,
+      contentFingerprint: {
+        version: 1,
+        algorithm: 'sha256',
+        state:
+          recordedFingerprint === null
+            ? 'unrecorded'
+            : recordedFingerprint === currentFingerprint
+              ? 'matched'
+              : 'drifted',
+        recorded: recordedFingerprint,
+        current: currentFingerprint,
+      },
       outputs:
         record?.outputs.map(({ path, checksum }) => ({
           path,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from 'node:stream';
 import type { AgentName } from './adapter-registry.js';
+import type { ManagedContentFingerprint } from './content-fingerprint-types.js';
 
 export type { AgentName };
 export type OutputAction = 'create' | 'replace-managed' | 'conflict';
@@ -64,6 +65,7 @@ export interface InstallRecord {
   packageVersion: string;
   adapter: AgentName;
   installedAt: string;
+  contentFingerprint?: string;
   outputs: RecordOutput[];
   ignoreFiles: string[];
   recordBackup: string | null;
@@ -125,6 +127,7 @@ export interface AdapterStatus {
   capabilities: AdapterCapabilities;
   packageVersion: string | null;
   installedAt: string | null;
+  contentFingerprint: ManagedContentFingerprint;
   outputs: Array<{ path: string; status: ManagedStatus }>;
 }
 


### PR DESCRIPTION
## Summary / 变更说明

- bind each new installation record to a normalized aggregate SHA-256 of the effective managed Prompt and Harness content
- expose recorded/current fingerprints and matched, drifted, or unrecorded state in status JSON and explain evidence
- normalize installation-specific absolute paths so equivalent installs are comparable across homes
- preserve legacy schema compatibility and report malformed context or modified/missing outputs as drift

## Related Issue / 关联 Issue

Closes #142

## Verification / 验证

- `pnpm run preflight`
- 770 preflight checks passed
- 160 test files passed; 1053 tests passed; 3 skipped

## Checklist / 检查清单

- [x] Tests added or updated
- [x] CLI documentation updated
