### PR TITLE
test(preflight): verify every adapter lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,10 +84,13 @@ verifier 证据绑定到精确候选 tarball；仓库中的 `eval:validate` 与 
 - Task 的 `complete` 路径必须在持久化之前调用 `assertTaskCanComplete`；该检查是 acceptance gate 的机械入口，不能由
   Prompt、completion curation 或普通 checkpoint 代替。
 - Host identity、专属路径、环境变量与 hook 只能由外层 Adapter 拥有；portable template 的静态检查拒绝这些身份泄漏。
+- `preflight` 从 Adapter registry 派生完整目标集，并在隔离 clean room 中通过已构建外层 CLI 执行 dry-run、安装、
+  状态、内嵌 Runtime 校验和卸载；新增 Adapter 若未进入这条 package-facing 生命周期会直接失败。
 - `docs/capability-evidence.yaml` 中每个 capability claim 必须使用唯一 ID。`implemented` 不仅要指向实现，还必须指向
   executable verification；`delegated` 和 `unsupported` 则必须指向公开边界，不能靠措辞强度提升保证等级。
 
-这些检查证明仓库内的确定性结构没有漂移，不证明真实 Host 已执行规则，也不把自然语言 guidance 升级为权限强制。
+这些检查证明仓库内的确定性结构与 Adapter 安装事务没有漂移，不证明真实 Host 已执行规则，也不把自然语言 guidance
+升级为权限强制。
 
 ## 一次安装的事务边界
 

--- a/scripts/preflight-adapters.ts
+++ b/scripts/preflight-adapters.ts
@@ -1,0 +1,188 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { supportedAgentNames } from '../src/adapter-registry.js';
+import { withTemporaryWorkspace } from '../src/temporary-resource.js';
+
+type Check = (condition: unknown, message: string) => void;
+type RunNode = (entry: string, args: string[], env?: NodeJS.ProcessEnv) => string;
+
+interface AdapterOutput {
+  path?: string;
+}
+
+interface AdapterResult {
+  adapter?: string;
+  harness?: string;
+  record?: string;
+  outputs?: AdapterOutput[];
+}
+
+function jsonLines<T>(output: string): T[] {
+  return output
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as T);
+}
+
+export function checkAdapterSet(
+  actual: Array<string | undefined>,
+  subject: string,
+  check: Check,
+): void {
+  check(
+    JSON.stringify(actual) === JSON.stringify(supportedAgentNames),
+    `${subject} did not cover every registered adapter: ${actual.join(', ')}`,
+  );
+}
+
+function checkDryRun(
+  outerCli: string,
+  project: string,
+  env: NodeJS.ProcessEnv,
+  runNode: RunNode,
+  check: Check,
+): void {
+  const plans = jsonLines<{ adapter?: string; home?: string; outputs?: AdapterOutput[] }>(
+    runNode(
+      outerCli,
+      ['install', '--agent', 'all', '--project', project, '--dry-run', '--yes', '--json'],
+      env,
+    ),
+  );
+  checkAdapterSet(
+    plans.map(({ adapter }) => adapter),
+    'outer CLI dry-run',
+    check,
+  );
+  for (const plan of plans) {
+    check(Boolean(plan.outputs?.length), `outer CLI dry-run omitted ${plan.adapter} outputs`);
+    check(
+      Boolean(plan.home) && !existsSync(plan.home as string),
+      `outer CLI dry-run unexpectedly wrote the ${plan.adapter} home`,
+    );
+  }
+}
+
+function checkInstall(
+  outerCli: string,
+  project: string,
+  env: NodeJS.ProcessEnv,
+  runNode: RunNode,
+  check: Check,
+): AdapterResult[] {
+  const installation = JSON.parse(
+    runNode(
+      outerCli,
+      ['install', '--agent', 'all', '--project', project, '--no-init-global', '--yes', '--json'],
+      env,
+    ),
+  ) as { command?: string; results?: AdapterResult[] };
+  check(installation.command === 'install', 'outer CLI install returned the wrong command');
+  const results = installation.results || [];
+  checkAdapterSet(
+    results.map(({ adapter }) => adapter),
+    'outer CLI install',
+    check,
+  );
+  for (const result of results) {
+    const installedHarness = result.harness || '';
+    check(existsSync(result.record || ''), `${result.adapter} install record was not created`);
+    check(
+      !existsSync(join(installedHarness, 'src')),
+      `${result.adapter} installed Harness unexpectedly contains TypeScript sources`,
+    );
+    const validation = JSON.parse(
+      runNode(join(installedHarness, 'bin', 'harness.mjs'), ['validate', '--json'], env),
+    ) as { valid?: boolean };
+    check(validation.valid === true, `${result.adapter} installed Harness validation did not pass`);
+  }
+  return results;
+}
+
+function checkStatus(
+  outerCli: string,
+  project: string,
+  env: NodeJS.ProcessEnv,
+  runNode: RunNode,
+  check: Check,
+): void {
+  const statuses = jsonLines<{
+    adapter?: string;
+    installed?: boolean;
+    outputs?: Array<{ status?: string }>;
+  }>(runNode(outerCli, ['status', '--agent', 'all', '--project', project, '--yes', '--json'], env));
+  checkAdapterSet(
+    statuses.map(({ adapter }) => adapter),
+    'outer CLI status',
+    check,
+  );
+  for (const status of statuses) {
+    check(status.installed === true, `${status.adapter} status did not report installed`);
+    check(
+      Boolean(status.outputs?.every(({ status: state }) => state === 'managed')),
+      `${status.adapter} status did not report every output as managed`,
+    );
+  }
+}
+
+function checkUninstall(
+  outerCli: string,
+  project: string,
+  env: NodeJS.ProcessEnv,
+  results: AdapterResult[],
+  runNode: RunNode,
+  check: Check,
+): void {
+  const uninstalled = jsonLines<{ command?: string; adapter?: string }>(
+    runNode(
+      outerCli,
+      ['uninstall', '--agent', 'all', '--project', project, '--yes', '--json'],
+      env,
+    ),
+  );
+  checkAdapterSet(
+    uninstalled.map(({ adapter }) => adapter),
+    'outer CLI uninstall',
+    check,
+  );
+  for (const item of uninstalled)
+    check(item.command === 'uninstall', `${item.adapter} returned the wrong uninstall command`);
+  for (const result of results) {
+    check(!existsSync(result.record || ''), `${result.adapter} install record survived uninstall`);
+    for (const output of result.outputs || [])
+      check(!existsSync(output.path || ''), `${result.adapter} managed output survived uninstall`);
+  }
+}
+
+export function checkBuiltCliAdapters({
+  outerCli,
+  runNode,
+  check,
+}: {
+  outerCli: string;
+  runNode: RunNode;
+  check: Check;
+}): void {
+  withTemporaryWorkspace(
+    { owner: 'preflight', purpose: 'preflight', lifecycle: 'operation' },
+    ({ path: temporary }) => {
+      const project = join(temporary, 'project');
+      mkdirSync(project, { recursive: true });
+      const env = {
+        ...process.env,
+        HOME: temporary,
+        CODEX_HOME: join(temporary, 'codex'),
+        CLAUDE_CONFIG_DIR: join(temporary, 'claude'),
+        OPENCODE_CONFIG_DIR: join(temporary, 'opencode'),
+        KIMI_CODE_HOME: join(temporary, 'kimi'),
+        HARNESS_MEMORY_HOME: join(temporary, 'memory'),
+        HARNESS_REPOSITORY_ROOT: join(temporary, 'repositories'),
+        HARNESS_OWNER: 'preflight',
+      };
+      checkDryRun(outerCli, project, env, runNode, check);
+      const results = checkInstall(outerCli, project, env, runNode, check);
+      checkStatus(outerCli, project, env, runNode, check);
+      checkUninstall(outerCli, project, env, results, runNode, check);
+    },
+  );
+}

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -1,9 +1,8 @@
-import { existsSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Argument, Command } from 'commander';
 import { execaSync } from 'execa';
-import { withTemporaryWorkspace } from '../src/temporary-resource.js';
+import { checkBuiltCliAdapters } from './preflight-adapters.js';
 import { checkArchitectureImports } from './preflight-architecture.js';
 import { checkDocs } from './preflight-docs.js';
 import { checkBranch } from './preflight-git.js';
@@ -93,48 +92,7 @@ function checkCli(): void {
   check(versionContract.schemaVersion === 3, 'Harness task schema version is unsupported');
   check(versionContract.memorySchemaVersion === 1, 'Harness memory schema version is unsupported');
 
-  withTemporaryWorkspace(
-    { owner: 'preflight', purpose: 'preflight', lifecycle: 'operation' },
-    ({ path: temporary }) => {
-      const env = {
-        ...process.env,
-        HOME: temporary,
-        CODEX_HOME: join(temporary, 'host'),
-        HARNESS_MEMORY_HOME: join(temporary, 'memory'),
-        HARNESS_REPOSITORY_ROOT: join(temporary, 'repositories'),
-        HARNESS_OWNER: 'preflight',
-      };
-      const preview = runNode(
-        outerCli,
-        ['install', '--agent', 'codex', '--dry-run', '--yes', '--json'],
-        env,
-      );
-      const plan = JSON.parse(preview) as { adapter?: string; outputs?: unknown[] };
-      check(plan.adapter === 'codex', 'outer CLI dry-run returned the wrong adapter plan');
-      check(Boolean(plan.outputs?.length), 'outer CLI dry-run did not return planned outputs');
-      check(
-        !existsSync(join(temporary, 'host')),
-        'outer CLI dry-run unexpectedly wrote to the host directory',
-      );
-
-      const installed = runNode(
-        outerCli,
-        ['install', '--agent', 'codex', '--no-init-global', '--yes', '--json'],
-        env,
-      );
-      const installation = JSON.parse(installed) as { command?: string; results?: unknown[] };
-      check(installation.command === 'install', 'outer CLI install returned the wrong command');
-      check(installation.results?.length === 1, 'outer CLI install did not return one result');
-      const installedHarnessCli = join(temporary, 'host', 'agent-harness', 'bin', 'harness.mjs');
-      check(
-        !existsSync(join(temporary, 'host', 'agent-harness', 'src')),
-        'installed Harness unexpectedly contains TypeScript sources',
-      );
-      const validationOutput = runNode(installedHarnessCli, ['validate', '--json'], env);
-      const validation = JSON.parse(validationOutput) as { valid?: boolean };
-      check(validation.valid === true, 'installed Harness validation did not pass');
-    },
-  );
+  checkBuiltCliAdapters({ outerCli, runNode, check });
 }
 
 function main(): void {

--- a/src/__tests__/node-contract.test.ts
+++ b/src/__tests__/node-contract.test.ts
@@ -141,6 +141,15 @@ test('preflight mode parsing uses Commander choices', () => {
   assert.doesNotMatch(source, /\['all', 'cli', 'docs'\]\.includes\(mode\)/);
 });
 
+test('built CLI preflight derives and exercises the complete Adapter set', () => {
+  const source = readFileSync(join(root, 'scripts', 'preflight-adapters.ts'), 'utf8');
+
+  assert.match(source, /supportedAgentNames/);
+  assert.match(source, /\['install', '--agent', 'all'/);
+  assert.match(source, /\['status', '--agent', 'all'/);
+  assert.match(source, /\['uninstall', '--agent', 'all'/);
+});
+
 test('release manifest comparison uses Node deep equality', () => {
   const source = readFileSync(join(root, 'scripts', 'eval-fingerprint.ts'), 'utf8');
 

--- a/src/__tests__/preflight-adapters.test.ts
+++ b/src/__tests__/preflight-adapters.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { checkAdapterSet } from '../../scripts/preflight-adapters.js';
+import { supportedAgentNames } from '../adapter-registry.js';
+
+test('Adapter preflight accepts the registry order as its complete target set', () => {
+  const observations: Array<{ condition: boolean; message: string }> = [];
+
+  checkAdapterSet([...supportedAgentNames], 'test preflight', (condition, message) => {
+    observations.push({ condition: Boolean(condition), message });
+  });
+
+  assert.deepEqual(observations, [
+    {
+      condition: true,
+      message: `test preflight did not cover every registered adapter: ${supportedAgentNames.join(', ')}`,
+    },
+  ]);
+});
+
+test('Adapter preflight reports the observed target set when one registry entry is missing', () => {
+  const incomplete = supportedAgentNames.slice(0, -1);
+  const observations: Array<{ condition: boolean; message: string }> = [];
+
+  checkAdapterSet([...incomplete], 'test preflight', (condition, message) => {
+    observations.push({ condition: Boolean(condition), message });
+  });
+
+  assert.deepEqual(observations, [
+    {
+      condition: false,
+      message: `test preflight did not cover every registered adapter: ${incomplete.join(', ')}`,
+    },
+  ]);
+});


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

- Derive package-facing preflight targets from the Adapter registry.
- Exercise built CLI dry-run, install, status, Runtime validation, and uninstall for every Adapter in one isolated clean room.
- Fail with the observed Adapter set when registry coverage drifts.
- Document the deterministic guarantee and real-Host boundary.

## Related Issue / 关联 Issue

Closes #144

## Verification / 验证

- `pnpm exec vitest run src/__tests__/preflight-adapters.test.ts src/__tests__/node-contract.test.ts`
- `pnpm run preflight` (831 checks; 161 test files; 1057 passed, 3 skipped)
- `git diff --check`

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

This proves deterministic installer and Adapter behavior only; it does not claim real Host execution.
