### PR TITLE
feat(eval): compare candidate and baseline Host evidence

### DIFF
--- a/docs/concepts/evidence-and-evaluation.md
+++ b/docs/concepts/evidence-and-evaluation.md
@@ -75,6 +75,18 @@ transport failure 最多自动重试一次，即总尝试次数不超过两次�
 evaluator 崩溃归为 evaluator failure。退出码为 0 仍必须交给独立 evaluator，不能自动升级成行为通过。该能力不会自动
 登录、启动或持久化第三方 Host 证据，真实 RC 演练仍需维护者显式执行与复核。
 
+#### 候选—基线 Host A/B 比较
+
+`pnpm run eval:compare -- --baseline-runs-dir <dir> --baseline-artifact <tgz> --candidate-runs-dir <dir>
+--candidate-artifact <tgz>` 会先复用现有 schema、artifact 与 secret 检查，再按 Adapter、Host 产品与版本、模型与模型版本、
+场景 ID 和场景 fingerprint 一一配对。两侧 tarball SHA-256 必须分别匹配记录；dependency、rules 与 artifact fingerprint
+作为被测实现分别保留，允许不同，不能被误当成环境漂移。
+
+每个单元固定分类为 `improved`、`unchanged-passed`、`regressed`、`unchanged-failed` 或 `inconclusive`。任一侧出现
+transport/evaluator 不可判定时只能得到 `inconclusive`；总体通过要求所有候选单元都通过且没有回归。报告给出断言、禁止
+行为、工具动作数和耗时 delta；当前记录没有稳定 token 字段，因此明确写 `not-measured`。该比较减少人工对照错误，
+但不启动 Host、不生成证据，也不替代 release gate 或人工语义复核。
+
 发布证据按矩阵单元区分 `exact`、`inherited`、`infra-blocked`。`exact` 绑定当前候选 artifact；`inherited` 额外绑定来源
 版本与 artifact digest；`infra-blocked` 不计入 passing coverage。release state 和 release attestation 会保留这三类清单，
 并校验它们与聚合计数、`inheritedFrom` 和完整 release matrix 一致。正常发布不得含 `infra-blocked`；风险例外只能记录

--- a/evals/__tests__/eval-comparison.test.ts
+++ b/evals/__tests__/eval-comparison.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'vitest';
+import { compareHostEvaluationEvidence } from '../../scripts/eval-comparison.js';
+import { readNpmPackageTarball } from '../../scripts/npm-tarball.js';
+import { candidateArtifact, root, temporaryDirectory, writeRun } from './run-fixture.js';
+import { writeCandidateTarball } from './tarball-fixture.js';
+
+interface MutableFixtureRecord {
+  host: { modelVersion: string };
+  subject: {
+    packageArtifactSha256: string;
+    rulesSha256: string;
+    dependencySha256: string;
+  };
+}
+
+type RecordPatch = (record: MutableFixtureRecord) => void;
+
+function patchRecord(path: string, patch: RecordPatch): void {
+  const record = JSON.parse(readFileSync(path, 'utf8')) as MutableFixtureRecord;
+  patch(record);
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
+}
+
+function fixture({
+  baselineOutcome = 'passed',
+  candidateOutcome = 'passed',
+  baselineTermination = 'completed',
+  candidateTermination = 'completed',
+  patchBaseline = () => undefined,
+  patchCandidate = () => undefined,
+}: {
+  baselineOutcome?: 'passed' | 'behavior-failed' | 'infra-inconclusive' | 'evaluator-failed';
+  candidateOutcome?: 'passed' | 'behavior-failed' | 'infra-inconclusive' | 'evaluator-failed';
+  baselineTermination?:
+    | 'completed'
+    | 'transport-failure'
+    | 'scenario-budget-exhausted'
+    | 'circuit-open'
+    | 'evaluator-failure';
+  candidateTermination?:
+    | 'completed'
+    | 'transport-failure'
+    | 'scenario-budget-exhausted'
+    | 'circuit-open'
+    | 'evaluator-failure';
+  patchBaseline?: RecordPatch;
+  patchCandidate?: RecordPatch;
+} = {}) {
+  const directory = temporaryDirectory();
+  const baselineRunsDirectory = join(directory, 'baseline-runs');
+  const candidateRunsDirectory = join(directory, 'candidate-runs');
+  const baselineArtifact = join(directory, 'baseline.tgz');
+  writeCandidateTarball(baselineArtifact, root, { rule: '<!-- baseline rule -->\n' });
+  const baselinePath = writeRun(baselineRunsDirectory, {
+    outcome: baselineOutcome,
+    termination: baselineTermination,
+    runId: 'baseline-progressive-disclosure',
+  });
+  const candidatePath = writeRun(candidateRunsDirectory, {
+    outcome: candidateOutcome,
+    termination: candidateTermination,
+    runId: 'candidate-progressive-disclosure',
+  });
+  patchRecord(baselinePath, (record) => {
+    record.subject.packageArtifactSha256 = readNpmPackageTarball(baselineArtifact).sha256;
+    record.subject.rulesSha256 = 'a'.repeat(64);
+    record.subject.dependencySha256 = 'b'.repeat(64);
+    patchBaseline(record);
+  });
+  patchRecord(candidatePath, patchCandidate);
+  return {
+    baselineArtifact,
+    baselineRunsDirectory,
+    candidateArtifact,
+    candidateRunsDirectory,
+  };
+}
+
+test('Host evidence comparison reports a matched passing control without inventing token data', () => {
+  const result = compareHostEvaluationEvidence(fixture());
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.cells[0]?.classification, 'unchanged-passed');
+  assert.equal(result.cells[0]?.metrics.tokenUsage, 'not-measured');
+  assert.equal(result.cells[0]?.subject.baseline.dependencySha256, 'b'.repeat(64));
+  assert.notEqual(
+    result.cells[0]?.subject.baseline.packageArtifactSha256,
+    result.cells[0]?.subject.candidate.packageArtifactSha256,
+  );
+});
+
+test('Host evidence comparison CLI emits the versioned deterministic JSON contract', () => {
+  const options = fixture();
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      join(root, 'scripts', 'eval-gate.ts'),
+      'compare',
+      '--baseline-runs-dir',
+      options.baselineRunsDirectory,
+      '--baseline-artifact',
+      options.baselineArtifact,
+      '--candidate-runs-dir',
+      options.candidateRunsDirectory,
+      '--candidate-artifact',
+      options.candidateArtifact,
+      '--json',
+    ],
+    { cwd: root, encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout) as { schemaVersion: number; status: string };
+  assert.deepEqual(report, {
+    ...compareHostEvaluationEvidence(options),
+    schemaVersion: 1,
+    status: 'passed',
+  });
+});
+
+test('Host evidence comparison distinguishes improvement, regression, and infrastructure uncertainty', () => {
+  const improved = compareHostEvaluationEvidence(fixture({ baselineOutcome: 'behavior-failed' }));
+  assert.equal(improved.status, 'passed');
+  assert.equal(improved.cells[0]?.classification, 'improved');
+
+  const regressed = compareHostEvaluationEvidence(fixture({ candidateOutcome: 'behavior-failed' }));
+  assert.equal(regressed.status, 'failed');
+  assert.equal(regressed.cells[0]?.classification, 'regressed');
+
+  const inconclusive = compareHostEvaluationEvidence(
+    fixture({
+      candidateOutcome: 'infra-inconclusive',
+      candidateTermination: 'transport-failure',
+    }),
+  );
+  assert.equal(inconclusive.status, 'inconclusive');
+  assert.equal(inconclusive.cells[0]?.classification, 'inconclusive');
+});
+
+test('Host evidence comparison fails closed on mismatched Host/model identity', () => {
+  assert.throws(
+    () =>
+      compareHostEvaluationEvidence(
+        fixture({ patchCandidate: (record) => (record.host.modelVersion = 'different-model') }),
+      ),
+    /Host\/model mismatch.*codex\/progressive-disclosure/i,
+  );
+});
+
+test('Host evidence comparison fails closed on duplicate, missing, and artifact-mismatched cells', () => {
+  const duplicate = fixture();
+  writeRun(duplicate.candidateRunsDirectory, {
+    runId: 'candidate-progressive-disclosure-duplicate',
+  });
+  assert.throws(() => compareHostEvaluationEvidence(duplicate), /duplicate candidate cell/i);
+
+  const missing = fixture();
+  const otherCandidateRuns = join(temporaryDirectory(), 'candidate-runs');
+  writeRun(otherCandidateRuns, {
+    scenarioId: 'safe-path-boundary',
+    runId: 'candidate-safe-path',
+  });
+  assert.throws(
+    () =>
+      compareHostEvaluationEvidence({
+        ...missing,
+        candidateRunsDirectory: otherCandidateRuns,
+      }),
+    /comparison cell mismatch/i,
+  );
+
+  const artifactMismatch = fixture({
+    patchCandidate: (record) => (record.subject.packageArtifactSha256 = 'f'.repeat(64)),
+  });
+  assert.throws(
+    () => compareHostEvaluationEvidence(artifactMismatch),
+    /candidate artifact digest mismatch/i,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eval:fingerprint": "node --import tsx scripts/eval-gate.ts fingerprint --json",
     "eval:plan": "node --import tsx scripts/eval-gate.ts plan --json",
     "eval:host-matrix": "node --import tsx scripts/eval-host-capability-matrix-cli.ts",
+    "eval:compare": "node --import tsx scripts/eval-gate.ts compare --json",
     "eval:first-value": "pnpm run build:emit && node --import tsx scripts/first-value-loop.ts",
     "eval:codex-matrix": "node --import tsx scripts/eval-codex-matrix.ts",
     "eval:validate": "node --import tsx scripts/eval-gate.ts validate",

--- a/scripts/eval-comparison.ts
+++ b/scripts/eval-comparison.ts
@@ -1,0 +1,204 @@
+import type { RunRecord } from './eval-artifacts.js';
+import type { VerifiedRun } from './eval-records.js';
+import { validateEvaluationRecords } from './eval-records.js';
+import { readNpmPackageTarball } from './npm-tarball.js';
+
+type HostIdentity = {
+  adapter: string;
+  product: string;
+  version: string;
+  model: string;
+  modelVersion: string;
+};
+
+type ComparisonRecord = RunRecord & {
+  host: HostIdentity;
+  toolActions: Array<{ sequence: number }>;
+};
+
+export type HostEvalCellClassification =
+  | 'improved'
+  | 'unchanged-passed'
+  | 'regressed'
+  | 'unchanged-failed'
+  | 'inconclusive';
+
+export interface HostEvalComparisonOptions {
+  baselineArtifact: string;
+  baselineRunsDirectory: string;
+  candidateArtifact: string;
+  candidateRunsDirectory: string;
+}
+
+function cellKey(record: ComparisonRecord): string {
+  return `${record.host.adapter}/${record.scenarioId}`;
+}
+
+function indexRecords(
+  runs: VerifiedRun[],
+  side: 'baseline' | 'candidate',
+  artifactSha256: string,
+): Map<string, ComparisonRecord> {
+  const indexed = new Map<string, ComparisonRecord>();
+  for (const { record } of runs) {
+    const comparisonRecord = record as ComparisonRecord;
+    const key = cellKey(comparisonRecord);
+    if (indexed.has(key)) throw new Error(`Duplicate ${side} cell: ${key}`);
+    if (record.subject.packageArtifactSha256 !== artifactSha256) {
+      throw new Error(
+        `${side} artifact digest mismatch for ${key}: expected ${artifactSha256}, received ${record.subject.packageArtifactSha256}`,
+      );
+    }
+    indexed.set(key, comparisonRecord);
+  }
+  return indexed;
+}
+
+function assertSameCells(
+  baseline: Map<string, ComparisonRecord>,
+  candidate: Map<string, ComparisonRecord>,
+): string[] {
+  const baselineKeys = [...baseline.keys()].sort();
+  const candidateKeys = [...candidate.keys()].sort();
+  if (JSON.stringify(baselineKeys) !== JSON.stringify(candidateKeys)) {
+    throw new Error(
+      `Comparison cell mismatch: baseline=${baselineKeys.join(',')}; candidate=${candidateKeys.join(',')}`,
+    );
+  }
+  return baselineKeys;
+}
+
+function assertPairContract(
+  key: string,
+  baseline: ComparisonRecord,
+  candidate: ComparisonRecord,
+): void {
+  const hostFields = ['adapter', 'product', 'version', 'model', 'modelVersion'] as const;
+  if (hostFields.some((field) => baseline.host[field] !== candidate.host[field])) {
+    throw new Error(`Host/model mismatch for ${key}`);
+  }
+  if (baseline.subject.scenarioSha256 !== candidate.subject.scenarioSha256) {
+    throw new Error(`Scenario fingerprint mismatch for ${key}`);
+  }
+  for (const [label, baselineAssertions, candidateAssertions] of [
+    ['scenario', baseline.scenarioAssertions, candidate.scenarioAssertions],
+    ['forbidden-action', baseline.forbiddenActionAssertions, candidate.forbiddenActionAssertions],
+  ] as const) {
+    const contract = (assertions: typeof baselineAssertions) =>
+      assertions
+        .map(({ id, description }) => ({ id, description }))
+        .sort((left, right) => left.id.localeCompare(right.id));
+    if (
+      JSON.stringify(contract(baselineAssertions)) !== JSON.stringify(contract(candidateAssertions))
+    ) {
+      throw new Error(`${label} assertion contract mismatch for ${key}`);
+    }
+  }
+}
+
+function behaviorPassed(record: ComparisonRecord): boolean {
+  return (
+    record.verdict.outcome === 'passed' &&
+    record.scenarioAssertions.every(({ passed }) => passed) &&
+    record.forbiddenActionAssertions.every(({ passed }) => passed)
+  );
+}
+
+function nonBehaviorOutcome(record: ComparisonRecord): boolean {
+  return ['infra-inconclusive', 'evaluator-failed'].includes(record.verdict.outcome);
+}
+
+function classification(
+  baseline: ComparisonRecord,
+  candidate: ComparisonRecord,
+): HostEvalCellClassification {
+  if (nonBehaviorOutcome(baseline) || nonBehaviorOutcome(candidate)) return 'inconclusive';
+  const baselinePassed = behaviorPassed(baseline);
+  const candidatePassed = behaviorPassed(candidate);
+  if (candidatePassed) return baselinePassed ? 'unchanged-passed' : 'improved';
+  return baselinePassed ? 'regressed' : 'unchanged-failed';
+}
+
+function metric(baseline: number, candidate: number) {
+  return { baseline, candidate, delta: candidate - baseline };
+}
+
+function passedAssertions(assertions: Array<{ passed: boolean }>): number {
+  return assertions.filter(({ passed }) => passed).length;
+}
+
+export function compareHostEvaluationEvidence(options: HostEvalComparisonOptions) {
+  const baselineArtifactSha256 = readNpmPackageTarball(options.baselineArtifact).sha256;
+  const candidateArtifactSha256 = readNpmPackageTarball(options.candidateArtifact).sha256;
+  const baseline = indexRecords(
+    validateEvaluationRecords({ runsDirectory: options.baselineRunsDirectory }),
+    'baseline',
+    baselineArtifactSha256,
+  );
+  const candidate = indexRecords(
+    validateEvaluationRecords({ runsDirectory: options.candidateRunsDirectory }),
+    'candidate',
+    candidateArtifactSha256,
+  );
+  const keys = assertSameCells(baseline, candidate);
+  const cells = keys.map((key) => {
+    const baselineRecord = baseline.get(key) as ComparisonRecord;
+    const candidateRecord = candidate.get(key) as ComparisonRecord;
+    assertPairContract(key, baselineRecord, candidateRecord);
+    return {
+      cell: key,
+      host: baselineRecord.host,
+      scenarioId: baselineRecord.scenarioId,
+      classification: classification(baselineRecord, candidateRecord),
+      outcomes: {
+        baseline: baselineRecord.verdict.outcome,
+        candidate: candidateRecord.verdict.outcome,
+      },
+      subject: {
+        baseline: {
+          packageArtifactSha256: baselineRecord.subject.packageArtifactSha256,
+          rulesSha256: baselineRecord.subject.rulesSha256,
+          dependencySha256: baselineRecord.subject.dependencySha256,
+        },
+        candidate: {
+          packageArtifactSha256: candidateRecord.subject.packageArtifactSha256,
+          rulesSha256: candidateRecord.subject.rulesSha256,
+          dependencySha256: candidateRecord.subject.dependencySha256,
+        },
+        scenarioSha256: baselineRecord.subject.scenarioSha256,
+      },
+      metrics: {
+        scenarioAssertionsPassed: metric(
+          passedAssertions(baselineRecord.scenarioAssertions),
+          passedAssertions(candidateRecord.scenarioAssertions),
+        ),
+        forbiddenActionAssertionsPassed: metric(
+          passedAssertions(baselineRecord.forbiddenActionAssertions),
+          passedAssertions(candidateRecord.forbiddenActionAssertions),
+        ),
+        toolActions: metric(baselineRecord.toolActions.length, candidateRecord.toolActions.length),
+        elapsedMs: metric(baselineRecord.execution.elapsedMs, candidateRecord.execution.elapsedMs),
+        tokenUsage: 'not-measured' as const,
+      },
+    };
+  });
+  const counts = Object.fromEntries(
+    ['improved', 'unchanged-passed', 'regressed', 'unchanged-failed', 'inconclusive'].map(
+      (value) => [value, cells.filter(({ classification }) => classification === value).length],
+    ),
+  ) as Record<HostEvalCellClassification, number>;
+  const status =
+    counts.regressed > 0 || counts['unchanged-failed'] > 0
+      ? 'failed'
+      : counts.inconclusive > 0
+        ? 'inconclusive'
+        : 'passed';
+  return {
+    schemaVersion: 1 as const,
+    status,
+    baselineArtifactSha256,
+    candidateArtifactSha256,
+    counts,
+    cells,
+  };
+}

--- a/scripts/eval-gate.ts
+++ b/scripts/eval-gate.ts
@@ -1,4 +1,5 @@
 import { Command, InvalidArgumentError } from 'commander';
+import { compareHostEvaluationEvidence } from './eval-comparison.js';
 import { gateEvaluationRecords, validateEvaluationRecords } from './eval-contract.js';
 import { evaluationFingerprint, releaseArtifactPath } from './eval-fingerprint.js';
 import { EvaluationGateError } from './eval-gate-failure.js';
@@ -12,11 +13,46 @@ function positiveNumber(value: string): number {
   return parsed;
 }
 
+function addCompareCommand(program: Command): void {
+  program
+    .command('compare')
+    .description('compare paired baseline and candidate Host evaluation evidence')
+    .requiredOption('--baseline-runs-dir <path>', 'baseline Host evaluation records directory')
+    .requiredOption('--baseline-artifact <path>', 'exact baseline npm tarball')
+    .requiredOption('--candidate-runs-dir <path>', 'candidate Host evaluation records directory')
+    .requiredOption('--candidate-artifact <path>', 'exact candidate npm tarball')
+    .requiredOption('--json', 'write the deterministic comparison as JSON')
+    .action(
+      ({
+        baselineArtifact,
+        baselineRunsDir,
+        candidateArtifact,
+        candidateRunsDir,
+      }: {
+        baselineArtifact: string;
+        baselineRunsDir: string;
+        candidateArtifact: string;
+        candidateRunsDir: string;
+      }) => {
+        const result = compareHostEvaluationEvidence({
+          baselineArtifact,
+          baselineRunsDirectory: baselineRunsDir,
+          candidateArtifact,
+          candidateRunsDirectory: candidateRunsDir,
+        });
+        process.stdout.write(`${JSON.stringify(result)}\n`);
+        if (result.status !== 'passed') process.exitCode = 1;
+      },
+    );
+}
+
 function main(): void {
   const program = new Command()
     .name('eval-gate')
     .description('Validate maintainer-attested Harness host evaluation evidence')
     .showHelpAfterError();
+
+  addCompareCommand(program);
 
   program
     .command('plan')


### PR DESCRIPTION
# Pull Request / 拉取请求

## Summary / 变更说明

- Add deterministic candidate/baseline Host evidence comparison.
- Bind both sides to their exact tarball SHA-256 and pair only identical Host/model/scenario contracts.
- Classify cells as improved, unchanged-passed, regressed, unchanged-failed, or inconclusive.
- Report assertion, forbidden-action, tool-action, elapsed-time deltas and explicit not-measured token usage.
- Keep comparison separate from Host transport and release gating.

## Related Issue / 关联 Issue

Closes #146

## Verification / 验证

- `pnpm exec vitest run evals/__tests__/eval-comparison.test.ts` (5 passed)
- `pnpm exec vitest run src/__tests__/adapter-conformance.test.ts evals/__tests__/eval-comparison.test.ts` (22 passed)
- `pnpm run check`
- `pnpm run preflight:quality` (832 checks)
- `git diff --check`

Known unrelated environment-sensitive failures during full `pnpm run preflight`: existing Codex fixture process timeout and existing multi-adapter test default timeout; all other 160 test files passed.

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试的原因。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 如涉及用户可见行为或能力边界，文档已同步更新。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未修改生成的 `dist/` 文件，且不包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

The comparison does not launch Hosts or create evidence; it evaluates already validated, maintainer-attested records only.
