### PR TITLE
feat(cli): add Zed Agent adapter

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -59,6 +59,7 @@ You can also ask a coding agent to read the installation protocol first:
 | Claude Code | global | `claude` (alias: `claude-code`) |
 | OpenCode | global | `opencode` |
 | Kimi Code CLI | global | `kimi` (alias: `kimi-code`) |
+| Zed Agent | global | `zed` |
 
 Cursor requires `--project /path/to/project`. See the
 [host guide](https://alexpang.cn/harnessmith/guide/hosts) for destinations, aliases, and support evidence.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npx harnessmith setup --agent codex
 | Claude Code | 全局 | `claude`（别名 `claude-code`） |
 | OpenCode | 全局 | `opencode` |
 | Kimi Code CLI | 全局 | `kimi`（别名 `kimi-code`） |
+| Zed Agent | 全局 | `zed` |
 
 Cursor 需用 `--project /path/to/project` 指定项目根。目标路径、别名和支持证据见
 [宿主指南](https://alexpang.cn/harnessmith/guide/hosts)。

--- a/apps/docs/site/architecture.md
+++ b/apps/docs/site/architecture.md
@@ -7,7 +7,7 @@ owner: maintainers
 # Harnessmith 架构设计
 
 Harnessmith 是**跨 Host 的 Personal Harness 分发与工作状态控制层**。它把一套宿主中立的规则、文档和本地 Runtime
-安全地接入 Codex、Cursor、Claude Code、OpenCode 与 Kimi Code CLI，但不替代这些宿主的 Agent Runtime。
+安全地接入 Codex、Cursor、Claude Code、OpenCode、Kimi Code CLI 与 Zed Agent，但不替代这些宿主的 Agent Runtime。
 
 公开能力始终分成三种状态：**已实现（Implemented）** 表示代码与可执行证据都存在；**由宿主负责（Delegated to the
 Host）** 表示 Harnessmith 只提供 guidance 或接入点；**不支持（Unsupported）** 表示当前明确不声称拥有。逐项 owner
@@ -128,6 +128,7 @@ capabilities 输出与 Eval `host.adapter` 枚举都从该清单派生或与之�
 | Claude Code | global | Markdown | host-default | host |
 | OpenCode | global | Markdown | host-default | host |
 | Kimi Code CLI | global | Markdown | host-default | host |
+| Zed Agent | global | Markdown | host-default | host |
 | Cursor | project | AGENTS.md + MDC | MDC always | host |
 
 “支持”表示 Adapter 生命周期、能力描述和回归测试存在，不表示每个宿主版本都完成真实运行评测。逐项状态以

--- a/apps/docs/site/capability-evidence.yaml
+++ b/apps/docs/site/capability-evidence.yaml
@@ -8,7 +8,7 @@ claims:
   - id: cross-host-distribution
     status: implemented
     owner: outer installer adapters
-    claim: Distribute one Personal Harness across Codex, Cursor, Claude Code, OpenCode, and Kimi Code CLI.
+    claim: Distribute one Personal Harness across Codex, Cursor, Claude Code, OpenCode, Kimi Code CLI, and Zed Agent.
     implementation:
       - packages/cli/src/adapters/adapter-registry.ts
       - packages/cli/src/adapters/adapters.ts
@@ -21,6 +21,7 @@ claims:
       - packages/cli/src/__tests__/adapters-opencode.test.ts
       - packages/cli/src/__tests__/adapters-kimi.test.ts
       - packages/cli/src/__tests__/install-kimi.test.ts
+      - packages/cli/src/__tests__/adapters-zed.test.ts
 
   - id: safe-install-lifecycle
     status: implemented

--- a/apps/docs/site/concepts/boundaries.md
+++ b/apps/docs/site/concepts/boundaries.md
@@ -25,7 +25,7 @@ owner: maintainers
 ## Coding Agent 宿主保证什么
 
 模型循环、上下文压缩、工具/MCP 调度、sandbox、网络访问、权限提示、凭据管理、token/成本与事件真实性属于 Codex、
-Cursor、Claude Code、OpenCode 或 Kimi Code CLI。Harnesssmith 可以提供建议和接入点，但不能替宿主执行这些职责。
+Cursor、Claude Code、OpenCode、Kimi Code CLI 或 Zed Agent。Harnesssmith 可以提供建议和接入点，但不能替宿主执行这些职责。
 
 例如，Harnesssmith 可以写明“远端写入需要明确授权”，但真正阻止一次未经批准的网络调用，需要宿主权限系统和用户
 审批；Markdown 本身不是 sandbox。

--- a/apps/docs/site/en/getting-started.md
+++ b/apps/docs/site/en/getting-started.md
@@ -31,7 +31,7 @@ risk, and stable action codes without executing them. Host-limited checks remain
 Every interactive step can be cancelled before writing. Setup still refuses unmanaged and modified targets by default;
 confirmation does not bypass ownership safeguards. Unsupported hosts stop before destination resolution or writes.
 
-Codex, Claude Code, OpenCode, and Kimi Code CLI use global scope. Cursor uses project scope:
+Codex, Claude Code, OpenCode, Kimi Code CLI, and Zed Agent use global scope. Cursor uses project scope:
 
 ```bash
 npx harnessmith setup --agent cursor --project /path/to/project

--- a/apps/docs/site/en/index.md
+++ b/apps/docs/site/en/index.md
@@ -8,7 +8,7 @@ lang: en
 # Harnessmith documentation
 
 Harnessmith is an npm initializer that distributes one personal Agent Harness across Codex, Cursor, Claude Code, OpenCode,
-and Kimi Code CLI. It manages installation, ownership checks, backups, restore, and uninstall while leaving model execution,
+Kimi Code CLI, and Zed Agent. It manages installation, ownership checks, backups, restore, and uninstall while leaving model execution,
 tools, sandboxing, and approvals to each host.
 
 Harnessmith grew from practical multi-project work: reusable instructions, document retrieval, and durable work notes came

--- a/apps/docs/site/guide/hosts.md
+++ b/apps/docs/site/guide/hosts.md
@@ -6,7 +6,7 @@ owner: maintainers
 
 # 宿主支持
 
-Harnessmith 当前为五类 Coding Agent 提供 Adapter。Adapter 负责路径与文件格式适配，不会替代宿主自身的
+Harnesssmith 当前为六类 Coding Agent 提供 Adapter。Adapter 负责路径与文件格式适配，不会替代宿主自身的
 模型循环、工具调度、sandbox 或权限批准。
 
 | 宿主 | `--agent` | 默认规则入口 | 范围与激活 |
@@ -16,6 +16,7 @@ Harnessmith 当前为五类 Coding Agent 提供 Adapter。Adapter 负责路径�
 | Claude Code | `claude`（别名 `claude-code`） | `${CLAUDE_CONFIG_DIR:-~/.claude}/AGENTS.md` 与 `CLAUDE.md` | 全局；宿主默认 |
 | OpenCode | `opencode` | `${OPENCODE_CONFIG_DIR:-${XDG_CONFIG_HOME:-~/.config}/opencode}/AGENTS.md` | 全局；宿主默认 |
 | Kimi Code CLI | `kimi`（别名 `kimi-code`） | `${KIMI_CODE_HOME:-~/.kimi-code}/AGENTS.md` | 全局；宿主默认 |
+| Zed Agent | `zed` | `~/.config/zed/AGENTS.md`（Windows：`%APPDATA%\Zed\AGENTS.md`） | 全局；宿主默认 |
 
 可以用机器可读输出核对当前版本的 Adapter 声明：
 

--- a/apps/docs/site/index.md
+++ b/apps/docs/site/index.md
@@ -22,7 +22,7 @@ hero:
 <section class="home-signal" aria-label="Harnessmith 概览">
   <p class="home-eyebrow">Personal Agent Harness · Local first</p>
   <div class="home-signal-grid">
-    <div><strong>5</strong><span>个已接入宿主</span></div>
+    <div><strong>6</strong><span>个已接入宿主</span></div>
     <div><strong>2</strong><span>层清晰架构</span></div>
     <div><strong>1</strong><span>套可携带工作方式</span></div>
   </div>
@@ -43,9 +43,9 @@ hero:
   <article class="home-card home-card-hosts">
     <span class="home-card-index">01 / DISTRIBUTE</span>
     <h2>一套方法，适配多个宿主</h2>
-    <p>Codex、Cursor、Claude Code、OpenCode 与 Kimi Code CLI 共享宿主中立的 Harness；路径、入口和激活差异由 Adapter 处理。</p>
+    <p>Codex、Cursor、Claude Code、OpenCode、Kimi Code CLI 与 Zed Agent 共享宿主中立的 Harness；路径、入口和激活差异由 Adapter 处理。</p>
     <div class="host-list" aria-label="支持的宿主">
-      <span>Codex</span><span>Cursor</span><span>Claude Code</span><span>OpenCode</span><span>Kimi Code</span>
+      <span>Codex</span><span>Cursor</span><span>Claude Code</span><span>OpenCode</span><span>Kimi Code</span><span>Zed Agent</span>
     </div>
   </article>
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,15 +1,15 @@
 # Harness behavior evaluations
 
 Unit tests prove deterministic file and CLI behavior. This directory defines a separate contract for
-recording a maintainer-observed Codex, Cursor, Claude Code, OpenCode, or Kimi Code CLI run against the installed Harness. The
-current release policy requires Codex; Cursor, Claude Code, OpenCode, and Kimi Code CLI records remain supported optional evidence. A schema
+recording a maintainer-observed Codex, Cursor, Claude Code, OpenCode, Kimi Code CLI, or Zed Agent run against the installed Harness. The
+current release policy requires Codex; Cursor, Claude Code, OpenCode, Kimi Code CLI, and Zed Agent records remain supported optional evidence. A schema
 fixture, scenario catalog, mocked transcript, or passing unit test is never real host evidence.
 
 ## Multi-Host capability matrix
 
 `host-capability-matrix.v1.json` maps the current first-startup, read-only analysis, typed-writer,
 uninitialized-project, compaction, second-task, sidecar-failure, dirty-worktree, local-write prohibition,
-and replay capabilities across all five distribution adapters. `pnpm run eval:host-matrix` binds that
+and replay capabilities across all six distribution adapters. `pnpm run eval:host-matrix` binds that
 contract and every accepted record to one exact candidate tarball:
 
 ```bash

--- a/evals/__tests__/host-capability-matrix.test.ts
+++ b/evals/__tests__/host-capability-matrix.test.ts
@@ -30,7 +30,7 @@ test('host capability matrix is complete, unique, and backed by repository evide
   assert.equal(validate(matrix), true, JSON.stringify(validate.errors));
   assert.deepEqual(
     matrix.hosts.map(({ id }: { id: string }) => id),
-    ['codex', 'cursor', 'claude', 'opencode', 'kimi'],
+    ['codex', 'cursor', 'claude', 'opencode', 'kimi', 'zed'],
   );
   assert.deepEqual(
     matrix.capabilities.map(({ id }: { id: string }) => id),
@@ -90,10 +90,10 @@ test('matrix report binds every cell to one candidate and preserves real outcome
   const fingerprint = currentFingerprint();
   assert.equal(report.subject.packageArtifactSha256, fingerprint.packageArtifactSha256);
   assert.equal(report.subject.rulesSha256, fingerprint.rulesSha256);
-  assert.equal(report.cells.length, 50);
+  assert.equal(report.cells.length, 60);
   assert.equal(report.summary.passed, 1);
   assert.equal(report.summary['infra-inconclusive'], 2);
-  assert.equal(report.summary.inconclusive, 43);
+  assert.equal(report.summary.inconclusive, 53);
   assert.equal(report.summary['not-executed'], 4);
   assert.equal(report.summary.unsupported, 0);
   const passed = report.cells.find(
@@ -225,7 +225,7 @@ test('matrix CLI reports missing execution without manufacturing Host proof', ()
   const report = JSON.parse(reportResult.stdout);
   assert.equal(report.hostProof, false);
   assert.equal(report.summary['not-executed'], 7);
-  assert.equal(report.summary.inconclusive, 43);
+  assert.equal(report.summary.inconclusive, 53);
 
   const required = run(['--require-complete']);
   assert.equal(required.status, 1);

--- a/evals/host-capability-matrix.schema.json
+++ b/evals/host-capability-matrix.schema.json
@@ -8,8 +8,8 @@
     "schemaVersion": { "const": 1 },
     "hosts": {
       "type": "array",
-      "minItems": 5,
-      "maxItems": 5,
+      "minItems": 6,
+      "maxItems": 6,
       "items": { "$ref": "#/$defs/host" }
     },
     "capabilities": {
@@ -51,7 +51,7 @@
       "additionalProperties": false,
       "required": ["id", "state", "reason", "evidence"],
       "properties": {
-        "id": { "enum": ["codex", "cursor", "claude", "opencode", "kimi"] },
+        "id": { "enum": ["codex", "cursor", "claude", "opencode", "kimi", "zed"] },
         "state": { "enum": ["executable", "inconclusive", "unsupported"] },
         "reason": { "$ref": "#/$defs/text" },
         "evidence": {

--- a/evals/host-capability-matrix.v1.json
+++ b/evals/host-capability-matrix.v1.json
@@ -30,6 +30,12 @@
       "state": "inconclusive",
       "reason": "The distribution adapter exists, but no Kimi Code CLI real-Host transport and independent evaluator are implemented.",
       "evidence": ["packages/cli/src/adapters/adapter-registry.ts", "evals/README.md"]
+    },
+    {
+      "id": "zed",
+      "state": "inconclusive",
+      "reason": "The distribution adapter exists, but no Zed Agent real-Host transport and independent evaluator are implemented.",
+      "evidence": ["packages/cli/src/adapters/adapter-registry.ts", "evals/README.md"]
     }
   ],
   "capabilities": [

--- a/evals/run.schema.json
+++ b/evals/run.schema.json
@@ -31,7 +31,7 @@
       "type": "object",
       "required": ["adapter", "product", "version", "model", "modelVersion"],
       "properties": {
-        "adapter": { "enum": ["codex", "cursor", "claude", "opencode", "kimi"] },
+        "adapter": { "enum": ["codex","cursor","claude","opencode","kimi","zed"] },
         "product": { "type": "string", "minLength": 1 },
         "version": { "type": "string", "minLength": 1 },
         "model": { "type": "string", "minLength": 1 },

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,10 @@
 # Harnessmith
 
 > Harnessmith is a cross-host Personal Harness distribution and work-state control plane for Codex, Cursor,
-> Claude Code, OpenCode, and Kimi Code CLI.
+> Claude Code, OpenCode, Kimi Code CLI, and Zed Agent.
 > This file is an operational guide for an LLM helping a user install or initialize it.
 
-Project: https://www.npmjs.com/package/harnessmith
+Project: <https://www.npmjs.com/package/harnessmith>
 Release channel: npm registry (`latest` dist-tag)
 Runtime: Node.js 24.12 or newer
 Repository package manager: pnpm 10.13.0 (locked by `packageManager` and `pnpm-lock.yaml`)
@@ -47,12 +47,15 @@ use the published `npx --yes harnessmith` commands below.
   - Instructions: `$KIMI_CODE_HOME/AGENTS.md`, default `~/.kimi-code/AGENTS.md`
   - Harness: `agent-harness` under the same effective Kimi Code CLI data directory
   - Supports Kimi Code CLI `0.12.0` or newer; does not target legacy Python `kimi-cli` data at `~/.kimi/`
+- `zed`
+  - Instructions: `~/.config/zed/AGENTS.md` (Windows: `%APPDATA%\Zed\AGENTS.md`)
+  - Harness: `agent-harness` under the same effective Zed configuration directory
 
 ## LLM installation protocol
 
 1. Verify the runtime with `node --version`. Stop and explain the requirement if Node.js is older than 24.12.
 2. Determine the exact agent selection from the user's request. Accepted values are `codex`, `cursor`,
-   `claude`, `claude-code`, `opencode`, `kimi`, `kimi-code`, and `all`. Never infer `all` from an ambiguous request.
+   `claude`, `claude-code`, `opencode`, `kimi`, `kimi-code`, `zed`, and `all`. Never infer `all` from an ambiguous request.
 3. If Cursor is selected, determine the intended project path. Ask the user if more than one repository is
    plausible. Prefer an absolute path.
 4. Preview the shared first-use plan before writing:

--- a/packages/cli/src/__tests__/adapter-conformance.test.ts
+++ b/packages/cli/src/__tests__/adapter-conformance.test.ts
@@ -26,6 +26,7 @@ function fixture(prefix: string) {
   const env = {
     ...process.env,
     HOME: root,
+    APPDATA: join(root, 'appdata'),
     CODEX_HOME: join(root, 'codex'),
     CLAUDE_CONFIG_DIR: join(root, 'claude'),
     OPENCODE_CONFIG_DIR: join(root, 'opencode'),

--- a/packages/cli/src/__tests__/adapter-registry.test.ts
+++ b/packages/cli/src/__tests__/adapter-registry.test.ts
@@ -31,13 +31,14 @@ test('adapter registry is the single host inventory for CLI selection and aliase
   assert.deepEqual(normalizeAgents(['all']), [...supportedAgentNames]);
   assert.deepEqual(normalizeAgents(['claude-code']), ['claude']);
   assert.deepEqual(normalizeAgents(['kimi-code']), ['kimi']);
-  assert.deepEqual(normalizeAgents(['1', '2', '3', '4', '5']), [...supportedAgentNames]);
+  assert.deepEqual(normalizeAgents(['1', '2', '3', '4', '5', '6']), [...supportedAgentNames]);
   assert.deepEqual([...adapterAliasMap().entries()].sort(), [
     ['1', 'codex'],
     ['2', 'cursor'],
     ['3', 'claude'],
     ['4', 'opencode'],
     ['5', 'kimi'],
+    ['6', 'zed'],
     ['claude-code', 'claude'],
     ['kimi-code', 'kimi'],
   ]);
@@ -91,6 +92,6 @@ test('createAdapter preserves registry metadata for every registered host', () =
 });
 
 test('AgentName union stays aligned with registry order used by install records', () => {
-  const names: AgentName[] = ['codex', 'cursor', 'claude', 'opencode', 'kimi'];
+  const names: AgentName[] = ['codex', 'cursor', 'claude', 'opencode', 'kimi', 'zed'];
   assert.deepEqual(names, [...supportedAgentNames]);
 });

--- a/packages/cli/src/__tests__/adapters-zed.test.ts
+++ b/packages/cli/src/__tests__/adapters-zed.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { onTestFinished, test } from 'vitest';
+import { createAdapter, resolveZedAgentHome } from '../adapters/adapters.js';
+
+test('Zed Agent adapter uses the documented Unix personal configuration directory', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-zed-config-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const canonicalRoot = realpathSync.native(root);
+
+  const adapter = createAdapter('zed', {
+    env: { HOME: root, APPDATA: join(root, 'appdata') },
+  });
+  const expectedHome =
+    process.platform === 'win32'
+      ? join(canonicalRoot, 'appdata', 'Zed')
+      : join(canonicalRoot, '.config', 'zed');
+
+  assert.equal(adapter.label, 'Zed Agent');
+  assert.equal(adapter.home, expectedHome);
+  assert.equal(adapter.instructions.length, 1);
+  assert.equal(adapter.instructions[0].path, join(expectedHome, 'AGENTS.md'));
+  assert.equal(adapter.harness, join(expectedHome, 'agent-harness'));
+  assert.equal(adapter.record, join(expectedHome, '.harnessmith', 'install.json'));
+  assert.equal(adapter.capabilities.scope, 'global');
+  assert.equal(adapter.capabilities.instructionFormat, 'markdown');
+  assert.equal(adapter.capabilities.nativeRuleActivation, 'host-default');
+});
+
+test('Zed Agent adapter uses APPDATA on Windows', () => {
+  const root = mkdtempSync(join(tmpdir(), 'harness-zed-appdata-'));
+  onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+  const canonicalRoot = realpathSync.native(root);
+
+  assert.equal(
+    resolveZedAgentHome({ APPDATA: join(root, 'AppData'), HOME: join(root, 'home') }, 'win32'),
+    join(canonicalRoot, 'AppData', 'Zed'),
+  );
+});

--- a/packages/cli/src/__tests__/args.test.ts
+++ b/packages/cli/src/__tests__/args.test.ts
@@ -36,7 +36,14 @@ test('Commander supports repeatable and comma-separated agent values', async () 
 });
 
 test('normalizeAgents expands all and rejects unknown agents', () => {
-  assert.deepEqual(normalizeAgents(['all']), ['codex', 'cursor', 'claude', 'opencode', 'kimi']);
+  assert.deepEqual(normalizeAgents(['all']), [
+    'codex',
+    'cursor',
+    'claude',
+    'opencode',
+    'kimi',
+    'zed',
+  ]);
   assert.throws(() => normalizeAgents(['windsurf']), /Unsupported agent/);
 });
 
@@ -157,7 +164,7 @@ test('capabilities reports every adapter without resolving installation paths', 
   assert.equal(report.version, 1);
   assert.deepEqual(
     report.adapters.map(({ agent }: { agent: string }) => agent),
-    ['codex', 'cursor', 'claude', 'opencode', 'kimi'],
+    ['codex', 'cursor', 'claude', 'opencode', 'kimi', 'zed'],
   );
   assert.equal(report.adapters[0].capabilities.enforcement.permissions, 'host-owned');
 });

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -64,7 +64,7 @@ function backupWithContent(directory: string, prefix: string, expected: string):
   assert.equal(readFileSync(join(directory, backup), 'utf8'), expected);
 }
 
-test('installs all adapters, maps paths, and renames existing rules', () => {
+test('installs all adapters, maps paths, and renames existing rules', { timeout: 60_000 }, () => {
   const root = mkdtempSync(join(tmpdir(), 'harnessmith-'));
   onTestFinished(() => rmSync(root, { recursive: true, force: true }));
   const project = join(root, 'project');
@@ -280,7 +280,7 @@ test('json mode emits parseable automation output without terminal decoration', 
     .map((line) => JSON.parse(line));
   assert.deepEqual(
     plans.map(({ adapter }) => adapter),
-    ['codex', 'cursor', 'claude', 'opencode', 'kimi'],
+    ['codex', 'cursor', 'claude', 'opencode', 'kimi', 'zed'],
   );
   assert.equal(plans[0].capabilities.scope, 'global');
   assert.equal(plans[1].capabilities.scope, 'project');

--- a/packages/cli/src/adapters/adapter-registry.ts
+++ b/packages/cli/src/adapters/adapter-registry.ts
@@ -82,6 +82,18 @@ export const adapterRegistry = [
       enforcement: defaultAdapterEnforcement,
     },
   },
+  {
+    name: 'zed',
+    label: 'Zed Agent',
+    aliases: [],
+    hint: 'global configuration',
+    capabilities: {
+      scope: 'global',
+      instructionFormat: 'markdown',
+      nativeRuleActivation: 'host-default',
+      enforcement: defaultAdapterEnforcement,
+    },
+  },
 ] as const satisfies readonly AdapterRegistryEntry[];
 
 export type AgentName = (typeof adapterRegistry)[number]['name'];

--- a/packages/cli/src/adapters/adapters.ts
+++ b/packages/cli/src/adapters/adapters.ts
@@ -119,6 +119,20 @@ function resolveKimiAdapter({ env, userHome }: AdapterResolveContext): Adapter {
   return globalMarkdownAdapter('kimi', agentHome);
 }
 
+export function resolveZedAgentHome(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+  userHome = canonicalPath(env.HOME || homedir()),
+): string {
+  if (platform === 'win32')
+    return canonicalPath(join(env.APPDATA || join(userHome, 'AppData', 'Roaming'), 'Zed'));
+  return canonicalPath(join(userHome, '.config', 'zed'));
+}
+
+function resolveZedAdapter({ env, userHome }: AdapterResolveContext): Adapter {
+  return globalMarkdownAdapter('zed', resolveZedAgentHome(env, process.platform, userHome));
+}
+
 function resolveCursorAdapter({ project }: AdapterResolveContext): Adapter {
   const definition = getAdapterDefinition('cursor');
   const root = projectRoot(project);
@@ -186,6 +200,7 @@ const adapterResolvers = {
   claude: resolveClaudeAdapter,
   opencode: resolveOpenCodeAdapter,
   kimi: resolveKimiAdapter,
+  zed: resolveZedAdapter,
 } as const satisfies Record<AgentName, AdapterResolver>;
 
 export function createAdapter(

--- a/scripts/evaluation/contracts/eval-host-capability-matrix-contract.ts
+++ b/scripts/evaluation/contracts/eval-host-capability-matrix-contract.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AnySchema } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
-import type { AgentName } from '../../../packages/cli/src/shared/types.js';
+import {
+  type AgentName,
+  supportedAgentNames,
+} from '../../../packages/cli/src/adapters/adapter-registry.js';
 import { worktreeScenarioCatalog } from '../planning/eval-scenarios.js';
 import { repositoryRoot } from '../records/eval-fingerprint.js';
 
@@ -30,7 +33,7 @@ function validateContract(matrix: HostCapabilityMatrix): HostCapabilityMatrix {
   if (!validate(matrix)) {
     throw new Error(`Host capability matrix violates schema: ${JSON.stringify(validate.errors)}`);
   }
-  const expectedHosts: AgentName[] = ['codex', 'cursor', 'claude', 'opencode', 'kimi'];
+  const expectedHosts: AgentName[] = [...supportedAgentNames];
   if (matrix.hosts.some(({ id }, index) => id !== expectedHosts[index])) {
     throw new Error('Host capability matrix must contain the canonical ordered Host list');
   }


### PR DESCRIPTION
## Summary / 变更说明

Add a built-in Zed Agent Adapter that distributes the personal Harness through Zed's documented `AGENTS.md` location and the existing transactional lifecycle. The implementation supports Unix `~/.config/zed/AGENTS.md`, Windows `%APPDATA%\\Zed\\AGENTS.md`, registry-driven CLI selection, generated Eval contracts, and public host documentation.

## Related Issue / 关联 Issue

Closes #154

<!-- Branch: feat/154-zed-agent-adapter; the issue numbers match. / 分支：feat/154-zed-agent-adapter；Issue 编号一致。 -->

## Verification / 验证

- `pnpm run preflight` — passed; 684 checks and 166 test files, 1079 passed, 3 skipped
- `pnpm exec vitest run evals/__tests__/host-capability-matrix.test.ts packages/cli/src/__tests__/adapters-zed.test.ts packages/cli/src/__tests__/adapter-registry.test.ts packages/cli/src/__tests__/adapter-conformance.test.ts packages/cli/src/__tests__/args.test.ts packages/cli/src/__tests__/install.test.ts` — 63/63 passed
- `pnpm run eval:schema:check` — passed
- `git diff --check` — passed

## Checklist / 检查清单

- [x] The change is focused and excludes unrelated edits. / 变更范围聚焦，不包含无关修改。
- [x] Behavior changes include focused tests, or I explained why tests are unnecessary. / 行为变化已补充定向测试，或已说明无需测试。
- [x] User-facing behavior and capability boundaries are documented when relevant. / 用户可见行为和能力边界已同步文档。
- [x] I did not edit generated `dist/` files or include secrets, personal memory, or private paths. / 未编辑生成的 `dist/` 文件，未包含凭据、个人记忆或私有路径。

## Additional Notes / 补充说明

Zed Agent model execution, tools, MCP, sandboxing, permissions, authentication, and real Host Eval remain delegated to Zed or inconclusive under the existing capability evidence policy.
